### PR TITLE
fix(cohort): support diagnosis_date_range as a standalone criterion

### DIFF
--- a/agent/db/queries/cohort.py
+++ b/agent/db/queries/cohort.py
@@ -52,9 +52,16 @@ def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
 
     Returns (sql, params). The caller passes both into adapter.fetch_all.
     """
+    # A diagnosis_date_range with a start or end bound is a standalone
+    # criterion ("any diagnosis in this window"); an all-None DateRange
+    # carries no filter and does not count.
+    _dr = getattr(criteria, "diagnosis_date_range", None)
+    _dr_active = _dr is not None and (getattr(_dr, "start", None) or getattr(_dr, "end", None))
+
     if not any(
         (
             getattr(criteria, "diagnosis_codes", None),
+            _dr_active,
             getattr(criteria, "medication_rxnorm_codes", None),
             getattr(criteria, "condition_text", None),
             getattr(criteria, "age_min", None) is not None,
@@ -77,24 +84,27 @@ def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
     # above guarantees this is never an unfiltered scan.
     where_clauses: list[str] = ["1=1"]
 
-    # --- diagnosis codes ----------------------------------------------
-    if getattr(criteria, "diagnosis_codes", None):
-        codes = list(criteria.diagnosis_codes)
-        placeholders = ", ".join(f":dx_{i}" for i in range(len(codes)))
-        for i, c in enumerate(codes):
-            params[f"dx_{i}"] = c
-        dx_filter = [
-            f"code IN ({placeholders})",
-            "code_type IN ('ICD-10', 'ICD10', 'SNOMED')",
-        ]
-        dr = getattr(criteria, "diagnosis_date_range", None)
-        if dr is not None:
-            if getattr(dr, "start", None):
+    # --- diagnosis: codes and/or date window --------------------------
+    # The diagnosis JOIN fires when codes are given, a date window is given,
+    # or both. With only a window we drop the code IN clause and count any
+    # ICD-10/SNOMED problem whose start_date falls in range; medication rows
+    # (RxNorm/NDC) are excluded by the code_type filter so "any diagnosis"
+    # never counts a prescription.
+    if getattr(criteria, "diagnosis_codes", None) or _dr_active:
+        dx_filter = ["code_type IN ('ICD-10', 'ICD10', 'SNOMED')"]
+        if getattr(criteria, "diagnosis_codes", None):
+            codes = list(criteria.diagnosis_codes)
+            placeholders = ", ".join(f":dx_{i}" for i in range(len(codes)))
+            for i, c in enumerate(codes):
+                params[f"dx_{i}"] = c
+            dx_filter.insert(0, f"code IN ({placeholders})")
+        if _dr_active:
+            if getattr(_dr, "start", None):
                 dx_filter.append("start_date >= :dx_start")
-                params["dx_start"] = dr.start.isoformat()
-            if getattr(dr, "end", None):
+                params["dx_start"] = _dr.start.isoformat()
+            if getattr(_dr, "end", None):
                 dx_filter.append("start_date <= :dx_end")
-                params["dx_end"] = dr.end.isoformat()
+                params["dx_end"] = _dr.end.isoformat()
         join_clauses.append(
             f"JOIN (SELECT DISTINCT patient_id FROM {schema_prefix}metric_federated_data_v "
             f"WHERE {' AND '.join(dx_filter)}) dx ON dx.patient_id = p.patient_id"

--- a/agent/tools/search_patients_by_criteria.py
+++ b/agent/tools/search_patients_by_criteria.py
@@ -47,11 +47,16 @@ class CohortCriteria(BaseModel):
 
     @model_validator(mode="after")
     def _require_at_least_one_criterion(self) -> "CohortCriteria":
-        # diagnosis_date_range alone is a no-op (only used to narrow
-        # diagnosis_codes), so it does not count as a criterion.
+        # A diagnosis_date_range with a start or end bound is a standalone
+        # criterion ("any diagnosis in this window"). An all-None DateRange
+        # carries no filter and does not count.
+        dr_active = self.diagnosis_date_range is not None and (
+            self.diagnosis_date_range.start or self.diagnosis_date_range.end
+        )
         if not any(
             (
                 self.diagnosis_codes,
+                dr_active,
                 self.medication_rxnorm_codes,
                 self.condition_text,
                 self.age_min is not None,
@@ -137,7 +142,13 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
 
     Criteria fields:
       - diagnosis_codes: ICD-10 or SNOMED codes; matched in metric_federated_data_v.
-      - diagnosis_date_range: optional DateRange narrowing diagnosis events.
+      - diagnosis_date_range: DateRange (start/end, inclusive) over diagnosis
+        start_date. Works WITH diagnosis_codes (narrows those codes to the
+        window) OR ALONE — a bare range counts patients with ANY ICD-10/SNOMED
+        diagnosis in the window. Use it alone for "how many patients had a
+        diagnosis in <period>". Do NOT fake this with age_min/age_max: an
+        age band does not filter by diagnosis date and yields the whole
+        population.
       - medication_rxnorm_codes: RxNorm or NDC codes; matched in metric_federated_data_v.
       - condition_text: free-text fallback when codes are not known; LIKE matches
         the denormalized conditions string. Prefer diagnosis_codes when available.
@@ -179,7 +190,9 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
     # Compute reliability_note up front so the no_records path also surfaces it
     # — geo-filter misses are most informative when no rows came back.
     reliability_parts: list[str] = []
-    if criteria.diagnosis_codes:
+    _dr = criteria.diagnosis_date_range
+    _dr_active = _dr is not None and (_dr.start or _dr.end)
+    if criteria.diagnosis_codes or _dr_active:
         reliability_parts.append(_RELIABILITY_DX)
     elif criteria.medication_rxnorm_codes:
         reliability_parts.append(_RELIABILITY_RX)

--- a/tests/agent/db/test_cohort_queries.py
+++ b/tests/agent/db/test_cohort_queries.py
@@ -11,6 +11,7 @@ Builds the SELECT for search_patients_by_criteria. Verifies:
 
 from __future__ import annotations
 from datetime import date
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import text
@@ -91,6 +92,42 @@ def test_diagnosis_with_facility_and_age(synthetic_db):
     with synthetic_db.connect() as conn:
         rows = conn.execute(text(sql), params).fetchall()
     assert len(rows) == 2, f"expected exactly 2 (Mary id=4, Susan id=8); got {len(rows)}"
+
+
+def test_diagnosis_date_range_alone_filters_by_window(synthetic_db):
+    """A date window WITHOUT codes counts patients with any ICD-10/SNOMED
+    diagnosis whose start_date falls in the window. Nov-Dec 2025 contains
+    Daniel (E11.9 2025-11-30) and Susan (E11.9 2025-12-01)."""
+    sql, params = cohort_sql(
+        _make(diagnosis_date_range=SimpleNamespace(start=date(2025, 11, 1), end=date(2025, 12, 31))),
+        schema_prefix="",
+    )
+    with synthetic_db.connect() as conn:
+        rows = conn.execute(text(sql), params).fetchall()
+    src_ids = sorted(r._mapping["source_id"] for r in rows)
+    assert src_ids == ["src-daniel-1977", "src-susan-1955"], f"got {src_ids}"
+
+
+def test_diagnosis_date_range_alone_excludes_medication_rows(synthetic_db):
+    """Jan-Feb 2026 contains only RxNorm rows (metformin); an 'any diagnosis'
+    window must NOT count medication events, so the cohort is empty."""
+    sql, params = cohort_sql(
+        _make(diagnosis_date_range=SimpleNamespace(start=date(2026, 1, 1), end=date(2026, 2, 28))),
+        schema_prefix="",
+    )
+    with synthetic_db.connect() as conn:
+        rows = conn.execute(text(sql), params).fetchall()
+    assert rows == [], f"expected no diagnosis patients in Jan-Feb 2026; got {[r._mapping['source_id'] for r in rows]}"
+
+
+def test_diagnosis_date_range_alone_satisfies_criteria_guard(synthetic_db):
+    """A bare date window is a real criterion now — cohort_sql must not
+    raise the empty-criteria guard."""
+    sql, params = cohort_sql(
+        _make(diagnosis_date_range=SimpleNamespace(start=date(2025, 1, 1), end=None)),
+        schema_prefix="",
+    )
+    assert "metric_federated_data_v" in sql
 
 
 def test_medication_rxnorm_codes_join(synthetic_db):

--- a/tests/agent/tools/test_search_patients_by_criteria.py
+++ b/tests/agent/tools/test_search_patients_by_criteria.py
@@ -237,6 +237,65 @@ def test_cohort_criteria_still_rejects_truly_empty():
         CohortCriteria()
 
 
+def test_cohort_criteria_accepts_diagnosis_date_range_alone():
+    """'How many patients had a diagnosis in December 2024' — a date window
+    with no codes is now a valid standalone criterion."""
+    from agent.tools.search_patients_by_criteria import CohortCriteria, DateRange
+
+    c = CohortCriteria(diagnosis_date_range=DateRange(start=date(2024, 12, 1), end=date(2024, 12, 31)))
+    assert c.diagnosis_date_range.start == date(2024, 12, 1)
+
+
+def test_cohort_criteria_rejects_empty_diagnosis_date_range():
+    """An all-None DateRange carries no filter and must NOT satisfy the
+    at-least-one-criterion guard — otherwise it scans the whole table."""
+    from agent.tools.search_patients_by_criteria import CohortCriteria, DateRange
+
+    with pytest.raises(ValidationError):
+        CohortCriteria(diagnosis_date_range=DateRange())
+
+
+def test_diagnosis_date_range_alone_count(synthetic_db):
+    """End-to-end: a bare diagnosis window counts distinct patients with any
+    ICD-10/SNOMED diagnosis in that window (Daniel + Susan in Nov-Dec 2025)."""
+    from agent.tools.search_patients_by_criteria import (
+        CohortCriteria,
+        DateRange,
+        search_patients_by_criteria,
+    )
+
+    ctx = MagicMock()
+    ctx.deps = _deps(synthetic_db, selected=None)
+    out = search_patients_by_criteria(
+        ctx,
+        CohortCriteria(
+            diagnosis_date_range=DateRange(start=date(2025, 11, 1), end=date(2025, 12, 31)),
+            sample_size=0,
+        ),
+    )
+    assert out.data_availability == "data_present"
+    assert out.total_count == 2
+
+
+def test_diagnosis_date_range_alone_attaches_dx_reliability(synthetic_db):
+    """A diagnosis-window query hits the same low-coverage problems data, so
+    the ICD-10/SNOMED coverage caveat MUST be surfaced."""
+    from agent.tools.search_patients_by_criteria import (
+        CohortCriteria,
+        DateRange,
+        search_patients_by_criteria,
+        _RELIABILITY_DX,
+    )
+
+    ctx = MagicMock()
+    ctx.deps = _deps(synthetic_db, selected=None)
+    out = search_patients_by_criteria(
+        ctx,
+        CohortCriteria(diagnosis_date_range=DateRange(start=date(2025, 11, 1), end=date(2025, 12, 31))),
+    )
+    assert out.reliability_note == _RELIABILITY_DX
+
+
 def test_geo_only_attaches_geo_reliability(synthetic_db):
     from agent.tools.search_patients_by_criteria import (
         CohortCriteria,


### PR DESCRIPTION
## Problem

"How many patients had a diagnosis in <period>?" silently returned the **entire patient population**. `diagnosis_date_range` was only a modifier of `diagnosis_codes`; supplied alone it was dropped without error, the at-least-one-criterion guard rejected it, and the model worked around that with `age_min=0`/`age_max=120` — counting everyone and reporting it confidently as the diagnosis count (observed: 1,920,695).

## Fix

Make a bounded `diagnosis_date_range` a real criterion:
- The diagnosis JOIN now fires on codes **OR** a date window. With a bare window it keeps the `code_type IN ('ICD-10','ICD10','SNOMED')` filter (so medication/procedure rows can't leak into a "diagnosis" count) and drops the `code IN` clause.
- An all-None `DateRange` still carries no filter and is rejected.
- The ICD-10/SNOMED coverage caveat now fires for window-only queries too.
- The tool docstring tells the model to use the bare range and explicitly warns against faking it with an age band.

## Semantics

Counts distinct patients with any ICD-10/SNOMED diagnosis whose `start_date` (onset) falls in the window. Note: onset-dated, not "active during the window" — a chronic problem with onset before the window won't be counted. Flagged for follow-up if "active during" is the desired interpretation.

## Tests

7 new tests (TDD, watched fail first), 53 green total across cohort SQL / tool / flow suites. No regressions.

Verified on the dev server: the question now emits the `metric_federated_data_v` JOIN with `dx_start`/`dx_end` instead of the age-band workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)