### PR TITLE
feat(agentic): default agentic mode on for everybody

### DIFF
--- a/alembic/versions/f235fb6fdd7f_agentic_mode_default_on.py
+++ b/alembic/versions/f235fb6fdd7f_agentic_mode_default_on.py
@@ -1,0 +1,36 @@
+"""agentic_mode_default_on
+
+Revision ID: f235fb6fdd7f
+Revises: f3e688a55df6
+Create Date: 2026-05-27 11:53:41.398569
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f235fb6fdd7f"
+down_revision: Union[str, Sequence[str], None] = "f3e688a55df6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Turn agentic mode on for everybody.
+
+    Data-only migration: flips every existing user (including any with a NULL
+    value) to agentic_mode = True. New users get True via the ORM column
+    default in orm/models.py. The column's server_default is intentionally
+    left as-is since all inserts go through the ORM.
+    """
+    op.execute("UPDATE thrive_user SET agentic_mode = 1 WHERE agentic_mode IS NULL OR agentic_mode = 0")
+
+
+def downgrade() -> None:
+    """No-op: a data migration that turned a preference on is not safely
+    reversible — we can't tell which users were on before. Downgrading the
+    schema is handled by the previous revision."""
+    pass

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -130,7 +130,8 @@ def set_user_preferences_in_session_state():
         st.session_state.show_elapsed_time = user.show_elapsed_time
         st.session_state.llm_fallback = user.llm_fallback
         st.session_state.confirm_magic_commands = getattr(user, "confirm_magic_commands", True)
-        st.session_state.agentic_mode = bool(getattr(user, "agentic_mode", False))
+        agentic_pref = getattr(user, "agentic_mode", True)
+        st.session_state.agentic_mode = bool(agentic_pref) if agentic_pref is not None else True
         st.session_state.min_message_id = user.min_message_id
         st.session_state.user_role = user.role.role.value
         st.session_state.user_theme = user.theme

--- a/orm/models.py
+++ b/orm/models.py
@@ -179,7 +179,7 @@ class User(Base):
     show_elapsed_time = Column(Boolean, default=True)
     llm_fallback = Column(Boolean, default=False)
     confirm_magic_commands = Column(Boolean, default=True)  # True = show popup, False = auto-execute
-    agentic_mode = Column(Boolean, default=False)
+    agentic_mode = Column(Boolean, default=True)
     min_message_id = Column(Integer, default=0)
     theme = Column(String(50), default=ThemeType.WELLTELLAI.value)
     selected_llm_provider = Column(String(50), default=None)

--- a/tests/orm/test_agentic_mode_default.py
+++ b/tests/orm/test_agentic_mode_default.py
@@ -1,0 +1,54 @@
+"""agentic_mode should default ON for everybody — new users and existing.
+
+- New users created via the ORM / create_user get agentic_mode = True.
+- The data migration flips all pre-existing rows to True.
+"""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from orm.functions import create_user
+from orm.models import User, UserRole
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_create_user_defaults_agentic_mode_on(in_memory_orm_session):
+    with in_memory_orm_session() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+
+    assert create_user("newdoc", "pw", "New", "Doc", role_id) is True
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "newdoc").one()
+        assert user.agentic_mode is True
+
+
+def test_migration_turns_on_agentic_mode_for_existing_users(tmp_path):
+    """Upgrade to the prior revision, insert a user with agentic_mode=0,
+    then upgrade to head — the new migration must flip it to 1."""
+    url = f"sqlite:///{tmp_path / 'thrive.sqlite3'}"
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", url)
+
+    # Schema state just before the default-on migration.
+    command.upgrade(cfg, "f3e688a55df6")
+
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO thrive_user (username, first_name, last_name, password, agentic_mode) "
+                "VALUES ('legacy', 'Leg', 'Acy', 'x', 0)"
+            )
+        )
+
+    # Apply the default-on migration.
+    command.upgrade(cfg, "head")
+
+    with engine.connect() as conn:
+        val = conn.execute(text("SELECT agentic_mode FROM thrive_user WHERE username='legacy'")).scalar()
+    assert val == 1, "existing user should have been flipped to agentic_mode on"

--- a/tests/orm/test_user_agentic_mode.py
+++ b/tests/orm/test_user_agentic_mode.py
@@ -1,10 +1,18 @@
-import pytest
-from orm.models import User
+from orm.models import User, UserRole
 
 
-def test_user_has_agentic_mode_default_false():
-    user = User(username="test@example.com", first_name="Test", last_name="User", password="x")
-    assert user.agentic_mode is None or user.agentic_mode is False
+def test_user_agentic_mode_defaults_on(in_memory_orm_session):
+    """A user inserted without specifying agentic_mode gets the column
+    default, which is now True (agentic mode on for everybody)."""
+    with in_memory_orm_session() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+        user = User(
+            username="test@example.com", first_name="Test", last_name="User", password="x", user_role_id=role_id
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        assert user.agentic_mode is True
 
 
 def test_user_agentic_mode_in_to_dict():

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -350,9 +350,9 @@ with st.sidebar.expander("Settings"):
             st.toast("Settings saved!")
 
 agentic_mode_initial = bool(
-    getattr(st.session_state.get("user"), "agentic_mode", False)
+    getattr(st.session_state.get("user"), "agentic_mode", True)
     if st.session_state.get("user")
-    else st.session_state.get("agentic_mode", False)
+    else st.session_state.get("agentic_mode", True)
 )
 agentic_mode = st.sidebar.checkbox(
     "Agentic mode (beta)",


### PR DESCRIPTION
Makes agentic mode default **on** — for both new and existing users.

## Changes
- **`orm/models.py`** — `User.agentic_mode` column default `False` → `True`. New users (ORM `create_user`, seed) get it on.
- **Migration `f235fb6fdd7f`** — data-only: `UPDATE thrive_user SET agentic_mode = 1` for all existing rows (incl. NULLs), so current users get it too. Downgrade is a no-op (can't recover prior per-user values).
- **Fallbacks** — sidebar "initial value" (`views/chat_bot.py`) and `set_user_preferences` now default an unset preference to `True`. Runtime "is it active right now" gates left as safe `False` guards.

## Tests
- `test_user_agentic_mode` updated to assert default-on after a flushed insert (the old test only checked the unflushed `None` state and was misleadingly named).
- New `test_agentic_mode_default.py`: `create_user` default-on + migration flips an existing `agentic_mode=0` user to `1`.

Full orm + alembic suites pass (13).

> Per request, this turns it on for **everybody**, overriding anyone who previously toggled it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)