### PR TITLE
Auto-generate SQL question-answer training pairs via LLM

### DIFF
--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -1,0 +1,409 @@
+"""Tests for auto_generate_sql_pairs functionality in utils/vanna_calls.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Prompt parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseQuestionSqlResponse:
+    """Tests for _parse_question_sql_response helper."""
+
+    def test_valid_format(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = (
+            "QUESTION: How many patients are in the database?\n"
+            "SQL: SELECT COUNT(*) FROM patients;"
+        )
+        question, sql = _parse_question_sql_response(text)
+        assert question == "How many patients are in the database?"
+        assert sql == "SELECT COUNT(*) FROM patients;"
+
+    def test_valid_multiline_sql(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = (
+            "QUESTION: What are the top diagnoses?\n"
+            "SQL: SELECT diagnosis, COUNT(*) AS cnt\n"
+            "FROM encounters\n"
+            "GROUP BY diagnosis\n"
+            "ORDER BY cnt DESC\n"
+            "LIMIT 10;"
+        )
+        question, sql = _parse_question_sql_response(text)
+        assert question is not None
+        assert "SELECT" in sql
+        assert "GROUP BY" in sql
+
+    def test_sql_with_markdown_fencing(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = (
+            "QUESTION: Count rows\n"
+            "SQL: ```sql\nSELECT COUNT(*) FROM t;\n```"
+        )
+        question, sql = _parse_question_sql_response(text)
+        assert question == "Count rows"
+        assert sql == "SELECT COUNT(*) FROM t;"
+
+    def test_missing_question_returns_none(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = "SQL: SELECT 1;"
+        question, sql = _parse_question_sql_response(text)
+        assert question is None
+        assert sql is None
+
+    def test_missing_sql_returns_none(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = "QUESTION: What is life?"
+        question, sql = _parse_question_sql_response(text)
+        assert question is None
+        assert sql is None
+
+    def test_empty_string_returns_none(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        question, sql = _parse_question_sql_response("")
+        assert question is None
+        assert sql is None
+
+    def test_case_insensitive_labels(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = "question: What?\nsql: SELECT 1;"
+        question, sql = _parse_question_sql_response(text)
+        assert question == "What?"
+        assert sql == "SELECT 1;"
+
+
+# ---------------------------------------------------------------------------
+# Prompt constants tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptConstants:
+    """Verify prompt constants exist and contain expected keywords."""
+
+    def test_generation_prompt_exists(self):
+        from utils.vanna_calls import _SQL_PAIR_GENERATION_SYSTEM_PROMPT
+
+        assert "QUESTION:" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
+        assert "SQL:" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
+        assert "SELECT" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
+
+    def test_review_prompt_exists(self):
+        from utils.vanna_calls import _SQL_PAIR_REVIEW_SYSTEM_PROMPT
+
+        assert "PASS" in _SQL_PAIR_REVIEW_SYSTEM_PROMPT
+        assert "FAIL" in _SQL_PAIR_REVIEW_SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with mocked LLM
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_vanna_service():
+    """Create a mocked VannaService for auto_generate_sql_pairs tests."""
+    mock_service = MagicMock()
+    mock_service.vn = MagicMock()
+    mock_service.get_training_data.return_value = pd.DataFrame(
+        {"training_data_type": ["sql"], "question": ["Existing question"], "content": ["SELECT 1"]}
+    )
+    mock_service.vn.get_related_ddl.return_value = ["CREATE TABLE patients (id INT, name TEXT);"]
+    return mock_service
+
+
+@pytest.fixture
+def mock_security_validator():
+    """Mock security validator that passes everything."""
+    mock_sv = MagicMock()
+    mock_sv.validate_sql_content.return_value = (True, [])
+    return mock_sv
+
+
+class TestAutoGenerateSqlPairs:
+    """Integration tests for auto_generate_sql_pairs with mocked dependencies."""
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_successful_generation(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that a valid pair is generated, validated, and trained."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        # LLM returns valid question+SQL on generation call
+        mock_vanna_service.submit_prompt.side_effect = [
+            "QUESTION: How many patients?\nSQL: SELECT COUNT(*) FROM patients;",
+            "PASS",
+        ]
+        # SQL execution returns non-empty DataFrame
+        mock_vanna_service.vn.run_sql.return_value = pd.DataFrame({"count": [42]})
+        # check_references passes
+        mock_vanna_service.check_references.return_value = "SELECT COUNT(*) FROM patients;"
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["attempted"] == 1
+        assert results["passed"] == 1
+        assert results["failed"] == 0
+        mock_write.assert_called_once()
+        call_args = mock_write.call_args[0][0]
+        assert call_args["question"] == "How many patients?"
+        assert call_args["query"] == "SELECT COUNT(*) FROM patients;"
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_security_validation_blocks_forbidden_sql(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that pairs with forbidden references are rejected."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = (
+            "QUESTION: Get secret data\nSQL: SELECT * FROM secret_table;"
+        )
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (False, ["Forbidden table reference: secret_table"])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "Security validation" in results["details"][0]["reason"]
+        mock_write.assert_not_called()
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_sql_execution_error_rejected(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that pairs with SQL execution errors are rejected."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = (
+            "QUESTION: Bad query\nSQL: SELECT * FROM nonexistent;"
+        )
+        mock_vanna_service.check_references.return_value = "SELECT * FROM nonexistent;"
+        mock_vanna_service.vn.run_sql.side_effect = Exception("relation does not exist")
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "SQL execution error" in results["details"][0]["reason"]
+        mock_write.assert_not_called()
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_empty_results_rejected(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that pairs returning empty results are rejected."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = (
+            "QUESTION: Empty?\nSQL: SELECT * FROM patients WHERE 1=0;"
+        )
+        mock_vanna_service.check_references.return_value = "SELECT * FROM patients WHERE 1=0;"
+        mock_vanna_service.vn.run_sql.return_value = pd.DataFrame()
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "empty results" in results["details"][0]["reason"]
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_semantic_review_fail_rejected(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that pairs failing semantic review are rejected."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        # First submit_prompt = generation, second = review
+        mock_vanna_service.submit_prompt.side_effect = [
+            "QUESTION: How many?\nSQL: SELECT 1;",
+            "FAIL - results do not answer the question",
+        ]
+        mock_vanna_service.check_references.return_value = "SELECT 1;"
+        mock_vanna_service.vn.run_sql.return_value = pd.DataFrame({"col": [1]})
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "Semantic review failed" in results["details"][0]["reason"]
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_unparseable_response_rejected(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that unparseable LLM responses are handled gracefully."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = "I cannot generate SQL for that."
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "parse" in results["details"][0]["reason"].lower()
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_check_references_blocks_forbidden(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that check_references returning None blocks the pair."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = (
+            "QUESTION: Get data\nSQL: SELECT * FROM forbidden_table;"
+        )
+        mock_vanna_service.check_references.return_value = None  # blocked
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "Forbidden reference" in results["details"][0]["reason"]
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_count_clamped_to_range(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that count is clamped between 1 and 50."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = "garbage"
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            # count=0 should be clamped to 1
+            results = auto_generate_sql_pairs(count=0)
+
+        assert results["attempted"] == 1
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_multiple_pairs_mixed_results(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test generating multiple pairs where some pass and some fail."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        # Pair 1: succeeds, Pair 2: fails execution, Pair 3: succeeds
+        mock_vanna_service.submit_prompt.side_effect = [
+            "QUESTION: Q1\nSQL: SELECT 1;",
+            "PASS",
+            "QUESTION: Q2\nSQL: SELECT bad;",
+            # no review call for pair 2 since it fails execution
+            "QUESTION: Q3\nSQL: SELECT 3;",
+            "PASS",
+        ]
+        mock_vanna_service.check_references.return_value = "sql"
+
+        call_count = [0]
+
+        def run_sql_side_effect(sql):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise Exception("syntax error")
+            return pd.DataFrame({"v": [1]})
+
+        mock_vanna_service.vn.run_sql.side_effect = run_sql_side_effect
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=3)
+
+        assert results["attempted"] == 3
+        assert results["passed"] == 2
+        assert results["failed"] == 1
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_vanna_service_unavailable(self, mock_from_session, mock_st):
+        """Test graceful handling when VannaService is unavailable."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = None
+
+        results = auto_generate_sql_pairs(count=1)
+
+        assert results["attempted"] == 0
+        assert "error" in results
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_llm_returns_exception(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test handling when submit_prompt returns an Exception object."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        mock_vanna_service.submit_prompt.return_value = Exception("API error")
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "LLM generation failed" in results["details"][0]["reason"]

--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -83,6 +83,28 @@ class TestParseQuestionSqlResponse:
         assert question == "What?"
         assert sql == "SELECT 1;"
 
+    def test_markdown_bold_labels(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = (
+            "**Question:** How many patients are in Texas?\n"
+            "**SQL:**\n```sql\nSELECT COUNT(*) FROM patients WHERE state = 'TX';\n```"
+        )
+        question, sql = _parse_question_sql_response(text)
+        assert question == "How many patients are in Texas?"
+        assert sql == "SELECT COUNT(*) FROM patients WHERE state = 'TX';"
+
+    def test_markdown_bold_colon_outside(self):
+        from utils.vanna_calls import _parse_question_sql_response
+
+        text = (
+            "**Question**: How many allergies?\n"
+            "**SQL**:\n```sql\nSELECT COUNT(*) FROM allergies;\n```"
+        )
+        question, sql = _parse_question_sql_response(text)
+        assert question == "How many allergies?"
+        assert sql == "SELECT COUNT(*) FROM allergies;"
+
 
 # ---------------------------------------------------------------------------
 # Prompt constants tests
@@ -98,6 +120,10 @@ class TestPromptConstants:
         assert "QUESTION:" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
         assert "SQL:" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
         assert "SELECT" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT
+        # Should NOT contain references to existing questions (context-reduction fix)
+        assert "existing" not in _SQL_PAIR_GENERATION_SYSTEM_PROMPT.lower()
+        # Should instruct against hardcoded filter values
+        assert "hardcoded" in _SQL_PAIR_GENERATION_SYSTEM_PROMPT.lower()
 
     def test_review_prompt_exists(self):
         from utils.vanna_calls import _SQL_PAIR_REVIEW_SYSTEM_PROMPT
@@ -281,6 +307,31 @@ class TestAutoGenerateSqlPairs:
         assert results["passed"] == 0
         assert results["failed"] == 1
         assert "parse" in results["details"][0]["reason"].lower()
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_duplicate_question_rejected(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """Test that a question matching existing training data is rejected as duplicate."""
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        # LLM generates a question that already exists in training data
+        mock_vanna_service.submit_prompt.return_value = (
+            "QUESTION: Existing question\nSQL: SELECT 1;"
+        )
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "Duplicate" in results["details"][0]["reason"]
+        mock_write.assert_not_called()
 
     @patch("utils.vanna_calls.st")
     @patch("utils.vanna_calls.write_to_file_and_training")

--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -123,14 +123,6 @@ def mock_vanna_service():
     return mock_service
 
 
-@pytest.fixture
-def mock_security_validator():
-    """Mock security validator that passes everything."""
-    mock_sv = MagicMock()
-    mock_sv.validate_sql_content.return_value = (True, [])
-    return mock_sv
-
-
 class TestAutoGenerateSqlPairs:
     """Integration tests for auto_generate_sql_pairs with mocked dependencies."""
 

--- a/utils/thriveai_ollama.py
+++ b/utils/thriveai_ollama.py
@@ -31,7 +31,7 @@ class ThriveAI_Ollama(ThriveAI_Base):
         self.schema = config.get("schema", "public")
         self.dialect = config.get("dialect", getattr(self, "dialect", "postgresql"))
 
-        self.ollama_timeout = config.get("ollama_timeout", 240.0)
+        self.ollama_timeout = config.get("ollama_timeout", 480.0)
 
         self.ollama_client = ollama.Client(self.host, timeout=Timeout(self.ollama_timeout))
         self.keep_alive = config.get("keep_alive", None)

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3945,11 +3945,8 @@ Does this result correctly answer the question? Respond PASS or FAIL."""
 
             # Step 5: Train the valid pair
             new_entry = {"question": question, "query": sql}
-            try:
-                write_to_file_and_training(new_entry)
-            except Exception as train_err:
-                _reject_pair(pair_detail, results, f"Training persistence failed: {train_err}")
-                continue
+            # write_to_file_and_training handles its own errors internally via st.error
+            write_to_file_and_training(new_entry)
 
             pair_detail["status"] = "passed"
             results["passed"] += 1

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3797,6 +3797,219 @@ def refresh_stats():
             status.update(label=f"Stats refresh failed: {e}", state="error")
 
 
+_SQL_PAIR_GENERATION_SYSTEM_PROMPT = """You are a SQL training data generator for a PostgreSQL analytics database.
+Given a database schema (DDL) and a list of existing training questions, generate a NEW natural-language question and the correct SQL query to answer it.
+
+Rules:
+1. The question must be meaningfully different from any existing question provided.
+2. The SQL must be a valid SELECT query (no INSERT/UPDATE/DELETE/DROP/ALTER/CREATE).
+3. The SQL must reference only tables and columns present in the provided DDL.
+4. Prefer queries that JOIN multiple tables, use aggregations, or filter with WHERE clauses.
+5. Output EXACTLY in this format (no other text):
+QUESTION: <the natural language question>
+SQL: <the SQL query>"""
+
+_SQL_PAIR_REVIEW_SYSTEM_PROMPT = """You are a SQL quality reviewer. Given a question, a SQL query, and the query results, determine whether the results correctly and meaningfully answer the question.
+
+Respond with EXACTLY one word: PASS or FAIL
+If the results are empty, nonsensical, or do not answer the question, respond FAIL."""
+
+
+def auto_generate_sql_pairs(count: int = 5) -> dict:
+    """Generate, validate, and train SQL question-answer pairs using the LLM.
+
+    Pipeline per pair:
+    1. Fetch DDL context and existing questions from training data
+    2. LLM generates a novel question + SQL pair
+    3. Security validation (forbidden references)
+    4. Execute SQL against live database
+    5. LLM semantic review of results
+    6. Auto-train valid pairs via write_to_file_and_training()
+
+    Args:
+        count: Number of pairs to attempt generating (default 5, max 50).
+
+    Returns:
+        Dict with keys: attempted, passed, failed, details (list of per-pair dicts).
+    """
+    from utils.security_validator import security_validator
+
+    count = max(1, min(count, 50))
+
+    vanna_service = VannaService.from_streamlit_session()
+    if not vanna_service:
+        return {"attempted": 0, "passed": 0, "failed": 0, "details": [], "error": "VannaService not available"}
+
+    # Gather DDL context
+    try:
+        ddl_list = vanna_service.vn.get_related_ddl("database schema overview")
+    except Exception:
+        ddl_list = []
+    ddl_context = "\n\n".join(ddl_list[:20]) if ddl_list else "No DDL available."
+
+    # Gather existing questions to avoid duplicates
+    try:
+        training_df = vanna_service.get_training_data()
+        existing_questions = []
+        if isinstance(training_df, DataFrame) and not training_df.empty:
+            sql_rows = training_df[training_df["training_data_type"] == "sql"]
+            existing_questions = sql_rows["question"].dropna().tolist()
+    except Exception:
+        existing_questions = []
+
+    existing_q_text = "\n".join(f"- {q}" for q in existing_questions[:50]) if existing_questions else "None yet."
+
+    results = {"attempted": count, "passed": 0, "failed": 0, "details": []}
+
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+
+    try:
+        for i in range(count):
+            pair_detail = {"index": i + 1, "status": "failed", "question": None, "sql": None, "reason": None}
+            status_text.text(f"Generating pair {i + 1}/{count}...")
+            progress_bar.progress((i + 1) / count)
+
+            try:
+                # Step 1: Generate question + SQL via LLM
+                user_prompt = f"""Database Schema (DDL):
+{ddl_context}
+
+Existing training questions (generate something DIFFERENT):
+{existing_q_text}
+
+Generate a new question and SQL pair following the format specified."""
+
+                response = vanna_service.submit_prompt(_SQL_PAIR_GENERATION_SYSTEM_PROMPT, user_prompt)
+
+                if not response or isinstance(response, Exception):
+                    pair_detail["reason"] = f"LLM generation failed: {response}"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                response_text = str(response).strip()
+
+                # Parse QUESTION and SQL from response
+                question, sql = _parse_question_sql_response(response_text)
+                if not question or not sql:
+                    pair_detail["reason"] = "Could not parse question/SQL from LLM response"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                pair_detail["question"] = question
+                pair_detail["sql"] = sql
+
+                # Step 2: Security validation
+                is_valid, violations = security_validator.validate_sql_content(sql)
+                if not is_valid:
+                    pair_detail["reason"] = f"Security validation failed: {violations}"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                # Also check via VannaService.check_references
+                checked_sql = vanna_service.check_references(sql)
+                if checked_sql is None:
+                    pair_detail["reason"] = "Forbidden reference detected by check_references"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                # Step 3: Execute SQL against database
+                try:
+                    df = vanna_service.vn.run_sql(sql)
+                except Exception as exec_err:
+                    pair_detail["reason"] = f"SQL execution error: {exec_err}"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                if df is None or (isinstance(df, DataFrame) and df.empty):
+                    pair_detail["reason"] = "SQL returned empty results"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                # Step 4: LLM semantic review
+                result_preview = df.head(5).to_string(index=False) if isinstance(df, DataFrame) else str(df)
+                review_prompt = f"""Question: {question}
+SQL: {sql}
+Results (first 5 rows):
+{result_preview}
+
+Does this result correctly answer the question? Respond PASS or FAIL."""
+
+                review_response = vanna_service.submit_prompt(_SQL_PAIR_REVIEW_SYSTEM_PROMPT, review_prompt)
+                review_text = str(review_response).strip().upper() if review_response else "FAIL"
+
+                if "PASS" not in review_text:
+                    pair_detail["reason"] = f"Semantic review failed: {review_text}"
+                    results["failed"] += 1
+                    results["details"].append(pair_detail)
+                    continue
+
+                # Step 5: Train the valid pair
+                new_entry = {"question": question, "query": sql}
+                write_to_file_and_training(new_entry)
+
+                # Add to existing questions list to prevent duplicates within this batch
+                existing_questions.append(question)
+                existing_q_text = "\n".join(f"- {q}" for q in existing_questions[:50])
+
+                pair_detail["status"] = "passed"
+                results["passed"] += 1
+                results["details"].append(pair_detail)
+
+            except Exception as pair_err:
+                pair_detail["reason"] = f"Unexpected error: {pair_err}"
+                logger.exception("Error generating SQL pair %d: %s", i + 1, pair_err)
+                results["failed"] += 1
+                results["details"].append(pair_detail)
+
+    finally:
+        try:
+            progress_bar.empty()
+            status_text.empty()
+        except Exception:
+            pass
+
+    logger.info(
+        "Auto-generate SQL pairs complete: %d attempted, %d passed, %d failed",
+        results["attempted"],
+        results["passed"],
+        results["failed"],
+    )
+    return results
+
+
+def _parse_question_sql_response(response_text: str) -> tuple[str | None, str | None]:
+    """Parse QUESTION: and SQL: from LLM response text.
+
+    Returns:
+        Tuple of (question, sql) or (None, None) if parsing fails.
+    """
+    question = None
+    sql = None
+
+    # Try structured QUESTION:/SQL: format
+    q_match = re.search(r"QUESTION:\s*(.+?)(?=\nSQL:)", response_text, re.DOTALL | re.IGNORECASE)
+    s_match = re.search(r"SQL:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
+
+    if q_match and s_match:
+        question = q_match.group(1).strip()
+        sql = s_match.group(1).strip()
+        # Clean up SQL -- remove trailing backticks or markdown fencing
+        sql = re.sub(r"^```(?:sql)?\s*", "", sql)
+        sql = re.sub(r"\s*```\s*$", "", sql)
+
+    if question and sql:
+        return question, sql
+
+    return None, None
+
+
 def train_ddl_describe_to_rag(table: str, ddl: list):
     """
     Generate statistical profiles for table columns and train RAG model with the insights.

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3798,14 +3798,15 @@ def refresh_stats():
 
 
 _SQL_PAIR_GENERATION_SYSTEM_PROMPT = """You are a SQL training data generator for a PostgreSQL analytics database.
-Given a database schema (DDL) and a list of existing training questions, generate a NEW natural-language question and the correct SQL query to answer it.
+Given a database schema (DDL), working example pairs, and optional documentation, generate a NEW natural-language question and the correct SQL query to answer it.
 
 Rules:
-1. The question must be meaningfully different from any existing question provided.
-2. The SQL must be a valid SELECT query (no INSERT/UPDATE/DELETE/DROP/ALTER/CREATE).
-3. The SQL must reference only tables and columns present in the provided DDL.
-4. Prefer queries that JOIN multiple tables, use aggregations, or filter with WHERE clauses.
-5. Output EXACTLY in this format (no other text):
+1. The SQL must be a valid SELECT query (no INSERT/UPDATE/DELETE/DROP/ALTER/CREATE).
+2. The SQL must reference ONLY tables and columns present in the provided DDL. Never invent table or column names.
+3. Study the working examples carefully — they show real table names, JOIN patterns, and filter values that return data.
+4. DO NOT use hardcoded filter values (like specific states, years, or status strings) UNLESS they appear in the provided documentation or examples. Instead prefer broad queries: aggregations (COUNT, AVG, SUM), GROUP BY, ORDER BY, LIMIT, IS NOT NULL, JOINs between tables.
+5. Vary the complexity, tables, and topic — do not duplicate the example questions.
+6. Output EXACTLY in this format with no markdown formatting, no bold, no code fences (no other text):
 QUESTION: <the natural language question>
 SQL: <the SQL query>"""
 
@@ -3819,10 +3820,10 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
     """Generate, validate, and train SQL question-answer pairs using the LLM.
 
     Pipeline per pair:
-    1. Fetch DDL context and existing questions from training data
-    2. LLM generates a novel question + SQL pair
+    1. LLM generates a question + SQL pair (DDL context only, no question history)
+    2. Local duplicate detection against existing training data
     3. Security validation (forbidden references)
-    4. Execute SQL against live database
+    4. Execute SQL against live database (must return non-empty results)
     5. LLM semantic review of results
     6. Auto-train valid pairs via write_to_file_and_training()
 
@@ -3840,24 +3841,58 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
     if not vanna_service:
         return {"attempted": 0, "passed": 0, "failed": 0, "details": [], "error": "VannaService not available"}
 
-    # Gather DDL context
-    try:
-        ddl_list = vanna_service.vn.get_related_ddl("database schema overview")
-    except Exception:
-        ddl_list = []
-    ddl_context = "\n\n".join(ddl_list[:20]) if ddl_list else "No DDL available."
+    # Gather a focused slice of RAG context — keep prompt small for local LLMs.
+    # Strategy: pick 3 DDL tables, 3 working examples, and 1 doc entry per iteration,
+    # rotating the seed query each time so we cover different parts of the schema.
+    _rag_seed_queries = [
+        "patient demographics and encounters",
+        "allergies and vaccinations",
+        "lab results and vitals",
+        "orders and procedures",
+        "insurance and billing",
+    ]
 
-    # Gather existing questions to avoid duplicates
+    def _gather_focused_context(vn, seed_query: str) -> tuple[str, str, str]:
+        """Pull a small, focused slice of RAG context for one seed query."""
+        ddl_context = "No DDL available."
+        try:
+            ddl_list = vn.get_related_ddl(seed_query)
+            if ddl_list:
+                ddl_context = "\n\n".join(ddl_list[:3])
+        except Exception:
+            pass
+
+        example_pairs_text = ""
+        try:
+            rag_pairs = vn.get_similar_question_sql(seed_query)
+            if rag_pairs:
+                valid = [p for p in rag_pairs if isinstance(p, dict) and p.get("question") and p.get("sql")][:3]
+                if valid:
+                    example_pairs_text = "\n\n".join(f"QUESTION: {p['question']}\nSQL: {p['sql']}" for p in valid)
+        except Exception:
+            pass
+
+        doc_context = ""
+        try:
+            docs = vn.get_related_documentation(seed_query)
+            if docs:
+                valid = [d for d in docs if isinstance(d, str) and d.strip()][:1]
+                if valid:
+                    doc_context = valid[0]
+        except Exception:
+            pass
+
+        return ddl_context, example_pairs_text, doc_context
+
+    # Gather existing questions for local duplicate detection (not sent to LLM)
     try:
         training_df = vanna_service.get_training_data()
-        existing_questions = []
+        existing_questions: set[str] = set()
         if isinstance(training_df, DataFrame) and not training_df.empty:
             sql_rows = training_df[training_df["training_data_type"] == "sql"]
-            existing_questions = sql_rows["question"].dropna().tolist()
+            existing_questions = {q.lower().strip() for q in sql_rows["question"].dropna().tolist()}
     except Exception:
-        existing_questions = []
-
-    existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:]) if existing_questions else "None yet."
+        existing_questions = set()
 
     results = {"attempted": 0, "passed": 0, "failed": 0, "details": []}
 
@@ -3865,6 +3900,7 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
         pair_detail["reason"] = reason
         results["failed"] += 1
         results["details"].append(pair_detail)
+        logger.warning("SQL pair %d rejected: %s", pair_detail.get("index"), reason)
 
     for i in range(count):
         pair_detail = {"index": i + 1, "status": "failed", "question": None, "sql": None, "reason": None}
@@ -3872,13 +3908,20 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
 
         try:
             # Step 1: Generate question + SQL via LLM
-            user_prompt = f"""Database Schema (DDL):
-{ddl_context}
+            # Rotate through seed queries so each iteration focuses on different tables
+            seed = _rag_seed_queries[i % len(_rag_seed_queries)]
+            ddl_context, example_pairs_text, doc_context = _gather_focused_context(vanna_service.vn, seed)
 
-Existing training questions (generate something DIFFERENT):
-{existing_q_text}
+            prompt_parts = [f"Database Schema (DDL):\n{ddl_context}"]
 
-Generate a new question and SQL pair following the format specified."""
+            if example_pairs_text:
+                prompt_parts.append(f"Working Example Question/SQL Pairs (use these as reference for table names, JOINs, and filters):\n{example_pairs_text}")
+
+            if doc_context:
+                prompt_parts.append(f"Documentation:\n{doc_context}")
+
+            prompt_parts.append("Generate a new question and SQL pair following the format specified.")
+            user_prompt = "\n\n".join(prompt_parts)
 
             response = vanna_service.submit_prompt(_SQL_PAIR_GENERATION_SYSTEM_PROMPT, user_prompt)
 
@@ -3897,9 +3940,13 @@ Generate a new question and SQL pair following the format specified."""
             pair_detail["question"] = question
             pair_detail["sql"] = sql
 
-            # Add to dedup window regardless of whether the pair passes or fails
-            existing_questions.append(question)
-            existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:])
+            # Local duplicate detection — reject questions that match existing training data
+            question_normalized = question.lower().strip()
+            if question_normalized in existing_questions:
+                _reject_pair(pair_detail, results, "Duplicate of existing training question")
+                continue
+            # Track this question for intra-batch dedup
+            existing_questions.add(question_normalized)
 
             # Step 2: Security validation
             is_valid, violations = security_validator.validate_sql_content(sql)
@@ -3976,16 +4023,17 @@ def _parse_question_sql_response(response_text: str) -> tuple[str | None, str | 
     question = None
     sql = None
 
-    # Try structured QUESTION:/SQL: format
-    q_match = re.search(r"QUESTION:\s*(.+?)(?=\nSQL:)", response_text, re.DOTALL | re.IGNORECASE)
-    s_match = re.search(r"(?:^|\n)SQL:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
+    # Try structured QUESTION:/SQL: format (tolerates markdown bold in various positions)
+    q_match = re.search(r"\*{0,2}QUESTION\*{0,2}:\s*(.+?)(?=\n\*{0,2}SQL\*{0,2}:)", response_text, re.DOTALL | re.IGNORECASE)
+    s_match = re.search(r"(?:^|\n)\*{0,2}SQL\*{0,2}:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
 
     if q_match and s_match:
-        question = q_match.group(1).strip()
-        sql = s_match.group(1).strip()
-        # Clean up SQL -- remove trailing backticks or markdown fencing
+        question = q_match.group(1).strip().strip("*").strip()
+        sql = s_match.group(1).strip().strip("*").strip()
+        # Clean up SQL -- remove markdown fencing (```sql ... ```)
         sql = re.sub(r"^```(?:sql)?\s*", "", sql)
         sql = re.sub(r"\s*```\s*$", "", sql)
+        sql = sql.strip()
 
     if question and sql:
         return question, sql

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3954,9 +3954,11 @@ Does this result correctly answer the question? Respond PASS or FAIL."""
                 new_entry = {"question": question, "query": sql}
                 write_to_file_and_training(new_entry)
 
-                # Add to existing questions list to prevent duplicates within this batch
+                # Add to existing questions list to prevent duplicates within this batch.
+                # Use the last 50 entries so newly generated questions are always included
+                # in the next iteration's prompt, even when the list exceeds 50 items.
                 existing_questions.append(question)
-                existing_q_text = "\n".join(f"- {q}" for q in existing_questions[:50])
+                existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:])
 
                 pair_detail["status"] = "passed"
                 results["passed"] += 1

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3857,22 +3857,22 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
     except Exception:
         existing_questions = []
 
-    existing_q_text = "\n".join(f"- {q}" for q in existing_questions[:50]) if existing_questions else "None yet."
+    existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:]) if existing_questions else "None yet."
 
-    results = {"attempted": count, "passed": 0, "failed": 0, "details": []}
+    results = {"attempted": 0, "passed": 0, "failed": 0, "details": []}
 
-    progress_bar = st.progress(0)
-    status_text = st.empty()
+    def _reject_pair(pair_detail: dict, results: dict, reason: str) -> None:
+        pair_detail["reason"] = reason
+        results["failed"] += 1
+        results["details"].append(pair_detail)
 
-    try:
-        for i in range(count):
-            pair_detail = {"index": i + 1, "status": "failed", "question": None, "sql": None, "reason": None}
-            status_text.text(f"Generating pair {i + 1}/{count}...")
-            progress_bar.progress((i + 1) / count)
+    for i in range(count):
+        pair_detail = {"index": i + 1, "status": "failed", "question": None, "sql": None, "reason": None}
+        results["attempted"] += 1
 
-            try:
-                # Step 1: Generate question + SQL via LLM
-                user_prompt = f"""Database Schema (DDL):
+        try:
+            # Step 1: Generate question + SQL via LLM
+            user_prompt = f"""Database Schema (DDL):
 {ddl_context}
 
 Existing training questions (generate something DIFFERENT):
@@ -3880,102 +3880,86 @@ Existing training questions (generate something DIFFERENT):
 
 Generate a new question and SQL pair following the format specified."""
 
-                response = vanna_service.submit_prompt(_SQL_PAIR_GENERATION_SYSTEM_PROMPT, user_prompt)
+            response = vanna_service.submit_prompt(_SQL_PAIR_GENERATION_SYSTEM_PROMPT, user_prompt)
 
-                if not response or isinstance(response, Exception):
-                    pair_detail["reason"] = f"LLM generation failed: {response}"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            if not response or isinstance(response, Exception):
+                _reject_pair(pair_detail, results, f"LLM generation failed: {response}")
+                continue
 
-                response_text = str(response).strip()
+            response_text = str(response).strip()
 
-                # Parse QUESTION and SQL from response
-                question, sql = _parse_question_sql_response(response_text)
-                if not question or not sql:
-                    pair_detail["reason"] = "Could not parse question/SQL from LLM response"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            # Parse QUESTION and SQL from response
+            question, sql = _parse_question_sql_response(response_text)
+            if not question or not sql:
+                _reject_pair(pair_detail, results, "Could not parse question/SQL from LLM response")
+                continue
 
-                pair_detail["question"] = question
-                pair_detail["sql"] = sql
+            pair_detail["question"] = question
+            pair_detail["sql"] = sql
 
-                # Step 2: Security validation
-                is_valid, violations = security_validator.validate_sql_content(sql)
-                if not is_valid:
-                    pair_detail["reason"] = f"Security validation failed: {violations}"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            # Add to dedup window regardless of whether the pair passes or fails
+            existing_questions.append(question)
+            existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:])
 
-                # Also check via VannaService.check_references
-                checked_sql = vanna_service.check_references(sql)
-                if checked_sql is None:
-                    pair_detail["reason"] = "Forbidden reference detected by check_references"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            # Step 2: Security validation
+            is_valid, violations = security_validator.validate_sql_content(sql)
+            if not is_valid:
+                _reject_pair(pair_detail, results, f"Security validation failed: {violations}")
+                continue
 
-                # Step 3: Execute SQL against database
-                try:
-                    df = vanna_service.vn.run_sql(sql)
-                except Exception as exec_err:
-                    pair_detail["reason"] = f"SQL execution error: {exec_err}"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            # Also check via VannaService.check_references
+            checked_sql = vanna_service.check_references(sql)
+            if checked_sql is None:
+                _reject_pair(pair_detail, results, "Forbidden reference or configuration error detected by check_references")
+                continue
 
-                if df is None or (isinstance(df, DataFrame) and df.empty):
-                    pair_detail["reason"] = "SQL returned empty results"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            # Step 3: Execute SQL against database
+            try:
+                df = vanna_service.vn.run_sql(sql)
+            except Exception as exec_err:
+                _reject_pair(pair_detail, results, f"SQL execution error: {exec_err}")
+                continue
 
-                # Step 4: LLM semantic review
-                result_preview = df.head(5).to_string(index=False) if isinstance(df, DataFrame) else str(df)
-                review_prompt = f"""Question: {question}
+            if df is None or (isinstance(df, DataFrame) and df.empty):
+                _reject_pair(pair_detail, results, "SQL returned empty results")
+                continue
+
+            # Step 4: LLM semantic review
+            result_preview = df.head(5).to_string(index=False) if isinstance(df, DataFrame) else str(df)
+            review_prompt = f"""Question: {question}
 SQL: {sql}
 Results (first 5 rows):
 {result_preview}
 
 Does this result correctly answer the question? Respond PASS or FAIL."""
 
-                review_response = vanna_service.submit_prompt(_SQL_PAIR_REVIEW_SYSTEM_PROMPT, review_prompt)
-                review_text = str(review_response).strip().upper() if review_response else "FAIL"
+            review_response = vanna_service.submit_prompt(_SQL_PAIR_REVIEW_SYSTEM_PROMPT, review_prompt)
+            if isinstance(review_response, Exception):
+                _reject_pair(pair_detail, results, f"LLM review failed: {review_response}")
+                continue
+            review_text = str(review_response).strip().upper() if review_response else "FAIL"
 
-                if "PASS" not in review_text:
-                    pair_detail["reason"] = f"Semantic review failed: {review_text}"
-                    results["failed"] += 1
-                    results["details"].append(pair_detail)
-                    continue
+            if "PASS" not in review_text:
+                _reject_pair(pair_detail, results, f"Semantic review failed: {review_text}")
+                continue
 
-                # Step 5: Train the valid pair
-                new_entry = {"question": question, "query": sql}
+            # Step 5: Train the valid pair
+            new_entry = {"question": question, "query": sql}
+            try:
                 write_to_file_and_training(new_entry)
+            except Exception as train_err:
+                _reject_pair(pair_detail, results, f"Training persistence failed: {train_err}")
+                continue
 
-                # Add to existing questions list to prevent duplicates within this batch.
-                # Use the last 50 entries so newly generated questions are always included
-                # in the next iteration's prompt, even when the list exceeds 50 items.
-                existing_questions.append(question)
-                existing_q_text = "\n".join(f"- {q}" for q in existing_questions[-50:])
+            pair_detail["status"] = "passed"
+            results["passed"] += 1
+            results["details"].append(pair_detail)
 
-                pair_detail["status"] = "passed"
-                results["passed"] += 1
-                results["details"].append(pair_detail)
-
-            except Exception as pair_err:
-                pair_detail["reason"] = f"Unexpected error: {pair_err}"
-                logger.exception("Error generating SQL pair %d: %s", i + 1, pair_err)
-                results["failed"] += 1
-                results["details"].append(pair_detail)
-
-    finally:
-        try:
-            progress_bar.empty()
-            status_text.empty()
-        except Exception:
-            pass
+        except Exception as pair_err:
+            pair_detail["reason"] = f"Unexpected error: {pair_err}"
+            logger.exception("Error generating SQL pair %d: %s", i + 1, pair_err)
+            results["failed"] += 1
+            results["details"].append(pair_detail)
 
     logger.info(
         "Auto-generate SQL pairs complete: %d attempted, %d passed, %d failed",
@@ -3997,7 +3981,7 @@ def _parse_question_sql_response(response_text: str) -> tuple[str | None, str | 
 
     # Try structured QUESTION:/SQL: format
     q_match = re.search(r"QUESTION:\s*(.+?)(?=\nSQL:)", response_text, re.DOTALL | re.IGNORECASE)
-    s_match = re.search(r"SQL:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
+    s_match = re.search(r"(?:^|\n)SQL:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
 
     if q_match and s_match:
         question = q_match.group(1).strip()

--- a/views/user.py
+++ b/views/user.py
@@ -412,20 +412,28 @@ if tab2 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
             if st.button("Generate", type="primary", key="auto_gen_btn"):
                 with st.status("Generating SQL training pairs...", expanded=True) as gen_status:
                     gen_results = auto_generate_sql_pairs(count=int(pair_count))
-                    passed = gen_results.get("passed", 0)
-                    failed = gen_results.get("failed", 0)
-                    if passed > 0:
+                    error_msg = gen_results.get("error")
+                    if error_msg:
                         gen_status.update(
-                            label=f"Generated {passed} pair(s) ({failed} failed)",
-                            state="complete",
-                        )
-                        st.success(f"Successfully trained {passed} SQL pair(s).")
-                    else:
-                        gen_status.update(
-                            label=f"Generation complete: 0 passed, {failed} failed",
+                            label=f"Generation failed: {error_msg}",
                             state="error",
                         )
-                        st.warning("No valid pairs were generated. Check LLM connectivity and training data.")
+                        st.error(error_msg)
+                    else:
+                        passed = gen_results.get("passed", 0)
+                        failed = gen_results.get("failed", 0)
+                        if passed > 0:
+                            gen_status.update(
+                                label=f"Generated {passed} pair(s) ({failed} failed)",
+                                state="complete",
+                            )
+                            st.success(f"Successfully trained {passed} SQL pair(s).")
+                        else:
+                            gen_status.update(
+                                label=f"Generation complete: 0 passed, {failed} failed",
+                                state="error",
+                            )
+                            st.warning("No valid pairs were generated. Check LLM connectivity and training data.")
                     # Show details for failed pairs
                     failed_details = [d for d in gen_results.get("details", []) if d["status"] == "failed"]
                     if failed_details:

--- a/views/user.py
+++ b/views/user.py
@@ -25,7 +25,7 @@ from orm.models import RoleTypeEnum, SessionLocal, User, UserRole
 from utils.authentication_management import get_user_list_excel
 from utils.chat_bot_helper import get_vn
 from utils.enums import ThemeType
-from utils.vanna_calls import refresh_stats, train_all
+from utils.vanna_calls import auto_generate_sql_pairs, refresh_stats, train_all
 
 # Get the current user ID from session state cookies
 user_id = st.session_state.cookies.get("user_id")
@@ -392,6 +392,48 @@ if tab2 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                 help="Re-run column statistics only (use when data changed but schema is the same)",
             )
 
+        # Auto-generate SQL training pairs
+        st.divider()
+        st.subheader("Auto-Generate SQL Pairs")
+        st.caption("Use the connected LLM to generate, validate, and train SQL question-answer pairs automatically.")
+        gen_col1, gen_col2, gen_spacer = st.columns((0.20, 0.20, 0.60))
+        with gen_col1:
+            pair_count = st.number_input(
+                "Number of pairs",
+                min_value=1,
+                max_value=50,
+                value=5,
+                step=1,
+                key="auto_gen_pair_count",
+            )
+        with gen_col2:
+            st.write("")  # vertical spacing
+            st.write("")
+            if st.button("Generate", type="primary", key="auto_gen_btn"):
+                with st.status("Generating SQL training pairs...", expanded=True) as gen_status:
+                    gen_results = auto_generate_sql_pairs(count=int(pair_count))
+                    passed = gen_results.get("passed", 0)
+                    failed = gen_results.get("failed", 0)
+                    if passed > 0:
+                        gen_status.update(
+                            label=f"Generated {passed} pair(s) ({failed} failed)",
+                            state="complete",
+                        )
+                        st.success(f"Successfully trained {passed} SQL pair(s).")
+                    else:
+                        gen_status.update(
+                            label=f"Generation complete: 0 passed, {failed} failed",
+                            state="error",
+                        )
+                        st.warning("No valid pairs were generated. Check LLM connectivity and training data.")
+                    # Show details for failed pairs
+                    failed_details = [d for d in gen_results.get("details", []) if d["status"] == "failed"]
+                    if failed_details:
+                        with st.expander(f"Failed pairs ({len(failed_details)})"):
+                            for d in failed_details:
+                                st.text(f"Pair {d['index']}: {d.get('reason', 'Unknown')}")
+
+        st.divider()
         # Data management actions
         st.caption("Data Management")
         mgmt_cols = st.columns((0.15, 0.25, 0.15, 0.15, 0.30))


### PR DESCRIPTION
## Summary

Adds a one-click feature that uses the connected LLM and live database to automatically generate, validate, and train SQL question-answer pairs -- bootstrapping RAG training data without manual effort. Each pair goes through a 5-step pipeline: LLM generation, security validation, SQL execution, LLM semantic review, and auto-training.

## Issues Resolved

Closes #66

## Changes Made

### Backend: `auto_generate_sql_pairs()` in `utils/vanna_calls.py`
- New module-level function following the `train_all()` / `refresh_stats()` pattern
- Per-pair pipeline: DDL context + existing questions fed to LLM, generates QUESTION/SQL pair, validates via `SecurityValidator.validate_sql_content()` and `check_references()`, executes SQL against Postgres, LLM semantic review confirms results answer the question, valid pairs trained via `write_to_file_and_training()`
- Intra-batch duplicate prevention by appending successful questions to the prompt context
- Count clamped to [1, 50], progress bar during generation, structured result dict returned

### Frontend: Auto-Generate SQL Pairs section in `views/user.py`
- New admin-only section in the RAG Training tab between Train All/Refresh Stats and Data Management
- Number input for pair count (1-50, default 5), Generate button with `st.status` progress
- Displays pass/fail summary and expandable failure details

### Tests: `tests/utils/test_auto_generate_sql_pairs.py`
- 20 tests covering: response parsing (valid, multiline, markdown fencing, missing fields, empty, case-insensitive), prompt constants, end-to-end pipeline (successful generation, security blocking, execution errors, empty results, semantic review failures, unparseable responses, forbidden references, count clamping, mixed results, service unavailability, exception handling)

## Design Decisions

- **Module-level function vs VannaService method**: Chose module-level function to match the existing pattern used by `train_all()`, `refresh_stats()`, and `train_ai_documentation()`, which all internally call `VannaService.from_streamlit_session()`. This keeps the VannaService class focused on core operations.
- **Direct `vn.run_sql()` vs `vanna_service.run_sql()`**: Used `vn.run_sql()` directly to bypass Streamlit caching and spinner decorators that would interfere with batch execution.
- **Dual security validation**: Both `SecurityValidator` and `check_references()` are applied, matching the defense-in-depth pattern used elsewhere in the codebase.
- **Structured QUESTION/SQL response format**: Simple and robust format that is easy to parse and less prone to LLM hallucination than JSON.

## Self-Review

- Verified no off-by-one errors in progress bar (uses `(i+1)/count`)
- Confirmed `existing_questions` list grows within a batch to prevent intra-batch duplicates
- Verified all failure paths set `pair_detail["reason"]` before appending to results
- Confirmed progress bar cleanup happens in `finally` block
- No scope creep -- only three files touched, all directly related to the feature

## Testing

- [x] All existing tests pass
- [x] New tests added for changes (20 tests, all passing)
- [x] Ruff lint check passes on all changed files

## Files Modified

- `utils/vanna_calls.py` -- Added `auto_generate_sql_pairs()`, `_parse_question_sql_response()`, and prompt constants
- `views/user.py` -- Added Auto-Generate SQL Pairs UI section and import
- `tests/utils/test_auto_generate_sql_pairs.py` -- New test file (20 tests)