### PR TITLE
feat(training): Add AI documentation generation and simplify DDL training

### DIFF
--- a/tests/utils/test_vanna_ddl_training.py
+++ b/tests/utils/test_vanna_ddl_training.py
@@ -160,7 +160,7 @@ def test_train_ddl_adds_to_chromadb_with_user_role(
     service.vn.add_ddl = MagicMock(wraps=original_add_ddl)
 
     try:
-        train_ddl(describe_ddl=False)  # We are not testing describe part here
+        train_ddl()  # Train DDL only (no describe)
 
         assert service.vn.add_ddl.call_count == 2  # Once for 'users', once for 'orders'
 
@@ -708,18 +708,18 @@ def test_train_ddl_shows_success_messages(
         service.vn.ddl_collection.delete(ids=existing_ids)
 
     # 2. Call the function
-    train_ddl(describe_ddl=False)
+    train_ddl()
 
     # 3. Verify success messages were shown
     # Check that starting message was shown
     mock_toast.assert_any_call("🚀 Starting DDL training...")
 
     # Check that individual table completion messages were shown
-    mock_toast.assert_any_call("✓ Trained DDL for table: users")
-    mock_toast.assert_any_call("✓ Trained DDL for table: orders")
+    mock_toast.assert_any_call("Trained DDL for table: users")
+    mock_toast.assert_any_call("Trained DDL for table: orders")
 
     # Check that final success message was shown
-    mock_success.assert_called_once_with("🎉 DDL Training completed successfully! Trained 2 table(s).")
+    mock_success.assert_called_once_with("DDL Training completed! Trained 2 table(s).")
 
     # Verify warning was not called (since we have tables)
     mock_warning.assert_not_called()
@@ -758,7 +758,7 @@ def test_train_ddl_shows_warning_when_no_tables(
     service = mock_vanna_service_with_in_memory_chroma
 
     # 2. Call the function
-    train_ddl(describe_ddl=False)
+    train_ddl()
 
     # 3. Verify appropriate messages were shown
     # Check that starting message was shown

--- a/utils/chromadb_vector.py
+++ b/utils/chromadb_vector.py
@@ -147,8 +147,11 @@ class ThriveAI_ChromaDB(ChromaDB_VectorStore):
         )
         return id
 
-    def add_documentation(self, documentation: str, metadata: dict[str, Any] | None = None, **kwargs) -> str:
-        id = deterministic_uuid(documentation) + "-doc"
+    def add_documentation(
+        self, documentation: str, metadata: dict[str, Any] | None = None, id: str | None = None, **kwargs
+    ) -> str:
+        if id is None:
+            id = deterministic_uuid(documentation) + "-doc"
         self._safe_add(
             self.documentation_collection,
             documents=documentation,

--- a/utils/milvus_vector.py
+++ b/utils/milvus_vector.py
@@ -245,9 +245,11 @@ class ThriveAI_Milvus:
             logger.exception("Error adding DDL to Milvus: %s", e)
             raise
 
-    def add_documentation(self, documentation: str, metadata: dict[str, Any] | None = None, **kwargs) -> str:
+    def add_documentation(
+        self, documentation: str, metadata: dict[str, Any] | None = None, id: str | None = None, **kwargs
+    ) -> str:
         try:
-            doc_id = deterministic_uuid(documentation) + "-doc"
+            doc_id = id if id is not None else deterministic_uuid(documentation) + "-doc"
             self._insert(self.documentation_collection, doc_id, documentation, metadata)
             return doc_id
         except Exception as e:

--- a/views/user.py
+++ b/views/user.py
@@ -26,7 +26,7 @@ from orm.models import RoleTypeEnum, SessionLocal, User, UserRole
 from utils.authentication_management import get_user_list_excel
 from utils.chat_bot_helper import get_vn
 from utils.enums import ThemeType
-from utils.vanna_calls import train_ddl, train_file, training_plan
+from utils.vanna_calls import train_ai_documentation, train_ddl, train_file, training_plan
 
 # Get the current user ID from session state cookies
 user_id = st.session_state.cookies.get("user_id")
@@ -365,11 +365,11 @@ with tab1:
 
 with tab2:
     if tab2 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
-        cols = st.columns((0.15, 0.25, 0.15, 0.15, 0.15, 0.25, 0.15, 0.15))
+        cols = st.columns((0.15, 0.20, 0.15, 0.15, 0.15, 0.25, 0.15, 0.15))
         with cols[0]:
             st.button("Train DDL", on_click=train_ddl)
         with cols[1]:
-            st.button("DDL Describe", on_click=lambda: train_ddl(describe_ddl=True))
+            st.button("AI Generate Docs", on_click=train_ai_documentation)
         with cols[2]:
             st.button("Train Plan", on_click=training_plan)
         with cols[3]:


### PR DESCRIPTION
## Summary

- **Simplified Train DDL**: Now only trains actual DDL (CREATE TABLE statements). Removed extra constraint docs, semantic type classification, and the `describe_ddl` parameter
- **New AI Generate Docs button**: Generates rich, LLM-powered documentation for each table including purpose, use cases, column descriptions with sample values, and example queries
- **Deterministic IDs**: AI-generated docs use `ai_doc_{schema}_{table}` IDs so re-running overwrites previous AI docs without affecting manually added documentation
- **Security fixes**: Fixed SQL injection vulnerabilities using parameterized queries
- **Better error handling**: Added LLM response validation, proper resource cleanup in finally blocks

## Test plan

- [x] Run `uv run pytest tests/utils/test_vanna_ddl_training.py -v` - verify DDL training tests pass
- [x] Run `uv run pytest tests/utils/test_vanna_calls.py -v` - verify vanna service tests pass
- [x] Start app with `uv run streamlit run app.py`
- [x] Login as admin, go to Settings tab
- [x] Click "Train DDL" - verify it only trains DDL (check training data table shows only DDL entries)
- [x] Click "AI Generate Docs" - verify progress bar shows, documentation is generated for each table
- [x] Re-run "AI Generate Docs" - verify it overwrites previous AI docs (no duplicates)
- [x] Ask a question about a table - verify the AI-generated documentation helps with SQL generation

🤖 Generated with [Claude Code](https://claude.ai/code)