### PR TITLE
feat: Add saved reports with trend tracking

### DIFF
--- a/tests/utils/test_report_service.py
+++ b/tests/utils/test_report_service.py
@@ -1,0 +1,418 @@
+"""Tests for the saved reports service."""
+
+import json
+import pytest
+import pandas as pd
+from datetime import datetime, timedelta
+
+from orm.models import SavedReport, ReportExecution, SessionLocal, Base, engine, User, UserRole, RoleTypeEnum
+from utils.report_service import (
+    save_report_from_chat,
+    get_user_reports,
+    get_report_by_id,
+    get_report_by_name,
+    archive_report,
+    find_matching_report,
+    record_report_execution,
+    get_report_executions,
+    get_latest_execution,
+    extract_numeric_summary,
+    get_consistent_columns,
+    get_execution_count,
+    format_delta,
+    _calculate_similarity,
+)
+
+
+@pytest.fixture
+def test_user():
+    """Create a test user for report tests."""
+    session = SessionLocal()
+    try:
+        # Ensure Admin role exists
+        role = session.query(UserRole).filter_by(role_name="Admin").first()
+        if not role:
+            role = UserRole(role_name="Admin", description="Test Admin", role=RoleTypeEnum.ADMIN)
+            session.add(role)
+            session.commit()
+
+        # Create a unique test user for each test
+        import uuid
+        unique_suffix = str(uuid.uuid4())[:8]
+        user = User(
+            username=f"test_report_user_{unique_suffix}",
+            first_name="Test",
+            last_name="User",
+            password="hashed_password",
+            user_role_id=role.id,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        user_id = user.id
+
+        yield user_id
+
+        # Cleanup - delete executions first (foreign key constraint)
+        reports = session.query(SavedReport).filter(SavedReport.user_id == user_id).all()
+        for report in reports:
+            session.query(ReportExecution).filter(ReportExecution.report_id == report.id).delete()
+        session.query(SavedReport).filter(SavedReport.user_id == user_id).delete()
+        session.query(User).filter(User.id == user_id).delete()
+        session.commit()
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def sample_dataframe():
+    """Create a sample DataFrame for testing."""
+    return pd.DataFrame({
+        "county": ["Erie", "Monroe", "Niagara"],
+        "patient_count": [100, 80, 60],
+        "avg_age": [45.5, 42.3, 48.1],
+    })
+
+
+class TestSimilarityCalculation:
+    """Tests for string similarity calculation."""
+
+    def test_identical_strings(self):
+        assert _calculate_similarity("hello world", "hello world") == 1.0
+
+    def test_similar_strings(self):
+        score = _calculate_similarity("how many patients by county", "how many patients by county?")
+        assert score > 0.9
+
+    def test_different_strings(self):
+        score = _calculate_similarity("show all tables", "delete everything")
+        assert score < 0.5
+
+    def test_empty_strings(self):
+        assert _calculate_similarity("", "hello") == 0.0
+        assert _calculate_similarity("hello", "") == 0.0
+        assert _calculate_similarity("", "") == 0.0
+
+    def test_case_insensitive(self):
+        score = _calculate_similarity("HELLO WORLD", "hello world")
+        assert score == 1.0
+
+
+class TestExtractNumericSummary:
+    """Tests for extracting numeric summaries from DataFrames."""
+
+    def test_basic_extraction(self, sample_dataframe):
+        summary = extract_numeric_summary(sample_dataframe)
+
+        assert "patient_count" in summary
+        assert "avg_age" in summary
+        assert "county" not in summary  # String column excluded
+
+        assert summary["patient_count"]["sum"] == 240
+        assert summary["patient_count"]["count"] == 3
+        assert summary["patient_count"]["min"] == 60
+        assert summary["patient_count"]["max"] == 100
+
+    def test_empty_dataframe(self):
+        df = pd.DataFrame()
+        summary = extract_numeric_summary(df)
+        assert summary == {}
+
+    def test_no_numeric_columns(self):
+        df = pd.DataFrame({"name": ["Alice", "Bob"], "city": ["NYC", "LA"]})
+        summary = extract_numeric_summary(df)
+        assert summary == {}
+
+
+class TestFormatDelta:
+    """Tests for delta formatting."""
+
+    def test_increase(self):
+        result = format_delta(110, 100)
+        assert "↑" in result
+        assert "10" in result
+
+    def test_decrease(self):
+        result = format_delta(90, 100)
+        assert "↓" in result
+        assert "10" in result
+
+    def test_no_change(self):
+        result = format_delta(100, 100)
+        assert "→" in result or "0" in result
+
+    def test_from_zero(self):
+        result = format_delta(100, 0)
+        assert result == "N/A"
+
+
+class TestSaveReportFromChat:
+    """Tests for saving reports from chat."""
+
+    def test_save_basic_report(self, test_user):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Monthly Patient Count",
+            sql_query="SELECT county, COUNT(*) FROM patients GROUP BY county",
+            original_question="How many patients by county?",
+        )
+
+        assert report is not None
+        assert report.id is not None
+        assert report.name == "Monthly Patient Count"
+        assert report.sql_query == "SELECT county, COUNT(*) FROM patients GROUP BY county"
+        assert report.original_question == "How many patients by county?"
+        assert report.user_id == test_user
+        assert report.is_archived == False
+
+    def test_save_with_description(self, test_user):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Test Report",
+            sql_query="SELECT * FROM test",
+            original_question="Show test data",
+            description="A test report for unit testing",
+        )
+
+        assert report.description == "A test report for unit testing"
+
+
+class TestGetUserReports:
+    """Tests for retrieving user reports."""
+
+    def test_get_reports_empty(self, test_user):
+        reports = get_user_reports(test_user)
+        # Filter to just our test user's reports
+        assert isinstance(reports, list)
+
+    def test_get_reports_excludes_archived(self, test_user):
+        # Create a normal report
+        report1 = save_report_from_chat(
+            user_id=test_user,
+            name="Active Report",
+            sql_query="SELECT 1",
+            original_question="Test",
+        )
+
+        # Create and archive a report
+        report2 = save_report_from_chat(
+            user_id=test_user,
+            name="Archived Report",
+            sql_query="SELECT 2",
+            original_question="Test 2",
+        )
+        archive_report(report2.id, test_user)
+
+        # Get non-archived reports
+        reports = get_user_reports(test_user, include_archived=False)
+        report_names = [r.name for r in reports]
+
+        assert "Active Report" in report_names
+        assert "Archived Report" not in report_names
+
+    def test_get_reports_includes_archived(self, test_user):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Another Archived",
+            sql_query="SELECT 3",
+            original_question="Test 3",
+        )
+        archive_report(report.id, test_user)
+
+        reports = get_user_reports(test_user, include_archived=True)
+        report_names = [r.name for r in reports]
+        assert "Another Archived" in report_names
+
+
+class TestFindMatchingReport:
+    """Tests for automatic report detection."""
+
+    def test_exact_question_match(self, test_user):
+        question = "How many patients are there by county?"
+        save_report_from_chat(
+            user_id=test_user,
+            name="Patient County Report",
+            sql_query="SELECT county, COUNT(*) FROM patients GROUP BY county",
+            original_question=question,
+        )
+
+        match = find_matching_report(test_user, question)
+        assert match is not None
+        assert match.name == "Patient County Report"
+
+    def test_similar_question_match(self, test_user):
+        save_report_from_chat(
+            user_id=test_user,
+            name="Patients by County",
+            sql_query="SELECT county, COUNT(*) FROM patients GROUP BY county",
+            original_question="How many patients are there by county?",
+        )
+
+        # Almost identical question should match (>90% similar)
+        match = find_matching_report(test_user, "How many patients are there by county")
+        assert match is not None
+        assert match.name == "Patients by County"
+
+    def test_no_match_different_question(self, test_user):
+        save_report_from_chat(
+            user_id=test_user,
+            name="Some Report",
+            sql_query="SELECT * FROM table1",
+            original_question="Show all data from table1",
+        )
+
+        # Very different question should not match
+        match = find_matching_report(test_user, "What is the average age of patients?")
+        assert match is None
+
+    def test_no_match_empty_question(self, test_user):
+        match = find_matching_report(test_user, "")
+        assert match is None
+
+        match = find_matching_report(test_user, None)
+        assert match is None
+
+
+class TestRecordReportExecution:
+    """Tests for recording report executions."""
+
+    def test_record_successful_execution(self, test_user, sample_dataframe):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Execution Test Report",
+            sql_query="SELECT * FROM data",
+            original_question="Show data",
+        )
+
+        execution = record_report_execution(
+            report=report,
+            df=sample_dataframe,
+            user_id=test_user,
+            group_id="test-group-123",
+            elapsed_time=0.5,
+        )
+
+        assert execution is not None
+        assert execution.report_id == report.id
+        assert execution.success == True
+        assert execution.row_count == 3
+        assert execution.elapsed_time == 0.5
+        assert execution.group_id == "test-group-123"
+        assert execution.triggered_by == "auto"
+
+        # Check numeric summary was computed
+        summary = json.loads(execution.numeric_summary)
+        assert "patient_count" in summary
+
+    def test_record_null_dataframe(self, test_user):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Null DF Test",
+            sql_query="SELECT * FROM empty",
+            original_question="Show empty",
+        )
+
+        execution = record_report_execution(
+            report=report,
+            df=None,
+            user_id=test_user,
+            group_id="test-group-456",
+        )
+
+        assert execution.success == False
+        assert execution.row_count == 0
+
+
+class TestGetReportExecutions:
+    """Tests for retrieving execution history."""
+
+    def test_get_executions_ordered(self, test_user, sample_dataframe):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="History Test",
+            sql_query="SELECT * FROM test",
+            original_question="Test query",
+        )
+
+        # Record multiple executions
+        for i in range(3):
+            record_report_execution(report, sample_dataframe, test_user, f"group-{i}")
+
+        executions = get_report_executions(report.id)
+        # Should have at least 3 executions (from this test)
+        assert len(executions) >= 3
+
+        # Should be ordered by most recent first
+        for i in range(len(executions) - 1):
+            assert executions[i].created_at >= executions[i + 1].created_at
+
+    def test_get_executions_with_limit(self, test_user, sample_dataframe):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Limit Test",
+            sql_query="SELECT 1",
+            original_question="Test",
+        )
+
+        for i in range(5):
+            record_report_execution(report, sample_dataframe, test_user, f"group-{i}")
+
+        executions = get_report_executions(report.id, limit=2)
+        assert len(executions) == 2
+
+
+class TestGetExecutionCount:
+    """Tests for execution count."""
+
+    def test_count_executions(self, test_user, sample_dataframe):
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Count Test",
+            sql_query="SELECT 1",
+            original_question="Test",
+        )
+
+        # Get initial count for this specific report
+        initial_count = get_execution_count(report.id)
+
+        record_report_execution(report, sample_dataframe, test_user, "group-1")
+        assert get_execution_count(report.id) == initial_count + 1
+
+        record_report_execution(report, sample_dataframe, test_user, "group-2")
+        assert get_execution_count(report.id) == initial_count + 2
+
+
+class TestGetConsistentColumns:
+    """Tests for consistent column detection."""
+
+    def test_consistent_columns_basic(self, test_user, sample_dataframe):
+        """Test that consistent columns are detected across multiple executions."""
+        report = save_report_from_chat(
+            user_id=test_user,
+            name="Consistent Cols Test",
+            sql_query="SELECT * FROM data",
+            original_question="Show data",
+        )
+
+        # Record executions with the same DataFrame schema
+        for i in range(3):
+            record_report_execution(report, sample_dataframe, test_user, f"group-{i}")
+
+        cols = get_consistent_columns(report.id)
+        # Should have numeric columns from sample_dataframe
+        assert isinstance(cols, list)
+
+    def test_extract_numeric_summary_works(self):
+        """Test that numeric summary extraction works correctly."""
+        df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "name": ["x", "y", "z"]})
+        summary = extract_numeric_summary(df)
+
+        assert "a" in summary
+        assert "b" in summary
+        assert "name" not in summary  # String column excluded
+
+        assert summary["a"]["sum"] == 6.0
+        assert summary["a"]["avg"] == 2.0
+        assert summary["a"]["min"] == 1.0
+        assert summary["a"]["max"] == 3.0
+        assert summary["a"]["count"] == 3

--- a/utils/config/training_data.json
+++ b/utils/config/training_data.json
@@ -171,6 +171,10 @@
         {
             "question": "How many patients have diabetes? What percentage of the population is that?",
             "query": "SELECT\n    COUNT(DISTINCT CASE WHEN diabetes = 'Y' THEN research_id END) AS diabetes_count,\n    COUNT(DISTINCT research_id) AS total_patients,\n    ROUND(100.0 * COUNT(DISTINCT CASE WHEN diabetes = 'Y' THEN research_id END) / COUNT(DISTINCT research_id), 2) AS diabetes_percentage\nFROM wny_health"
+        },
+        {
+            "question": "what were the top diagnosis for males over 50 in wny?\n\n",
+            "query": "SELECT question, COUNT(*) AS count \nFROM chronic_disease \nWHERE questionid IN (SELECT questionid FROM wny_health WHERE age > 50 AND sex = 'MALE') \nGROUP BY question \nORDER BY count DESC \nLIMIT 10"
         }
     ],
     "sample_documents": [

--- a/utils/report_service.py
+++ b/utils/report_service.py
@@ -1,0 +1,703 @@
+"""Service layer for Saved Reports with trend tracking functionality."""
+
+import json
+import logging
+from datetime import datetime
+from difflib import SequenceMatcher
+
+import pandas as pd
+
+from orm.models import ReportExecution, SavedReport, SessionLocal
+
+logger = logging.getLogger(__name__)
+
+# Similarity threshold for matching questions to saved reports
+SIMILARITY_THRESHOLD = 0.90
+
+
+def _normalize_question(text: str) -> str:
+    """Normalize a question by removing common prefixes and filler words.
+
+    This improves matching for semantically identical questions like:
+    - "what were the top diagnosis" vs "top diagnosis"
+    - "show me patients by age" vs "patients by age"
+    """
+    if not text:
+        return ""
+
+    normalized = text.lower().strip()
+
+    # Common question prefixes to strip (order matters - longer first)
+    prefixes = [
+        "can you show me ",
+        "can you tell me ",
+        "can you give me ",
+        "can you list ",
+        "please show me ",
+        "please tell me ",
+        "please give me ",
+        "please list ",
+        "what were the ",
+        "what are the ",
+        "what is the ",
+        "what was the ",
+        "show me the ",
+        "give me the ",
+        "tell me the ",
+        "list the ",
+        "show me ",
+        "give me ",
+        "tell me ",
+        "list ",
+        "what ",
+        "how many ",
+        "how much ",
+    ]
+
+    for prefix in prefixes:
+        if normalized.startswith(prefix):
+            normalized = normalized[len(prefix):]
+            break  # Only strip one prefix
+
+    return normalized.strip()
+
+
+def _calculate_similarity(text1: str, text2: str) -> float:
+    """Calculate similarity ratio between two strings (0-1).
+
+    Normalizes questions to remove common prefixes before comparison.
+    """
+    if not text1 or not text2:
+        return 0.0
+
+    # Normalize both texts
+    t1 = _normalize_question(text1)
+    t2 = _normalize_question(text2)
+
+    return SequenceMatcher(None, t1, t2).ratio()
+
+
+def extract_numeric_summary(df: pd.DataFrame) -> dict:
+    """Extract summary statistics for all numeric columns in a DataFrame.
+
+    Returns dict like: {column_name: {sum, avg, min, max, count}}
+    """
+    if df is None or df.empty:
+        return {}
+
+    summary = {}
+    numeric_cols = df.select_dtypes(include=["number"]).columns
+
+    for col in numeric_cols:
+        col_data = df[col].dropna()
+        if len(col_data) > 0:
+            summary[col] = {
+                "sum": float(col_data.sum()),
+                "avg": float(col_data.mean()),
+                "min": float(col_data.min()),
+                "max": float(col_data.max()),
+                "count": int(len(col_data)),
+            }
+
+    return summary
+
+
+# ==============================================================================
+# Core CRUD Operations
+# ==============================================================================
+
+
+def save_report_from_chat(
+    user_id: int,
+    name: str,
+    sql_query: str,
+    original_question: str,
+    source_group_id: str = None,
+    description: str = None,
+) -> SavedReport:
+    """Create a new saved report from chat context.
+
+    Args:
+        user_id: The user who is saving the report
+        name: User-provided name for the report
+        sql_query: The SQL query to save (frozen, never regenerated)
+        original_question: The natural language question that generated the SQL
+        source_group_id: Optional group_id from the chat message
+        description: Optional description
+
+    Returns:
+        The created SavedReport object
+    """
+    session = SessionLocal()
+    try:
+        report = SavedReport(
+            user_id=user_id,
+            name=name,
+            sql_query=sql_query,
+            original_question=original_question,
+            source_group_id=source_group_id,
+            description=description,
+        )
+        session.add(report)
+        session.commit()
+        session.refresh(report)
+        logger.info(f"Saved report '{name}' (id={report.id}) for user {user_id}")
+        return report
+    except Exception as e:
+        session.rollback()
+        logger.error(f"Failed to save report: {e}")
+        raise
+    finally:
+        session.close()
+
+
+def get_user_reports(user_id: int, include_archived: bool = False) -> list[SavedReport]:
+    """Get all saved reports for a user.
+
+    Args:
+        user_id: The user whose reports to retrieve
+        include_archived: Whether to include archived reports
+
+    Returns:
+        List of SavedReport objects ordered by most recent first
+    """
+    session = SessionLocal()
+    try:
+        query = session.query(SavedReport).filter(SavedReport.user_id == user_id)
+        if not include_archived:
+            query = query.filter(SavedReport.is_archived == False)  # noqa: E712
+        return query.order_by(SavedReport.updated_at.desc()).all()
+    finally:
+        session.close()
+
+
+def get_report_by_id(report_id: int) -> SavedReport | None:
+    """Get a single report by ID."""
+    session = SessionLocal()
+    try:
+        return session.query(SavedReport).filter(SavedReport.id == report_id).first()
+    finally:
+        session.close()
+
+
+def get_report_by_name(user_id: int, name: str) -> SavedReport | None:
+    """Get a report by name for a specific user (case-insensitive)."""
+    session = SessionLocal()
+    try:
+        # SQLite uses LIKE for case-insensitive, PostgreSQL uses ILIKE
+        return (
+            session.query(SavedReport)
+            .filter(SavedReport.user_id == user_id, SavedReport.name.ilike(name), SavedReport.is_archived == False)  # noqa: E712
+            .first()
+        )
+    finally:
+        session.close()
+
+
+def update_report(report_id: int, user_id: int, **kwargs) -> SavedReport | None:
+    """Update a saved report.
+
+    Args:
+        report_id: The report to update
+        user_id: The user making the update (must own the report)
+        **kwargs: Fields to update (name, description, tags)
+
+    Returns:
+        Updated SavedReport or None if not found/not authorized
+    """
+    session = SessionLocal()
+    try:
+        report = (
+            session.query(SavedReport).filter(SavedReport.id == report_id, SavedReport.user_id == user_id).first()
+        )
+        if not report:
+            return None
+
+        for key, value in kwargs.items():
+            if hasattr(report, key) and key not in ("id", "user_id", "created_at"):
+                setattr(report, key, value)
+
+        session.commit()
+        session.refresh(report)
+        return report
+    except Exception as e:
+        session.rollback()
+        logger.error(f"Failed to update report {report_id}: {e}")
+        raise
+    finally:
+        session.close()
+
+
+def archive_report(report_id: int, user_id: int) -> bool:
+    """Archive a saved report (soft delete).
+
+    Args:
+        report_id: The report to archive
+        user_id: The user making the request (must own the report)
+
+    Returns:
+        True if archived, False if not found/not authorized
+    """
+    session = SessionLocal()
+    try:
+        report = (
+            session.query(SavedReport).filter(SavedReport.id == report_id, SavedReport.user_id == user_id).first()
+        )
+        if not report:
+            return False
+
+        report.is_archived = True
+        session.commit()
+        logger.info(f"Archived report {report_id}")
+        return True
+    except Exception as e:
+        session.rollback()
+        logger.error(f"Failed to archive report {report_id}: {e}")
+        return False
+    finally:
+        session.close()
+
+
+# ==============================================================================
+# Report Execution
+# ==============================================================================
+
+
+def execute_report(
+    report_id: int,
+    user_id: int,
+    triggered_by: str = "manual",
+    group_id: str = None,
+) -> tuple[ReportExecution, pd.DataFrame | None]:
+    """Execute a saved report and record the execution.
+
+    Args:
+        report_id: The report to execute
+        user_id: The user executing the report
+        triggered_by: How this was triggered ("manual", "scheduled", "api", "auto")
+        group_id: Optional chat group_id to link this execution
+
+    Returns:
+        Tuple of (ReportExecution, DataFrame or None if failed)
+    """
+    import time
+
+    from utils.vanna_calls import VannaService
+
+    session = SessionLocal()
+    try:
+        report = session.query(SavedReport).filter(SavedReport.id == report_id).first()
+        if not report:
+            raise ValueError(f"Report {report_id} not found")
+
+        # Execute the SQL
+        vn = VannaService.from_streamlit_session()
+        start_time = time.time()
+
+        try:
+            result = vn.run_sql(sql=report.sql_query)
+            elapsed_time = time.time() - start_time
+
+            if isinstance(result, tuple):
+                df, _ = result
+            else:
+                df = result
+
+            if isinstance(df, pd.DataFrame):
+                # Successful execution
+                execution = ReportExecution(
+                    report_id=report_id,
+                    triggered_by=triggered_by,
+                    executed_by_user_id=user_id,
+                    dataframe_json=df.to_json(date_format="iso"),
+                    row_count=len(df),
+                    column_names=json.dumps(list(df.columns)),
+                    elapsed_time=elapsed_time,
+                    success=True,
+                    numeric_summary=json.dumps(extract_numeric_summary(df)),
+                    group_id=group_id,
+                )
+            else:
+                # Execution returned non-DataFrame
+                execution = ReportExecution(
+                    report_id=report_id,
+                    triggered_by=triggered_by,
+                    executed_by_user_id=user_id,
+                    elapsed_time=elapsed_time,
+                    success=False,
+                    error_message="Query did not return a DataFrame",
+                    group_id=group_id,
+                )
+                df = None
+
+        except Exception as e:
+            elapsed_time = time.time() - start_time
+            execution = ReportExecution(
+                report_id=report_id,
+                triggered_by=triggered_by,
+                executed_by_user_id=user_id,
+                elapsed_time=elapsed_time,
+                success=False,
+                error_message=str(e)[:2000],
+                group_id=group_id,
+            )
+            df = None
+            logger.error(f"Report execution failed for report {report_id}: {e}")
+
+        session.add(execution)
+        session.commit()
+        session.refresh(execution)
+
+        logger.info(
+            f"Recorded execution for report {report_id}: success={execution.success}, rows={execution.row_count}"
+        )
+        return execution, df
+
+    finally:
+        session.close()
+
+
+def record_report_execution(
+    report: SavedReport,
+    df: pd.DataFrame,
+    user_id: int,
+    group_id: str,
+    elapsed_time: float = 0,
+) -> ReportExecution:
+    """Record an execution when a question matches a saved report.
+
+    Called automatically from normal_message_flow when match detected.
+
+    Args:
+        report: The matched SavedReport
+        df: The DataFrame result from executing the query
+        user_id: The user who ran the query
+        group_id: The chat group_id
+        elapsed_time: Query execution time
+
+    Returns:
+        The created ReportExecution
+    """
+    session = SessionLocal()
+    try:
+        execution = ReportExecution(
+            report_id=report.id,
+            triggered_by="auto",
+            executed_by_user_id=user_id,
+            dataframe_json=df.to_json(date_format="iso") if df is not None else None,
+            row_count=len(df) if df is not None else 0,
+            column_names=json.dumps(list(df.columns)) if df is not None else None,
+            elapsed_time=elapsed_time,
+            success=df is not None,
+            numeric_summary=json.dumps(extract_numeric_summary(df)) if df is not None else None,
+            group_id=group_id,
+        )
+        session.add(execution)
+        session.commit()
+        session.refresh(execution)
+
+        logger.info(f"Auto-recorded execution for report '{report.name}' (id={report.id})")
+        return execution
+    except Exception as e:
+        session.rollback()
+        logger.error(f"Failed to record report execution: {e}")
+        raise
+    finally:
+        session.close()
+
+
+def get_report_executions(report_id: int, limit: int = 50) -> list[ReportExecution]:
+    """Get execution history for a report.
+
+    Args:
+        report_id: The report to get executions for
+        limit: Maximum number of executions to return
+
+    Returns:
+        List of ReportExecution objects ordered by most recent first
+    """
+    session = SessionLocal()
+    try:
+        return (
+            session.query(ReportExecution)
+            .filter(ReportExecution.report_id == report_id)
+            .order_by(ReportExecution.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+    finally:
+        session.close()
+
+
+def get_latest_execution(report_id: int) -> ReportExecution | None:
+    """Get the most recent execution for a report."""
+    session = SessionLocal()
+    try:
+        return (
+            session.query(ReportExecution)
+            .filter(ReportExecution.report_id == report_id)
+            .order_by(ReportExecution.created_at.desc())
+            .first()
+        )
+    finally:
+        session.close()
+
+
+# ==============================================================================
+# Automatic Report Detection
+# ==============================================================================
+
+
+def find_matching_report(user_id: int, question: str, sql: str = None) -> SavedReport | None:
+    """Check if a question/SQL matches an existing saved report.
+
+    Uses fuzzy matching (≥90% similarity) against:
+    - original_question field
+    - sql_query field (if provided)
+
+    Args:
+        user_id: The user whose reports to check
+        question: The user's question
+        sql: Optional SQL query to also compare
+
+    Returns:
+        The matching SavedReport or None if no match found
+    """
+    if not question:
+        return None
+
+    session = SessionLocal()
+    try:
+        reports = (
+            session.query(SavedReport)
+            .filter(SavedReport.user_id == user_id, SavedReport.is_archived == False)  # noqa: E712
+            .all()
+        )
+
+        best_match = None
+        best_score = 0
+
+        for report in reports:
+            # Check question similarity
+            q_score = _calculate_similarity(question, report.original_question)
+
+            # Check SQL similarity if provided
+            sql_score = 0
+            if sql and report.sql_query:
+                sql_score = _calculate_similarity(sql, report.sql_query)
+
+            # Use the higher of the two scores
+            score = max(q_score, sql_score)
+
+            if score >= SIMILARITY_THRESHOLD and score > best_score:
+                best_score = score
+                best_match = report
+
+        if best_match:
+            logger.debug(
+                f"Found matching report '{best_match.name}' (id={best_match.id}) "
+                f"with similarity {best_score:.2%}"
+            )
+
+        return best_match
+
+    finally:
+        session.close()
+
+
+# ==============================================================================
+# Trend Analysis
+# ==============================================================================
+
+
+def get_report_trends(report_id: int, column: str = None, metric: str = "sum") -> list[dict]:
+    """Get trend data for a report across all executions.
+
+    Args:
+        report_id: The report to get trends for
+        column: Specific column to get trends for (or None for all)
+        metric: The metric to extract (sum, avg, min, max, count)
+
+    Returns:
+        List of dicts with {timestamp, column, value} for charting
+    """
+    session = SessionLocal()
+    try:
+        executions = (
+            session.query(ReportExecution)
+            .filter(ReportExecution.report_id == report_id, ReportExecution.success == True)  # noqa: E712
+            .order_by(ReportExecution.created_at.asc())
+            .all()
+        )
+
+        trends = []
+        for exec in executions:
+            if not exec.numeric_summary:
+                continue
+
+            try:
+                summary = json.loads(exec.numeric_summary)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+            if column:
+                # Get specific column
+                if column in summary and metric in summary[column]:
+                    trends.append(
+                        {
+                            "timestamp": exec.created_at.isoformat() if exec.created_at else None,
+                            "column": column,
+                            "metric": metric,
+                            "value": summary[column][metric],
+                            "execution_id": exec.id,
+                        }
+                    )
+            else:
+                # Get all columns
+                for col, metrics in summary.items():
+                    if metric in metrics:
+                        trends.append(
+                            {
+                                "timestamp": exec.created_at.isoformat() if exec.created_at else None,
+                                "column": col,
+                                "metric": metric,
+                                "value": metrics[metric],
+                                "execution_id": exec.id,
+                            }
+                        )
+
+        return trends
+
+    finally:
+        session.close()
+
+
+def get_consistent_columns(report_id: int) -> list[str]:
+    """Return columns that exist in ALL executions for reliable trend charting.
+
+    Args:
+        report_id: The report to check
+
+    Returns:
+        List of column names present in every execution's numeric_summary
+    """
+    session = SessionLocal()
+    try:
+        executions = (
+            session.query(ReportExecution)
+            .filter(ReportExecution.report_id == report_id, ReportExecution.success == True)  # noqa: E712
+            .all()
+        )
+
+        if not executions:
+            return []
+
+        # Start with columns from first execution
+        consistent_cols = None
+        for exec in executions:
+            if not exec.numeric_summary:
+                continue
+            try:
+                summary = json.loads(exec.numeric_summary)
+                cols = set(summary.keys())
+                if consistent_cols is None:
+                    consistent_cols = cols
+                else:
+                    consistent_cols &= cols
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        return list(consistent_cols) if consistent_cols else []
+
+    finally:
+        session.close()
+
+
+def compare_executions(exec1_id: int, exec2_id: int) -> pd.DataFrame | None:
+    """Compare two executions side by side.
+
+    Args:
+        exec1_id: First execution (typically older)
+        exec2_id: Second execution (typically newer)
+
+    Returns:
+        DataFrame with comparison or None if either execution not found
+    """
+    session = SessionLocal()
+    try:
+        exec1 = session.query(ReportExecution).filter(ReportExecution.id == exec1_id).first()
+        exec2 = session.query(ReportExecution).filter(ReportExecution.id == exec2_id).first()
+
+        if not exec1 or not exec2:
+            return None
+
+        if not exec1.numeric_summary or not exec2.numeric_summary:
+            return None
+
+        try:
+            summary1 = json.loads(exec1.numeric_summary)
+            summary2 = json.loads(exec2.numeric_summary)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        # Build comparison data
+        all_cols = set(summary1.keys()) | set(summary2.keys())
+        rows = []
+        for col in sorted(all_cols):
+            for metric in ["sum", "avg", "min", "max", "count"]:
+                val1 = summary1.get(col, {}).get(metric)
+                val2 = summary2.get(col, {}).get(metric)
+                if val1 is not None or val2 is not None:
+                    delta = None
+                    delta_pct = None
+                    if val1 is not None and val2 is not None and val1 != 0:
+                        delta = val2 - val1
+                        delta_pct = (delta / val1) * 100
+
+                    rows.append(
+                        {
+                            "Column": col,
+                            "Metric": metric,
+                            "Previous": val1,
+                            "Current": val2,
+                            "Delta": delta,
+                            "Delta %": delta_pct,
+                        }
+                    )
+
+        return pd.DataFrame(rows) if rows else None
+
+    finally:
+        session.close()
+
+
+def get_execution_count(report_id: int) -> int:
+    """Get the total number of executions for a report."""
+    session = SessionLocal()
+    try:
+        return session.query(ReportExecution).filter(ReportExecution.report_id == report_id).count()
+    finally:
+        session.close()
+
+
+def format_delta(current: float, previous: float) -> str:
+    """Format a delta value as a string with arrow indicator.
+
+    Args:
+        current: Current value
+        previous: Previous value
+
+    Returns:
+        Formatted string like "↑ 12.5%" or "↓ 3.2%" or "→ 0%"
+    """
+    if previous == 0:
+        return "N/A"
+
+    delta_pct = ((current - previous) / previous) * 100
+
+    if delta_pct > 0:
+        return f"↑ {delta_pct:.1f}%"
+    elif delta_pct < 0:
+        return f"↓ {abs(delta_pct):.1f}%"
+    else:
+        return "→ 0%"

--- a/utils/trend_visualization.py
+++ b/utils/trend_visualization.py
@@ -1,0 +1,349 @@
+"""Trend visualization utilities for saved reports."""
+
+import json
+import logging
+from datetime import datetime
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from orm.models import ReportExecution
+
+logger = logging.getLogger(__name__)
+
+
+def build_trend_chart(
+    executions: list[ReportExecution],
+    column: str,
+    metric: str = "sum",
+) -> go.Figure | None:
+    """Build a Plotly line chart showing metric values over time.
+
+    Args:
+        executions: List of ReportExecution objects (should be ordered by created_at)
+        column: The column name to chart
+        metric: The metric to display (sum, avg, min, max, count)
+
+    Returns:
+        Plotly Figure or None if no data
+    """
+    if not executions:
+        return None
+
+    timestamps = []
+    values = []
+
+    for exec in executions:
+        if not exec.success or not exec.numeric_summary:
+            continue
+
+        try:
+            summary = json.loads(exec.numeric_summary)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        if column not in summary or metric not in summary[column]:
+            continue
+
+        timestamps.append(exec.created_at)
+        values.append(summary[column][metric])
+
+    if not timestamps:
+        return None
+
+    fig = go.Figure()
+
+    fig.add_trace(
+        go.Scatter(
+            x=timestamps,
+            y=values,
+            mode="lines+markers",
+            name=f"{column} ({metric})",
+            line=dict(width=2),
+            marker=dict(size=8),
+            hovertemplate="<b>%{x|%Y-%m-%d %H:%M}</b><br>" + f"{metric}: %{{y:.2f}}<extra></extra>",
+        )
+    )
+
+    fig.update_layout(
+        title=f"{column} - {metric.capitalize()} Over Time",
+        xaxis_title="Execution Date",
+        yaxis_title=metric.capitalize(),
+        hovermode="x unified",
+        template="plotly_white",
+        height=400,
+    )
+
+    return fig
+
+
+def build_multi_metric_chart(
+    executions: list[ReportExecution],
+    column: str,
+) -> go.Figure | None:
+    """Build a chart showing multiple metrics for a column over time.
+
+    Args:
+        executions: List of ReportExecution objects
+        column: The column name to chart
+
+    Returns:
+        Plotly Figure with multiple traces or None if no data
+    """
+    if not executions:
+        return None
+
+    # Collect data for each metric
+    data = {"timestamp": [], "sum": [], "avg": [], "min": [], "max": []}
+
+    for exec in executions:
+        if not exec.success or not exec.numeric_summary:
+            continue
+
+        try:
+            summary = json.loads(exec.numeric_summary)
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+        if column not in summary:
+            continue
+
+        data["timestamp"].append(exec.created_at)
+        for metric in ["sum", "avg", "min", "max"]:
+            data[metric].append(summary[column].get(metric))
+
+    if not data["timestamp"]:
+        return None
+
+    fig = go.Figure()
+
+    colors = {"sum": "#1f77b4", "avg": "#ff7f0e", "min": "#2ca02c", "max": "#d62728"}
+
+    for metric in ["sum", "avg", "min", "max"]:
+        if any(v is not None for v in data[metric]):
+            fig.add_trace(
+                go.Scatter(
+                    x=data["timestamp"],
+                    y=data[metric],
+                    mode="lines+markers",
+                    name=metric.capitalize(),
+                    line=dict(color=colors[metric], width=2),
+                    marker=dict(size=6),
+                )
+            )
+
+    fig.update_layout(
+        title=f"{column} - All Metrics Over Time",
+        xaxis_title="Execution Date",
+        yaxis_title="Value",
+        hovermode="x unified",
+        template="plotly_white",
+        height=400,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+
+    return fig
+
+
+def build_row_count_chart(executions: list[ReportExecution]) -> go.Figure | None:
+    """Build a simple chart showing row count over time.
+
+    Args:
+        executions: List of ReportExecution objects
+
+    Returns:
+        Plotly Figure or None if no data
+    """
+    if not executions:
+        return None
+
+    timestamps = []
+    row_counts = []
+
+    for exec in executions:
+        if not exec.success:
+            continue
+        timestamps.append(exec.created_at)
+        row_counts.append(exec.row_count or 0)
+
+    if not timestamps:
+        return None
+
+    fig = go.Figure()
+
+    fig.add_trace(
+        go.Bar(
+            x=timestamps,
+            y=row_counts,
+            name="Row Count",
+            marker_color="#1f77b4",
+            hovertemplate="<b>%{x|%Y-%m-%d %H:%M}</b><br>Rows: %{y}<extra></extra>",
+        )
+    )
+
+    fig.update_layout(
+        title="Row Count Over Time",
+        xaxis_title="Execution Date",
+        yaxis_title="Row Count",
+        template="plotly_white",
+        height=300,
+    )
+
+    return fig
+
+
+def build_comparison_table(
+    exec1: ReportExecution,
+    exec2: ReportExecution,
+) -> pd.DataFrame | None:
+    """Build a comparison DataFrame between two executions.
+
+    Args:
+        exec1: First (older) execution
+        exec2: Second (newer) execution
+
+    Returns:
+        DataFrame with comparison data or None if invalid
+    """
+    if not exec1 or not exec2:
+        return None
+
+    if not exec1.numeric_summary or not exec2.numeric_summary:
+        return None
+
+    try:
+        summary1 = json.loads(exec1.numeric_summary)
+        summary2 = json.loads(exec2.numeric_summary)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+    # Get all columns from both
+    all_cols = set(summary1.keys()) | set(summary2.keys())
+
+    rows = []
+    for col in sorted(all_cols):
+        for metric in ["count", "sum", "avg", "min", "max"]:
+            val1 = summary1.get(col, {}).get(metric)
+            val2 = summary2.get(col, {}).get(metric)
+
+            if val1 is None and val2 is None:
+                continue
+
+            # Calculate delta
+            delta = None
+            delta_str = ""
+            if val1 is not None and val2 is not None:
+                delta = val2 - val1
+                if val1 != 0:
+                    pct = (delta / val1) * 100
+                    if pct > 0:
+                        delta_str = f"↑ {pct:.1f}%"
+                    elif pct < 0:
+                        delta_str = f"↓ {abs(pct):.1f}%"
+                    else:
+                        delta_str = "→ 0%"
+                elif delta != 0:
+                    delta_str = "↑ ∞" if delta > 0 else "↓ ∞"
+                else:
+                    delta_str = "→ 0%"
+
+            rows.append(
+                {
+                    "Column": col,
+                    "Metric": metric.capitalize(),
+                    "Previous": f"{val1:.2f}" if val1 is not None else "N/A",
+                    "Current": f"{val2:.2f}" if val2 is not None else "N/A",
+                    "Change": delta_str,
+                }
+            )
+
+    return pd.DataFrame(rows) if rows else None
+
+
+def build_sparkline_data(executions: list[ReportExecution], column: str, metric: str = "sum") -> list[float]:
+    """Extract data points for a mini sparkline chart.
+
+    Args:
+        executions: List of ReportExecution objects (ordered by created_at)
+        column: Column to extract
+        metric: Metric to use
+
+    Returns:
+        List of float values for sparkline
+    """
+    values = []
+    for exec in executions:
+        if not exec.success or not exec.numeric_summary:
+            continue
+        try:
+            summary = json.loads(exec.numeric_summary)
+            if column in summary and metric in summary[column]:
+                values.append(summary[column][metric])
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return values
+
+
+def build_execution_history_df(executions: list[ReportExecution]) -> pd.DataFrame:
+    """Build a DataFrame summarizing execution history.
+
+    Args:
+        executions: List of ReportExecution objects
+
+    Returns:
+        DataFrame with execution history summary
+    """
+    if not executions:
+        return pd.DataFrame()
+
+    rows = []
+    for exec in executions:
+        rows.append(
+            {
+                "Date": exec.created_at.strftime("%Y-%m-%d %H:%M") if exec.created_at else "N/A",
+                "Rows": exec.row_count if exec.row_count is not None else 0,
+                "Time (s)": f"{float(exec.elapsed_time):.2f}" if exec.elapsed_time else "N/A",
+                "Status": "✓ Success" if exec.success else f"✗ {exec.error_message[:30]}..." if exec.error_message else "✗ Failed",
+                "Triggered By": exec.triggered_by or "manual",
+            }
+        )
+
+    return pd.DataFrame(rows)
+
+
+def format_time_ago(dt: datetime) -> str:
+    """Format a datetime as a human-readable 'time ago' string.
+
+    Args:
+        dt: The datetime to format
+
+    Returns:
+        String like "2 hours ago", "3 days ago", etc.
+    """
+    if not dt:
+        return "Never"
+
+    now = datetime.now()
+    if dt.tzinfo:
+        # If dt is timezone-aware, make now timezone-aware too
+        from datetime import timezone
+
+        now = datetime.now(timezone.utc)
+
+    diff = now - dt
+
+    seconds = diff.total_seconds()
+    if seconds < 60:
+        return "just now"
+    elif seconds < 3600:
+        minutes = int(seconds / 60)
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    elif seconds < 86400:
+        hours = int(seconds / 3600)
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    elif seconds < 604800:
+        days = int(seconds / 86400)
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    else:
+        weeks = int(seconds / 604800)
+        return f"{weeks} week{'s' if weeks != 1 else ''} ago"

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -13,6 +13,9 @@ from utils.chat_bot_helper import (
     normal_message_flow,
     render_message_group,
     set_question,
+    _render_save_report_dialog,
+    _render_report_history_popover,
+    _render_report_trends_popover,
 )
 from utils.communicate import listen
 from utils.enums import RoleType, ThemeType
@@ -55,7 +58,7 @@ logger = logging.getLogger(__name__)
 set_user_preferences_in_session_state()
 
 # Initialize session state variables
-if "messages" not in st.session_state or st.session_state.messages == []:
+if "messages" not in st.session_state or st.session_state.messages is None or st.session_state.messages == []:
     st.session_state.messages = get_recent_messages()
 if st.session_state.messages is None:
     st.session_state.messages = []
@@ -380,6 +383,11 @@ with messages_container:
         is_last_group = group_index == total_groups - 1
         render_message_group(group_messages, group_index, message_index, is_last_group=is_last_group)
         message_index += len(group_messages)
+
+# Render report-related dialogs if active
+_render_save_report_dialog()
+_render_report_history_popover()
+_render_report_trends_popover()
 
 # Footer placeholder that always stays at the end
 tail_placeholder = st.empty()


### PR DESCRIPTION
## Summary
- Add SavedReport and ReportExecution database models for persisting SQL reports and tracking executions over time
- Add report_service.py with CRUD operations, execution logic, and intelligent question similarity matching (90% threshold)
- Add trend_visualization.py for generating trend charts from historical report executions
- Add magic commands: `/list-reports`, `/run`, `/report-info`, `/trends`, `/save-report`, `/delete-report`

## Test plan
- [ ] Run `uv run python -m pytest tests/utils/test_report_service.py` to verify report service tests pass
- [ ] Test saving a report from the chat interface using `/save-report`
- [ ] Test listing reports with `/list-reports`
- [ ] Test running a saved report with `/run <report-name>`
- [ ] Test viewing trends with `/trends <report-name>`
- [ ] Verify database migrations create tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)