### PR TITLE
feat(auth): configurable cookie prefix; trim create_user inputs

### DIFF
--- a/.streamlit/secrets_example.toml
+++ b/.streamlit/secrets_example.toml
@@ -29,6 +29,10 @@ restrict_rag_by_role = false
 
 [cookie]
 password = ""
+## Optional cookie name prefix (default "thrive_ai_"). Set a distinct value per
+## deployment when multiple instances share a hostname (e.g. prod vs a "/dev"
+## instance) so they don't read each other's session cookies.
+# prefix = "thrive_ai_"
 
 [postgres]
 host = "localhost"

--- a/app.py
+++ b/app.py
@@ -48,9 +48,12 @@ if _bootstrap_err is not None:
     st.error(f"Database initialization failed: {_bootstrap_err}")
     st.stop()
 
-# Initialize the cookie manager
+# Initialize the cookie manager. The prefix is configurable so that multiple
+# deployments behind the same hostname (e.g. prod at "/" and a dev instance at
+# "/dev") don't read each other's cookies — a shared prefix points one app at a
+# user_id that only exists in the other's database. Defaults to "thrive_ai_".
 st.session_state.cookies = EncryptedCookieManager(
-    prefix="thrive_ai_",
+    prefix=st.secrets["cookie"].get("prefix", "thrive_ai_"),
     password=st.secrets["cookie"]["password"],
 )
 

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -203,6 +203,14 @@ def create_user(username: str, password: str, first_name: str, last_name: str, r
         bool: True if user was created successfully, False otherwise
     """
     try:
+        # Trim surrounding whitespace so a stray space (e.g. typed into the
+        # admin create-user form) can't silently break login — credential
+        # checks match on the exact stored username. Password is intentionally
+        # left untouched.
+        username = (username or "").strip()
+        first_name = (first_name or "").strip()
+        last_name = (last_name or "").strip()
+
         with SessionLocal() as session:
             # Check if username already exists
             existing_user = session.query(User).filter(func.lower(User.username) == username.lower()).first()

--- a/tests/orm/test_create_user_trim.py
+++ b/tests/orm/test_create_user_trim.py
@@ -1,0 +1,42 @@
+"""create_user must trim whitespace from username/name fields.
+
+A leading/trailing space in the username (e.g. from the admin create-user
+form) silently breaks login, because verify_user_credentials matches on the
+exact stored username. Regression test for the `" adlouhy"` case seen in dev.
+"""
+
+from orm.functions import create_user
+from orm.models import User, UserRole
+
+
+def _doctor_role_id(session_factory):
+    with session_factory() as session:
+        return session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+
+
+def test_create_user_trims_username_and_names(in_memory_orm_session):
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    ok = create_user(
+        username="  adlouhy  ",
+        password="pw",
+        first_name="  Adrienne ",
+        last_name=" Dlouhy  ",
+        role_id=role_id,
+    )
+    assert ok is True
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "adlouhy").one_or_none()
+        assert user is not None, "username should be stored trimmed"
+        assert user.first_name == "Adrienne"
+        assert user.last_name == "Dlouhy"
+
+
+def test_create_user_dedupes_against_trimmed_username(in_memory_orm_session):
+    """A padded duplicate of an existing username must be rejected."""
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    assert create_user("adlouhy", "pw", "A", "D", role_id) is True
+    # Same username with surrounding whitespace should be treated as a dup.
+    assert create_user("  adlouhy  ", "pw", "A", "D", role_id) is False


### PR DESCRIPTION
Follow-up to #71 — addresses the two underlying issues found while diagnosing the dev-server login cascade.

## 1. Configurable cookie prefix

Co-hosted deployments behind one hostname (prod at `/` :8502 and a dev instance at `/dev` :8503) both ran the same code with a **hardcoded** `prefix="thrive_ai_"` and the same `cookie.password`. The browser ended up with two `thrive_ai_user_id` cookies (different paths), and the dev app could read a `user_id` set by prod — a value that only exists in prod's **separate** SQLite DB. `get_user()` → `None` → the `NoneType ... show_sql` cascade.

The prefix is now read from `[cookie].prefix`, defaulting to `"thrive_ai_"`. Set a distinct value per deployment (e.g. `thrive_ai_dev_`) so the instances stop reading each other's cookies. Documented in `secrets_example.toml`.

## 2. Trim `create_user` inputs

`create_user()` now strips surrounding whitespace from `username`, `first_name`, `last_name`. A stray space typed into the admin create-user form (this is how dev got a `" adlouhy"` user) silently breaks login, since `verify_user_credentials` matches the exact stored username. Password is intentionally left untouched. The bulk-import path already strips.

## Tests

Adds `tests/orm/test_create_user_trim.py` (trim + dedupe-against-padded-duplicate). Full orm + auth suites pass (41 passed).

> Note: existing `" adlouhy"` row on the dev DB still needs a one-off `UPDATE ... SET username=TRIM(username)`; this PR only prevents new occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)