### PR TITLE
fix(auth): handle stale cookie pointing to a missing user

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,6 @@ pg = st.navigation(pages=pages)
 
 check_authenticate()
 
-initialize_discord_logging_after_streamlit(st.session_state.username)
+initialize_discord_logging_after_streamlit(st.session_state.get("username"))
 
 pg.run()

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -108,6 +108,14 @@ def set_user_preferences_in_session_state():
         user_id = json.loads(user_id_str)
         user = get_user(user_id)
 
+        # Cookie points to a user_id that no longer exists (e.g. the SQLite DB
+        # was recreated/migrated and IDs shifted). Treat as not-loaded so the
+        # caller can clear the stale cookie and re-prompt for login, instead of
+        # cascading into a series of 'NoneType' attribute errors.
+        if user is None:
+            logger.warning("Cookie user_id %s does not resolve to a user; treating as logged out.", user_id)
+            return None
+
         # if "loaded" not in st.session_state:
         st.session_state.show_sql = user.show_sql
         st.session_state.show_table = user.show_table

--- a/tests/utils/test_auth_stale_cookie.py
+++ b/tests/utils/test_auth_stale_cookie.py
@@ -1,0 +1,91 @@
+"""Stale/invalid cookie handling for local auth.
+
+Regression tests for the cascade where a cookie holds a ``user_id`` that no
+longer exists in the DB (e.g. after the SQLite DB was recreated/migrated). The
+old behavior dereferenced a ``None`` user three layers deep, producing:
+    - "Error setting user preferences in session state: 'NoneType'... 'show_sql'"
+    - "Error checking authentication: 'NoneType'... 'first_name'"
+    - "st.session_state has no attribute 'username'"
+
+Desired behavior: treat the cookie as invalid, clear it, and show the login
+form — no error spew.
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+
+class FakeSessionState(dict):
+    """Dict that also supports attribute access, like st.session_state."""
+
+    def __getattr__(self, key):
+        try:
+            return self[key]
+        except KeyError as exc:
+            raise AttributeError(key) from exc
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+
+class FakeCookies:
+    def __init__(self, initial=None):
+        self._d = dict(initial or {})
+        self.saved = False
+
+    def get(self, key, default=None):
+        return self._d.get(key, default)
+
+    def __contains__(self, key):
+        return key in self._d
+
+    def __setitem__(self, key, value):
+        self._d[key] = value
+
+    def __getitem__(self, key):
+        return self._d[key]
+
+    def save(self):
+        self.saved = True
+
+
+def test_set_preferences_returns_none_without_error_when_user_missing():
+    """get_user() -> None must short-circuit, not crash on user.show_sql."""
+    import orm.functions as functions
+
+    session_state = FakeSessionState()
+    session_state.cookies = FakeCookies({"user_id": "99"})
+
+    with (
+        patch("streamlit.session_state", session_state),
+        patch.object(functions, "get_user", return_value=None),
+        patch("streamlit.error") as error_mock,
+    ):
+        result = functions.set_user_preferences_in_session_state()
+
+    assert result is None
+    error_mock.assert_not_called()
+    assert "username" not in session_state
+    assert "show_sql" not in session_state
+
+
+def test_handle_local_auth_clears_stale_cookie_and_shows_login():
+    """An unresolvable user_id cookie => clear cookie + render login form."""
+    import utils.auth as auth_module
+
+    expiry = (datetime.now() + timedelta(hours=8)).isoformat()
+    session_state = FakeSessionState()
+    session_state.cookies = FakeCookies({"user_id": "99", "expiry_date": expiry})
+
+    with (
+        patch("streamlit.session_state", session_state),
+        patch.object(auth_module, "set_user_preferences_in_session_state", return_value=None),
+        patch.object(auth_module, "_show_local_login") as login_mock,
+        patch("streamlit.error") as error_mock,
+    ):
+        auth_module._handle_local_auth()
+
+    login_mock.assert_called_once()
+    error_mock.assert_not_called()
+    assert session_state.cookies.get("user_id") == ""
+    assert session_state.cookies.saved is True

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -38,6 +38,17 @@ def _handle_local_auth():
             expiry_date = datetime.fromisoformat(expiry_date_str)
             user = set_user_preferences_in_session_state()
 
+            # Cookie present but its user_id no longer resolves to a user
+            # (stale cookie after a DB recreate/migrate). Clear the stale
+            # cookie and fall back to the login form rather than dereferencing
+            # a None user below.
+            if user is None:
+                st.session_state.cookies["user_id"] = ""
+                st.session_state.cookies["expiry_date"] = ""
+                st.session_state.cookies.save()
+                _show_local_login()
+                return
+
             # Ensure VannaService instance is cleared when switching users.
             if "_vn_instance" in st.session_state and st.session_state._vn_instance is not None:
                 import json


### PR DESCRIPTION
## Problem

A newly-created (or any) user could hit a wall of three errors at login:

- `Error setting user preferences in session state: 'NoneType' object has no attribute 'show_sql'`
- `Error checking authentication: 'NoneType' object has no attribute 'first_name'`
- `AttributeError: st.session_state has no attribute "username"`

## Root cause

The session cookie held a `user_id` that no longer resolves to a row in `thrive_user` (e.g. after the SQLite DB was recreated/migrated and IDs shifted, or the app pointed at a different DB file). `get_user()` returns `None`, and nothing guarded against it, so the `None` user was dereferenced three layers deep.

This is **not** model/`create_user` drift — `create_user` populates every preference column and the DB has all model columns.

## Fix — graceful degradation at the three layers the cascade passes through

1. `orm/functions.py` — `set_user_preferences_in_session_state()` returns `None` early (with a warning log) when `get_user()` is `None`.
2. `utils/auth.py` — `_handle_local_auth()` detects the unresolved user, clears the stale `user_id`/`expiry_date` cookie, and renders the login form.
3. `app.py` — `st.session_state.get("username")` so discord-logging init can't crash pre-auth.

Net effect: a recreated DB / stale cookie degrades to "please log in again" instead of an error spew.

## Tests

Adds `tests/utils/test_auth_stale_cookie.py` with two regression tests reproducing errors #1 and #2. Full auth + orm suites pass; no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)