### PR TITLE
fix(agent): stop SYSTEM_PROMPT f-string crashing every agentic message

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -13,7 +13,11 @@ from datetime import datetime, timezone
 _TODAY = datetime.now(timezone.utc).date().isoformat()
 
 
-SYSTEM_PROMPT = f"""\
+# NOTE: this is a PLAIN string, not an f-string. The body is full of literal
+# JSON-shaped examples like {domain:'demographics'}; an f-string would parse
+# those braces as replacement fields and raise NameError at import. The single
+# dynamic value (today's date) is injected via the __TODAY__ sentinel below.
+SYSTEM_PROMPT = """\
 You are a clinical data assistant for healthcare professionals on the \
 Thrive AI platform. Answer questions about patient records by calling \
 typed tools that query a curated EHR/claims data warehouse.
@@ -53,7 +57,7 @@ TOOL ROUTING:
   - Patient named, no slot filled → `find_patient` FIRST. The UI surfaces \
 the chooser; do not enumerate matches in your reply.
 
-  - Patient slot is filled → `get_patient_clinical_data({{domain: …}})`. \
+  - Patient slot is filled → `get_patient_clinical_data({domain: …})`. \
 Available domains and their key filters:
       demographics — no filters
       encounters — facility_type (inpatient|outpatient|ed|ltc|any), date_range
@@ -175,9 +179,9 @@ summarize/describe/interpret.
 
 ARGUMENT SHAPES (emit as JSON objects, not strings):
 
-  - `date_range` is an OBJECT: {{"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}}. \
+  - `date_range` is an OBJECT: {"start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}. \
 Both fields optional; omit a key to leave one side unbounded. Never pass \
-a string like "last year" — compute the dates yourself. Today is {_TODAY}.
+a string like "last year" — compute the dates yourself. Today is __TODAY__.
   - Code lists (icd10_codes, loinc_codes, …) are arrays of strings: \
 ["E11.9"]. Even a single code goes in a list.
   - All filters are OPTIONAL. Omit any field the user didn't constrain.
@@ -229,4 +233,4 @@ a population question or explicitly asks to clear the selection.
 After `find_patient` returns matches, your `final_result.text` is a \
 brief prompt: "I found N patients matching that name. Please pick one \
 from the list below." Do NOT enumerate matches — the UI shows them.
-"""
+""".replace("__TODAY__", _TODAY)

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -1,4 +1,17 @@
+import datetime
+
 from agent.system_prompt import SYSTEM_PROMPT
+
+
+def test_prompt_imports_and_renders_today():
+    """Regression: the prompt body is full of literal JSON-shaped examples
+    like {domain:'demographics'}. It was once an f-string, so those braces
+    parsed as replacement fields and raised NameError at import — which, with
+    agentic mode defaulted on, crashed every chat message. Guard that the
+    module imports and the date sentinel is fully substituted (no stray
+    __TODAY__ or unrendered template braces)."""
+    assert "__TODAY__" not in SYSTEM_PROMPT
+    assert datetime.datetime.now(datetime.timezone.utc).date().isoformat() in SYSTEM_PROMPT
 
 
 def test_prompt_mentions_phase2_tools():


### PR DESCRIPTION
## Problem

`thriveai-je` (and everyone) hit a crash on **every** chat message on dev.

`agent/system_prompt.py` defined `SYSTEM_PROMPT` as an **f-string**, but the body is full of literal JSON-shaped examples like `{domain:'demographics'}`. Python parses those as f-string replacement fields → `NameError: name 'domain' is not defined` at **module import time**.

Because #74 (`feat(agentic): default agentic mode on for everybody`) made agentic mode the default, every message now imports `agent.runtime → runner → system_prompt`, so the latent crash became a total outage. The breaking edit lost its brace escaping during the merge-conflict resolution in `60844dc`.

## Fix

- Convert `SYSTEM_PROMPT` to a **plain string** (no `f`) so literal braces are safe — eliminates this class of bug for future prompt edits.
- Inject the one dynamic value (today's date) via a `__TODAY__` sentinel + `.replace()`, which can't collide with JSON braces.
- Un-double the two spots that had been manually `{{…}}`-escaped.
- Add `test_prompt_imports_and_renders_today` guarding both import and date substitution.

## Verification

- `import agent.system_prompt` ✅ (was `NameError`)
- Full crashed chain `from agent.runtime import run_agentic_message_flow` ✅
- `tests/agent/test_system_prompt.py` — was **erroring on collection**, now **17 passed**
- `tests/agent/test_runtime_smoke.py` ✅
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)