### PR TITLE
feat(agentic): full-fidelity run logging & analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,12 @@ password = "<random-strong-secret>"
 [security]
 allow_llm_to_see_data = false
 restrict_rag_by_role = true
+
+[agent_logging]
+mode = "full"                    # full | scrubbed | disabled
+max_logged_result_bytes = 5000000
+max_logged_event_bytes = 5000000
+retention_days = 0               # 0 = keep indefinitely
 ```
 
 ## Development Guidelines
@@ -153,3 +159,4 @@ restrict_rag_by_role = true
 - Missing `cookie.password` prevents login - app stops until cookies ready
 - Ollama defaults to `http://localhost:11434` - ensure model is pulled and running
 - Role-restricted RAG retrieval on by default; disable with `security.restrict_rag_by_role = false`
+- Agentic run logging defaults to `full` fidelity (verbatim PHI in the app SQLite DB); set `[agent_logging].mode = "scrubbed"` to hash SQL literals and drop full result rows, or `disabled` to turn it off. Protect DB backups accordingly.

--- a/agent/deps.py
+++ b/agent/deps.py
@@ -52,4 +52,8 @@ class AgentDeps:
     analytics_db: object
     rag: object
     sqlite_session: "Session"
-    audit_logger: object
+    run_logger: object  # AgentRunLogger | None
+    group_id: Optional[str] = None
+    user_message_id: Optional[int] = None
+    parent_run_id: Optional[str] = None
+    resume_reason: Optional[str] = None

--- a/agent/deps_builder.py
+++ b/agent/deps_builder.py
@@ -26,7 +26,8 @@ import uuid
 import streamlit as st
 
 from agent.deps import AgentDeps, SelectedPatient
-from agent.audit import AuditLogger
+from agent.run_logger import AgentRunLogger
+from agent.logging_config import AgentLoggingConfig
 from agent.db.analytics_adapter import AnalyticsDbAdapter
 from orm.models import RoleTypeEnum
 
@@ -114,6 +115,22 @@ def build_agent_deps(sqlite_session) -> AgentDeps:
         st.session_state["agent_session_id"] = str(uuid.uuid4())
     session_id = st.session_state["agent_session_id"]
 
+    config = AgentLoggingConfig.from_streamlit()
+    run_id = str(uuid.uuid4())
+    st.session_state["agent_current_run_id"] = run_id
+    group_id = st.session_state.get("current_group_id")
+    run_logger = None
+    if config.enabled:
+        run_logger = AgentRunLogger(
+            session=sqlite_session,
+            config=config,
+            run_id=run_id,
+            session_id=session_id,
+            user_id=user_id,
+            user_role=int(user_role.value),
+            group_id=group_id,
+        )
+
     return AgentDeps(
         user_id=user_id,
         user_role=user_role,
@@ -125,10 +142,9 @@ def build_agent_deps(sqlite_session) -> AgentDeps:
         analytics_db=_analytics_db(),
         rag=_rag(),
         sqlite_session=sqlite_session,
-        audit_logger=AuditLogger(
-            session=sqlite_session,
-            session_id=session_id,
-            user_id=user_id,
-            user_role=int(user_role.value),
-        ),
+        run_logger=run_logger,
+        group_id=group_id,
+        user_message_id=None,
+        parent_run_id=st.session_state.get("agent_parent_run_id"),
+        resume_reason=st.session_state.get("agent_resume_reason"),
     )

--- a/agent/logging_config.py
+++ b/agent/logging_config.py
@@ -1,0 +1,79 @@
+# agent/logging_config.py
+"""Configuration + payload-capping helpers for agentic run logging.
+
+Reads the [agent_logging] section of secrets.toml:
+
+    [agent_logging]
+    mode = "full"                       # "full" | "scrubbed" | "disabled"
+    max_logged_result_bytes = 5000000
+    max_logged_event_bytes = 5000000
+    retention_days = 0                  # 0 = keep indefinitely
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Optional
+
+_VALID_MODES = ("full", "scrubbed", "disabled")
+_DEFAULT_MAX_BYTES = 5_000_000
+
+
+@dataclass(frozen=True)
+class AgentLoggingConfig:
+    mode: str = "full"
+    max_logged_result_bytes: int = _DEFAULT_MAX_BYTES
+    max_logged_event_bytes: int = _DEFAULT_MAX_BYTES
+    retention_days: int = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.mode in ("full", "scrubbed")
+
+    @classmethod
+    def from_secrets(cls, section: dict | None) -> "AgentLoggingConfig":
+        section = dict(section or {})
+        mode = section.get("mode", "full")
+        if mode not in _VALID_MODES:
+            mode = "full"
+        return cls(
+            mode=mode,
+            max_logged_result_bytes=int(section.get("max_logged_result_bytes", _DEFAULT_MAX_BYTES)),
+            max_logged_event_bytes=int(section.get("max_logged_event_bytes", _DEFAULT_MAX_BYTES)),
+            retention_days=int(section.get("retention_days", 0)),
+        )
+
+    @classmethod
+    def from_streamlit(cls) -> "AgentLoggingConfig":
+        try:
+            import streamlit as st
+
+            return cls.from_secrets(dict(st.secrets.get("agent_logging", {})))
+        except Exception:
+            return cls()
+
+
+def cap_json(
+    obj: Any,
+    max_bytes: int,
+) -> tuple[Optional[str], bool, int, Optional[str]]:
+    """Serialize `obj` to JSON, capping stored size.
+
+    Returns (stored_text, truncated, original_byte_count, sha256_of_original).
+    - None obj -> (None, False, 0, None).
+    - Under cap -> full JSON, truncated=False.
+    - Over cap -> text truncated to max_bytes (UTF-8 safe), truncated=True,
+      original byte count + hash of the FULL payload preserved for integrity.
+    """
+    if obj is None:
+        return None, False, 0, None
+    full = json.dumps(obj, default=str)
+    raw = full.encode("utf-8")
+    nbytes = len(raw)
+    digest = hashlib.sha256(raw).hexdigest()
+    if nbytes <= max_bytes:
+        return full, False, nbytes, digest
+    truncated_text = raw[:max_bytes].decode("utf-8", errors="ignore")
+    return truncated_text, True, nbytes, digest

--- a/agent/run_logger.py
+++ b/agent/run_logger.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from agent.audit import scrub_arguments_json, summarize_result
@@ -71,15 +72,6 @@ class AgentRunLogger:
 
     _seq: int = field(default=0, init=False)
     _call_index: int = field(default=0, init=False)
-
-    # The test monkeypatches this to None to simulate a broken session.
-    @property
-    def _session(self) -> Optional[Session]:
-        return self.session
-
-    @_session.setter
-    def _session(self, value):
-        self.session = value
 
     def _next_seq(self) -> int:
         self._seq += 1
@@ -358,9 +350,7 @@ class AgentRunLogger:
                 run.error_type = error_type
                 run.error = error
                 run.stack_trace = stack_trace if self.config.mode == "full" else None
-                from sqlalchemy import func as _f
-
-                run.completed_at = _f.now()
+                run.completed_at = func.now()
                 self.session.add(run)
                 self._safe_commit()
         except Exception:

--- a/agent/run_logger.py
+++ b/agent/run_logger.py
@@ -18,7 +18,14 @@ so the SQLite write lock is not held while the agent yields more events.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from agent.audit import scrub_arguments_json, summarize_result
+from agent.logging_config import AgentLoggingConfig, cap_json
+from orm.models import AgentPatientAccess, AgentRun, AgentRunEvent, ToolCall
 
 
 def extract_source_ids(payload: Any) -> list[tuple[str, Optional[str]]]:
@@ -44,3 +51,350 @@ def extract_source_ids(payload: Any) -> list[tuple[str, Optional[str]]]:
 
     _walk(payload)
     return list(found.items())
+
+
+@dataclass
+class AgentRunLogger:
+    """Owns one run's logging lifecycle. Constructed per-run in deps_builder.
+
+    `seq` and `call_index` are monotonic counters held for the run's duration.
+    All public methods are guarded so logging never breaks the agent run.
+    """
+
+    session: Session
+    config: AgentLoggingConfig
+    run_id: str
+    session_id: str
+    user_id: int
+    user_role: int
+    group_id: Optional[str] = None
+
+    _seq: int = field(default=0, init=False)
+    _call_index: int = field(default=0, init=False)
+
+    # The test monkeypatches this to None to simulate a broken session.
+    @property
+    def _session(self) -> Optional[Session]:
+        return self.session
+
+    @_session.setter
+    def _session(self, value):
+        self.session = value
+
+    def _next_seq(self) -> int:
+        self._seq += 1
+        return self._seq
+
+    def _safe_commit(self) -> None:
+        try:
+            self.session.commit()
+        except Exception:
+            try:
+                self.session.rollback()
+            except Exception:
+                pass
+
+    def _append_event(
+        self,
+        event_type: str,
+        *,
+        payload: Any = None,
+        payload_summary: Optional[str] = None,
+        turn_index: Optional[int] = None,
+        tool_call_id: Optional[str] = None,
+        tool_name: Optional[str] = None,
+        elapsed_ms: Optional[int] = None,
+    ) -> int:
+        seq = self._next_seq()
+        try:
+            text, truncated, nbytes, digest = (None, False, 0, None)
+            if payload is not None and self.config.mode == "full":
+                text, truncated, nbytes, digest = cap_json(payload, self.config.max_logged_event_bytes)
+            elif payload is not None:
+                # scrubbed: store only a short summary, never the full payload
+                payload_summary = payload_summary or (str(payload)[:200])
+            row = AgentRunEvent(
+                run_id=self.run_id,
+                seq=seq,
+                event_type=event_type,
+                turn_index=turn_index,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                payload_json=text,
+                payload_summary=payload_summary,
+                payload_truncated=truncated,
+                payload_bytes=nbytes or None,
+                payload_hash=digest,
+                elapsed_ms=elapsed_ms,
+            )
+            self.session.add(row)
+            self._safe_commit()
+        except Exception:
+            pass
+        return seq
+
+    # ---- public API -------------------------------------------------
+
+    def start_run(
+        self,
+        *,
+        question: str,
+        llm_provider: Optional[str],
+        llm_model: Optional[str],
+        selected_patient: Optional[dict],
+        group_id: Optional[str],
+        parent_run_id: Optional[str] = None,
+        resume_reason: Optional[str] = None,
+        user_message_id: Optional[int] = None,
+        system_prompt_hash: Optional[str] = None,
+        tool_schema_hash: Optional[str] = None,
+        message_history: Any = None,
+        app_git_sha: Optional[str] = None,
+        environment: Optional[str] = None,
+    ) -> None:
+        self.group_id = group_id
+        try:
+            history_text = None
+            if message_history is not None and self.config.mode == "full":
+                history_text, *_ = cap_json(message_history, self.config.max_logged_event_bytes)
+            sp = selected_patient or {}
+            run = AgentRun(
+                run_id=self.run_id,
+                session_id=self.session_id,
+                group_id=group_id,
+                parent_run_id=parent_run_id,
+                resume_reason=resume_reason,
+                user_message_id=user_message_id,
+                user_id=self.user_id,
+                user_role=self.user_role,
+                question=question,
+                selected_patient_source_id=sp.get("source_id"),
+                selected_patient_display_name=sp.get("display_name"),
+                selected_patient_dob=sp.get("dob"),
+                selected_patient_selection_origin=sp.get("selection_origin"),
+                llm_provider=llm_provider,
+                llm_model=llm_model,
+                system_prompt_hash=system_prompt_hash,
+                tool_schema_hash=tool_schema_hash,
+                message_history_json=history_text,
+                status="open",
+                success=False,
+                logging_mode=self.config.mode,
+                schema_version=1,
+                app_git_sha=app_git_sha,
+                environment=environment,
+            )
+            self.session.add(run)
+            self._safe_commit()
+        except Exception:
+            pass
+        self._append_event("run_started", payload={"question": question})
+        if selected_patient and selected_patient.get("source_id"):
+            self._record_access(
+                source_id=selected_patient["source_id"],
+                display_name=selected_patient.get("display_name"),
+                access_type="pinned_at_run_start",
+                access_origin="run_context",
+            )
+
+    def log_event(
+        self,
+        event_type: str,
+        *,
+        payload: Any = None,
+        turn_index: Optional[int] = None,
+        elapsed_ms: Optional[int] = None,
+        payload_summary: Optional[str] = None,
+    ) -> int:
+        return self._append_event(
+            event_type, payload=payload, turn_index=turn_index, elapsed_ms=elapsed_ms, payload_summary=payload_summary
+        )
+
+    def log_tool_started(
+        self, *, tool_name: str, tool_call_id: Optional[str], turn_index: Optional[int], arguments: dict
+    ) -> int:
+        return self._append_event(
+            "tool_call_started",
+            payload={"arguments": arguments},
+            turn_index=turn_index,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+        )
+
+    def log_tool_completed(
+        self,
+        *,
+        tool_name: str,
+        tool_call_id: Optional[str],
+        turn_index: Optional[int],
+        arguments: dict,
+        result_obj: Any,
+        sql_executed: list,
+        elapsed_ms: int,
+        success: bool,
+        error: Optional[str],
+        selected_patient_source_id: Optional[str],
+        started_event_seq: Optional[int] = None,
+    ) -> None:
+        self._call_index += 1
+        call_index = self._call_index
+        scrubbed = self.config.mode == "scrubbed"
+        try:
+            # Arguments: verbatim in full, scrubbed (hashed literals) otherwise.
+            if scrubbed:
+                arguments_json = scrub_arguments_json(tool_name, arguments)
+            else:
+                arguments_json, *_ = cap_json(arguments, self.config.max_logged_result_bytes)
+
+            # Summary always cheap + PHI-safe.
+            try:
+                result_summary = summarize_result(tool_name, result_obj)
+            except Exception:
+                result_summary = f"result_type={type(result_obj).__name__}"
+
+            # Full result + SQL: only stored in full mode.
+            if scrubbed:
+                result_json, r_trunc, r_bytes, r_hash = (None, False, None, None)
+                sql_json, s_trunc, s_bytes, s_hash = (None, False, None, None)
+            else:
+                result_json, r_trunc, r_bytes, r_hash = cap_json(result_obj, self.config.max_logged_result_bytes)
+                sql_json, s_trunc, s_bytes, s_hash = cap_json(sql_executed, self.config.max_logged_result_bytes)
+
+            completed_seq = self._append_event(
+                "tool_call_completed",
+                payload={"result": result_obj, "sql_executed": sql_executed} if not scrubbed else None,
+                payload_summary=result_summary,
+                turn_index=turn_index,
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                elapsed_ms=elapsed_ms,
+            )
+
+            row = ToolCall(
+                session_id=self.session_id,
+                user_id=self.user_id,
+                user_role=self.user_role,
+                selected_patient_source_id=selected_patient_source_id,
+                tool_name=tool_name,
+                arguments_json=arguments_json or "{}",
+                result_summary=result_summary,
+                elapsed_ms=elapsed_ms,
+                success=success,
+                error=error,
+                run_id=self.run_id,
+                tool_call_id=tool_call_id,
+                call_index=call_index,
+                turn_index=turn_index,
+                attempt_index=1,
+                started_event_seq=started_event_seq,
+                completed_event_seq=completed_seq,
+                result_json=result_json,
+                result_truncated=r_trunc,
+                result_bytes=r_bytes,
+                result_hash=r_hash,
+                sql_executed_json=sql_json,
+                sql_executed_truncated=s_trunc,
+                sql_executed_bytes=s_bytes,
+                sql_executed_hash=s_hash,
+            )
+            self.session.add(row)
+            self._safe_commit()
+
+            # Patient access derived from full result payloads only.
+            if not scrubbed:
+                for sid, name in extract_source_ids(result_obj):
+                    self._record_access(
+                        source_id=sid,
+                        display_name=name,
+                        access_type="tool_result",
+                        access_origin="tool",
+                        tool_name=tool_name,
+                        tool_call_id=tool_call_id,
+                        event_seq=completed_seq,
+                    )
+        except Exception:
+            pass
+
+    def log_chooser_candidates(self, payload: dict) -> None:
+        if self.config.mode == "scrubbed":
+            return
+        for sid, name in extract_source_ids(payload):
+            self._record_access(
+                source_id=sid, display_name=name, access_type="selection_shown", access_origin="agent_disambiguation"
+            )
+
+    def finalize_run(
+        self,
+        *,
+        status: str,
+        final_answer_text: Optional[str],
+        usage: Optional[dict],
+        total_elapsed_ms: Optional[int],
+        cap_reached: Optional[str],
+        final_message_id: Optional[int] = None,
+        error_type: Optional[str] = None,
+        error: Optional[str] = None,
+        stack_trace: Optional[str] = None,
+    ) -> None:
+        if status == "cap_reached":
+            self._append_event("cap_reached", payload={"reason": cap_reached})
+        if status == "failed":
+            self._append_event("run_failed", payload={"error_type": error_type, "error": error})
+        try:
+            run = self.session.query(AgentRun).filter_by(run_id=self.run_id).first()
+            if run is not None:
+                usage = usage or {}
+                run.status = status
+                run.success = status == "success"
+                run.final_answer_text = final_answer_text
+                run.final_message_id = final_message_id
+                run.input_tokens = usage.get("input_tokens")
+                run.output_tokens = usage.get("output_tokens")
+                run.total_tokens = usage.get("total_tokens")
+                run.tool_call_count = self._call_index
+                run.event_count = self._seq + 1  # +1 for the terminal event below
+                run.total_elapsed_ms = total_elapsed_ms
+                run.cap_reached = cap_reached
+                run.error_type = error_type
+                run.error = error
+                run.stack_trace = stack_trace if self.config.mode == "full" else None
+                from sqlalchemy import func as _f
+
+                run.completed_at = _f.now()
+                self.session.add(run)
+                self._safe_commit()
+        except Exception:
+            pass
+        # Always emit the universal terminal marker last. `cap_reached` and
+        # `run_failed` are detail events; `run_completed` closes every timeline.
+        self._append_event("run_completed", payload={"status": status})
+
+    def _record_access(
+        self,
+        *,
+        source_id: str,
+        display_name: Optional[str],
+        access_type: str,
+        access_origin: str,
+        tool_name: Optional[str] = None,
+        tool_call_id: Optional[str] = None,
+        event_seq: Optional[int] = None,
+    ) -> None:
+        try:
+            self.session.add(
+                AgentPatientAccess(
+                    run_id=self.run_id,
+                    tool_call_id=tool_call_id,
+                    event_seq=event_seq,
+                    session_id=self.session_id,
+                    user_id=self.user_id,
+                    source_id=source_id,
+                    display_name=display_name,
+                    access_type=access_type,
+                    access_origin=access_origin,
+                    tool_name=tool_name,
+                )
+            )
+            self._safe_commit()
+        except Exception:
+            pass

--- a/agent/run_logger.py
+++ b/agent/run_logger.py
@@ -1,0 +1,46 @@
+# agent/run_logger.py
+"""AgentRunLogger — full-fidelity logging for agentic runs.
+
+Promoted from agent.audit.AuditLogger. Writes to the app SQLite DB:
+- thrive_agent_run         (one row per question; rollup)
+- thrive_agent_run_event   (append-only ordered timeline; source of truth)
+- thrive_tool_call         (enriched per-tool rows)
+- thrive_agent_patient_access (queryable patient touches)
+
+Mode-aware via AgentLoggingConfig:
+- "full":     verbatim payloads (byte-capped + hashed)
+- "scrubbed": reuses agent.audit.scrub_arguments_json / summarize_result
+- "disabled": logger is never constructed (deps_builder returns None)
+
+Every write is wrapped so logging NEVER breaks a run, and commits per call
+so the SQLite write lock is not held while the agent yields more events.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def extract_source_ids(payload: Any) -> list[tuple[str, Optional[str]]]:
+    """Walk a tool-result payload and return [(source_id, display_name?)].
+
+    Deduped by source_id, order-preserving. Looks for dict keys named
+    'source_id'; pairs with a sibling 'display_name' when present.
+    """
+    found: dict[str, Optional[str]] = {}
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            sid = obj.get("source_id")
+            if isinstance(sid, str) and sid:
+                name = obj.get("display_name")
+                if sid not in found or (found[sid] is None and name):
+                    found[sid] = name if isinstance(name, str) else None
+            for v in obj.values():
+                _walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                _walk(v)
+
+    _walk(payload)
+    return list(found.items())

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -114,8 +114,12 @@ def _usage_dict(run: Any) -> Optional[dict]:
         return None
     if usage is None:
         return None
-    inp = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", None)
-    out = getattr(usage, "output_tokens", None) or getattr(usage, "response_tokens", None)
+    inp = getattr(usage, "input_tokens", None)
+    if inp is None:
+        inp = getattr(usage, "request_tokens", None)
+    out = getattr(usage, "output_tokens", None)
+    if out is None:
+        out = getattr(usage, "response_tokens", None)
     tot = getattr(usage, "total_tokens", None)
     if tot is None and (inp is not None or out is not None):
         tot = (inp or 0) + (out or 0)
@@ -246,15 +250,18 @@ class AgenticRunner:
         logger = getattr(deps, "run_logger", None)
 
         if logger is not None:
-            sel = getattr(deps, "selected_patient", None)
             selected_patient = None
-            if sel is not None:
-                selected_patient = {
-                    "source_id": getattr(sel, "source_id", None),
-                    "display_name": getattr(sel, "display_name", None),
-                    "dob": sel.dob.isoformat() if getattr(sel, "dob", None) else None,
-                    "selection_origin": getattr(sel, "selection_origin", None),
-                }
+            try:
+                sel = getattr(deps, "selected_patient", None)
+                if sel is not None:
+                    selected_patient = {
+                        "source_id": getattr(sel, "source_id", None),
+                        "display_name": getattr(sel, "display_name", None),
+                        "dob": sel.dob.isoformat() if getattr(sel, "dob", None) else None,
+                        "selection_origin": getattr(sel, "selection_origin", None),
+                    }
+            except Exception:
+                selected_patient = None
             logger.start_run(
                 question=question,
                 llm_provider=self._provider_name,
@@ -498,12 +505,7 @@ class AgenticRunner:
 
                                     # Reuse the same dict we built for summarize_result
                                     # so we don't dump the model twice.
-                                    result_payload: dict | None = None
-                                    try:
-                                        if isinstance(summary_input, dict):
-                                            result_payload = summary_input
-                                    except Exception:
-                                        result_payload = None
+                                    result_payload = summary_input if isinstance(summary_input, dict) else None
 
                                     yield ToolCallCompleted(
                                         tool_name=info["tool_name"],

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -11,6 +11,7 @@ Caps are tunable via secrets.toml:
 
 from __future__ import annotations
 import asyncio
+import hashlib
 import json
 from typing import Any, AsyncIterator, Optional
 
@@ -105,6 +106,24 @@ def _normalize_args(raw: Any) -> dict:
     return {}
 
 
+def _usage_dict(run: Any) -> Optional[dict]:
+    """Best-effort token usage from a pydantic-ai run. Returns None if absent."""
+    try:
+        usage = run.usage()
+    except Exception:
+        return None
+    if usage is None:
+        return None
+    inp = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", None)
+    out = getattr(usage, "output_tokens", None) or getattr(usage, "response_tokens", None)
+    tot = getattr(usage, "total_tokens", None)
+    if tot is None and (inp is not None or out is not None):
+        tot = (inp or 0) + (out or 0)
+    if inp is None and out is None and tot is None:
+        return None
+    return {"input_tokens": inp, "output_tokens": out, "total_tokens": tot}
+
+
 def _sync_last_dataframe_to_session_state(
     last_dataframe: Optional[Any],
     session_state: dict,
@@ -135,8 +154,9 @@ class AgenticRunner:
         # for the discriminated-union clinical query. Two retries was
         # too tight — well-routed runs were aborting on a 3rd malformed
         # call. See the regression run notes in the Phase 2 plan.
+        model_obj = model or build_model()
         self._agent: Agent[AgentDeps, AgentResponse] = Agent(
-            model=model or build_model(),
+            model=model_obj,
             deps_type=AgentDeps,
             output_type=AgentResponse,
             system_prompt=SYSTEM_PROMPT,
@@ -144,6 +164,25 @@ class AgenticRunner:
         )
         self._agent.instructions(selection_instructions)
         self._register_tools()
+        self._system_prompt_hash = hashlib.sha256(SYSTEM_PROMPT.encode("utf-8")).hexdigest()
+        tool_names = ",".join(
+            sorted(
+                (
+                    "find_patient",
+                    "get_patient_clinical_data",
+                    "search_knowledge_base",
+                    "list_patient_documents",
+                    "search_codes",
+                    "run_sql",
+                    "make_chart",
+                    "summarize_results",
+                    "search_patients_by_criteria",
+                )
+            )
+        )
+        self._tool_schema_hash = hashlib.sha256(tool_names.encode("utf-8")).hexdigest()
+        self._provider_name = getattr(model_obj, "system", None) or getattr(model_obj, "_system", None)
+        self._model_name = getattr(model_obj, "model_name", None) or str(type(model_obj).__name__)
 
     def _register_tools(self) -> None:
         self._agent.tool(find_patient)
@@ -204,247 +243,342 @@ class AgenticRunner:
         tool_call_cap = _max_tool_calls()
         # tool_call_id -> {tool_name, args, started_at, started_perf}
         pending: dict[str, dict[str, Any]] = {}
+        logger = getattr(deps, "run_logger", None)
 
-        async with self._agent.iter(
-            question,
-            deps=deps,
-            message_history=message_history or None,
-        ) as run:
-            async for node in run:
-                if loop.time() - start > wall_clock_cap:
-                    yield CapReachedEvent(reason="wall_clock")
-                    return
+        if logger is not None:
+            sel = getattr(deps, "selected_patient", None)
+            selected_patient = None
+            if sel is not None:
+                selected_patient = {
+                    "source_id": getattr(sel, "source_id", None),
+                    "display_name": getattr(sel, "display_name", None),
+                    "dob": sel.dob.isoformat() if getattr(sel, "dob", None) else None,
+                    "selection_origin": getattr(sel, "selection_origin", None),
+                }
+            logger.start_run(
+                question=question,
+                llm_provider=self._provider_name,
+                llm_model=self._model_name,
+                selected_patient=selected_patient,
+                group_id=getattr(deps, "group_id", None),
+                parent_run_id=getattr(deps, "parent_run_id", None),
+                resume_reason=getattr(deps, "resume_reason", None),
+                user_message_id=getattr(deps, "user_message_id", None),
+                system_prompt_hash=self._system_prompt_hash,
+                tool_schema_hash=self._tool_schema_hash,
+                message_history=None if not message_history else f"{len(message_history)} prior messages",
+            )
 
-                if Agent.is_model_request_node(node):
-                    # Stream reasoning + plain text deltas from the model so
-                    # the UI shows signs of life instead of dead air. Tool
-                    # call parts are NOT consumed here — they're handled by
-                    # the call_tools_node branch below via the normal
-                    # FunctionToolCallEvent flow.
-                    turn_index += 1
-                    thinking_buf = ""
-                    thinking_started_perf: float | None = None
-                    text_buf = ""
-                    try:
-                        async with node.stream(run.ctx) as req_stream:
-                            async for ev in req_stream:
-                                if isinstance(ev, PartStartEvent):
-                                    if isinstance(ev.part, ThinkingPart):
-                                        if thinking_started_perf is None:
-                                            thinking_started_perf = loop.time()
-                                        initial = ev.part.content or ""
-                                        if initial:
-                                            thinking_buf += initial
-                                            yield ThinkingDeltaEvent(
-                                                delta=initial,
-                                                turn_index=turn_index,
-                                            )
-                                    elif isinstance(ev.part, TextPart):
-                                        initial = ev.part.content or ""
-                                        if initial:
-                                            text_buf += initial
-                                            yield AssistantTextDeltaEvent(
-                                                delta=initial,
-                                                turn_index=turn_index,
-                                            )
-                                elif isinstance(ev, PartDeltaEvent):
-                                    if isinstance(ev.delta, ThinkingPartDelta):
-                                        chunk = ev.delta.content_delta or ""
-                                        if chunk:
+        try:
+            async with self._agent.iter(
+                question,
+                deps=deps,
+                message_history=message_history or None,
+            ) as run:
+                async for node in run:
+                    if loop.time() - start > wall_clock_cap:
+                        if logger is not None:
+                            logger.finalize_run(
+                                status="cap_reached",
+                                final_answer_text=None,
+                                usage=None,
+                                total_elapsed_ms=int((loop.time() - start) * 1000),
+                                cap_reached="wall_clock",
+                            )
+                        yield CapReachedEvent(reason="wall_clock")
+                        return
+
+                    if Agent.is_model_request_node(node):
+                        # Stream reasoning + plain text deltas from the model so
+                        # the UI shows signs of life instead of dead air. Tool
+                        # call parts are NOT consumed here — they're handled by
+                        # the call_tools_node branch below via the normal
+                        # FunctionToolCallEvent flow.
+                        turn_index += 1
+                        thinking_buf = ""
+                        thinking_started_perf: float | None = None
+                        text_buf = ""
+                        try:
+                            async with node.stream(run.ctx) as req_stream:
+                                async for ev in req_stream:
+                                    if isinstance(ev, PartStartEvent):
+                                        if isinstance(ev.part, ThinkingPart):
                                             if thinking_started_perf is None:
                                                 thinking_started_perf = loop.time()
-                                            thinking_buf += chunk
-                                            yield ThinkingDeltaEvent(
-                                                delta=chunk,
-                                                turn_index=turn_index,
-                                            )
-                                    elif isinstance(ev.delta, TextPartDelta):
-                                        chunk = ev.delta.content_delta or ""
-                                        if chunk:
-                                            text_buf += chunk
-                                            yield AssistantTextDeltaEvent(
-                                                delta=chunk,
-                                                turn_index=turn_index,
-                                            )
-                                # PartEndEvent and other events are ignored:
-                                # we close the buffers after the stream exits.
-                    except AssertionError as e:
-                        # FunctionModel test stubs without stream_function raise
-                        # AssertionError mentioning `stream_function` on entry.
-                        # Catch only that exact case so real invariant failures
-                        # in pydantic-ai (malformed deltas, broken adapters)
-                        # still propagate instead of being silently swallowed.
-                        # Iteration advances internally even when we skip the
-                        # streaming surface, so the run completes normally
-                        # without any thinking events for this turn.
-                        if "stream_function" not in str(e):
-                            raise
-                    if thinking_buf:
-                        elapsed_ms = max(
-                            0,
-                            int((loop.time() - (thinking_started_perf or loop.time())) * 1000),
-                        )
-                        yield ThinkingCompletedEvent(
-                            text=thinking_buf,
-                            elapsed_ms=elapsed_ms,
-                            turn_index=turn_index,
-                        )
-                    if text_buf:
-                        # End-of-turn flush so the streamed narration survives
-                        # rerun as a persisted MessageType.TEXT row. Renderer
-                        # dedupes against FinalResponseEvent.response.text to
-                        # avoid double-rendering when the model echoes the
-                        # final answer here as well as via final_result.
-                        yield AssistantTextCompletedEvent(
-                            text=text_buf,
-                            turn_index=turn_index,
-                        )
-                    continue
-
-                if Agent.is_call_tools_node(node):
-                    async with node.stream(run.ctx) as handle_stream:
-                        async for event in handle_stream:
-                            if isinstance(event, FunctionToolCallEvent):
-                                tool_name = event.part.tool_name
-                                if tool_name in _OUTPUT_TOOL_NAMES:
-                                    continue
-                                tool_count += 1
-                                if tool_count > tool_call_cap:
-                                    yield CapReachedEvent(reason="tool_count")
-                                    return
-                                args = _normalize_args(event.part.args)
-                                pending[event.part.tool_call_id] = {
-                                    "tool_name": tool_name,
-                                    "args": args,
-                                    "started_perf": loop.time(),
-                                }
-                                yield ToolCallStarted(
-                                    tool_name=tool_name,
-                                    arguments=args,
+                                            initial = ev.part.content or ""
+                                            if initial:
+                                                thinking_buf += initial
+                                                yield ThinkingDeltaEvent(
+                                                    delta=initial,
+                                                    turn_index=turn_index,
+                                                )
+                                        elif isinstance(ev.part, TextPart):
+                                            initial = ev.part.content or ""
+                                            if initial:
+                                                text_buf += initial
+                                                yield AssistantTextDeltaEvent(
+                                                    delta=initial,
+                                                    turn_index=turn_index,
+                                                )
+                                    elif isinstance(ev, PartDeltaEvent):
+                                        if isinstance(ev.delta, ThinkingPartDelta):
+                                            chunk = ev.delta.content_delta or ""
+                                            if chunk:
+                                                if thinking_started_perf is None:
+                                                    thinking_started_perf = loop.time()
+                                                thinking_buf += chunk
+                                                yield ThinkingDeltaEvent(
+                                                    delta=chunk,
+                                                    turn_index=turn_index,
+                                                )
+                                        elif isinstance(ev.delta, TextPartDelta):
+                                            chunk = ev.delta.content_delta or ""
+                                            if chunk:
+                                                text_buf += chunk
+                                                yield AssistantTextDeltaEvent(
+                                                    delta=chunk,
+                                                    turn_index=turn_index,
+                                                )
+                                    # PartEndEvent and other events are ignored:
+                                    # we close the buffers after the stream exits.
+                        except AssertionError as e:
+                            # FunctionModel test stubs without stream_function raise
+                            # AssertionError mentioning `stream_function` on entry.
+                            # Catch only that exact case so real invariant failures
+                            # in pydantic-ai (malformed deltas, broken adapters)
+                            # still propagate instead of being silently swallowed.
+                            # Iteration advances internally even when we skip the
+                            # streaming surface, so the run completes normally
+                            # without any thinking events for this turn.
+                            if "stream_function" not in str(e):
+                                raise
+                        if thinking_buf:
+                            elapsed_ms = max(
+                                0,
+                                int((loop.time() - (thinking_started_perf or loop.time())) * 1000),
+                            )
+                            yield ThinkingCompletedEvent(
+                                text=thinking_buf,
+                                elapsed_ms=elapsed_ms,
+                                turn_index=turn_index,
+                            )
+                            if logger is not None:
+                                logger.log_event(
+                                    "thinking_completed",
+                                    payload={"text": thinking_buf},
+                                    turn_index=turn_index,
+                                    elapsed_ms=elapsed_ms,
                                 )
-                            elif isinstance(event, FunctionToolResultEvent):
-                                info = pending.pop(event.tool_call_id, None)
-                                if info is None:
-                                    continue
-                                elapsed_ms = max(0, int((loop.time() - info["started_perf"]) * 1000))
-                                result_content = getattr(event.result, "content", None)
-                                # summarize_result wants a dict. Pydantic results
-                                # (ClinicalResult, DocumentIndexResult, …) need to
-                                # be dumped first, otherwise the summarizer falls
-                                # through to the type-tag branch and the audit /
-                                # streamed event lose data_availability and the
-                                # row-count signals downstream graders rely on.
-                                try:
-                                    summary_input = (
-                                        result_content
-                                        if isinstance(result_content, dict)
-                                        else (
-                                            result_content.model_dump(mode="json")
-                                            if hasattr(result_content, "model_dump")
-                                            else result_content
+                        if text_buf:
+                            # End-of-turn flush so the streamed narration survives
+                            # rerun as a persisted MessageType.TEXT row. Renderer
+                            # dedupes against FinalResponseEvent.response.text to
+                            # avoid double-rendering when the model echoes the
+                            # final answer here as well as via final_result.
+                            yield AssistantTextCompletedEvent(
+                                text=text_buf,
+                                turn_index=turn_index,
+                            )
+                            if logger is not None:
+                                logger.log_event(
+                                    "assistant_text_completed",
+                                    payload={"text": text_buf},
+                                    turn_index=turn_index,
+                                )
+                        continue
+
+                    if Agent.is_call_tools_node(node):
+                        async with node.stream(run.ctx) as handle_stream:
+                            async for event in handle_stream:
+                                if isinstance(event, FunctionToolCallEvent):
+                                    tool_name = event.part.tool_name
+                                    if tool_name in _OUTPUT_TOOL_NAMES:
+                                        continue
+                                    tool_count += 1
+                                    if tool_count > tool_call_cap:
+                                        if logger is not None:
+                                            logger.finalize_run(
+                                                status="cap_reached",
+                                                final_answer_text=None,
+                                                usage=None,
+                                                total_elapsed_ms=int((loop.time() - start) * 1000),
+                                                cap_reached="tool_count",
+                                            )
+                                        yield CapReachedEvent(reason="tool_count")
+                                        return
+                                    args = _normalize_args(event.part.args)
+                                    started_event_seq = None
+                                    if logger is not None:
+                                        started_event_seq = logger.log_tool_started(
+                                            tool_name=tool_name,
+                                            tool_call_id=event.part.tool_call_id,
+                                            turn_index=turn_index,
+                                            arguments=args,
                                         )
+                                    pending[event.part.tool_call_id] = {
+                                        "tool_name": tool_name,
+                                        "args": args,
+                                        "started_perf": loop.time(),
+                                        "turn_index": turn_index,
+                                        "started_event_seq": started_event_seq,
+                                    }
+                                    yield ToolCallStarted(
+                                        tool_name=tool_name,
+                                        arguments=args,
                                     )
-                                    summary = summarize_result(info["tool_name"], summary_input)
-                                except Exception:
-                                    summary = f"result_type={type(result_content).__name__}"
-
-                                reliability_note = None
-                                rn_attr = getattr(result_content, "reliability_note", None)
-                                if isinstance(rn_attr, str) and rn_attr.strip():
-                                    reliability_note = rn_attr
-
-                                # Persist to audit (per spec §8.6).
-                                audit = getattr(deps, "audit_logger", None)
-                                if audit is not None:
-                                    selected = getattr(deps, "selected_patient", None)
-                                    sel_src = getattr(selected, "source_id", None) if selected is not None else None
+                                elif isinstance(event, FunctionToolResultEvent):
+                                    info = pending.pop(event.tool_call_id, None)
+                                    if info is None:
+                                        continue
+                                    elapsed_ms = max(0, int((loop.time() - info["started_perf"]) * 1000))
+                                    result_content = getattr(event.result, "content", None)
+                                    # summarize_result wants a dict. Pydantic results
+                                    # (ClinicalResult, DocumentIndexResult, …) need to
+                                    # be dumped first, otherwise the summarizer falls
+                                    # through to the type-tag branch and the streamed
+                                    # event lose data_availability and the
+                                    # row-count signals downstream graders rely on.
                                     try:
-                                        audit.log(
-                                            tool_name=info["tool_name"],
-                                            selected_patient_source_id=sel_src,
-                                            arguments=info["args"],
-                                            result_obj=result_content
+                                        summary_input = (
+                                            result_content
+                                            if isinstance(result_content, dict)
+                                            else (
+                                                result_content.model_dump(mode="json")
+                                                if hasattr(result_content, "model_dump")
+                                                else result_content
+                                            )
+                                        )
+                                        summary = summarize_result(info["tool_name"], summary_input)
+                                    except Exception:
+                                        summary = f"result_type={type(result_content).__name__}"
+
+                                    reliability_note = None
+                                    rn_attr = getattr(result_content, "reliability_note", None)
+                                    if isinstance(rn_attr, str) and rn_attr.strip():
+                                        reliability_note = rn_attr
+
+                                    # Pop SQL once, before logging, so it rides along
+                                    # on the tool row + the card. Tools run
+                                    # sequentially; whatever ran since the last pop is
+                                    # attributable to this tool.
+                                    sql_executed: list[dict] = []
+                                    adapter = getattr(deps, "analytics_db", None)
+                                    if adapter is not None and hasattr(adapter, "pop_sql_log"):
+                                        try:
+                                            sql_executed = adapter.pop_sql_log()
+                                        except Exception:
+                                            sql_executed = []
+
+                                    # Persist the enriched tool-call row (per spec §8.6).
+                                    if logger is not None:
+                                        selected = getattr(deps, "selected_patient", None)
+                                        sel_src = getattr(selected, "source_id", None) if selected is not None else None
+                                        result_for_log = (
+                                            result_content
                                             if isinstance(result_content, dict)
                                             else (
                                                 result_content.model_dump(mode="json")
                                                 if hasattr(result_content, "model_dump")
                                                 else {}
-                                            ),
+                                            )
+                                        )
+                                        logger.log_tool_completed(
+                                            tool_name=info["tool_name"],
+                                            tool_call_id=event.tool_call_id,
+                                            turn_index=info.get("turn_index"),
+                                            arguments=info["args"],
+                                            result_obj=result_for_log,
+                                            sql_executed=sql_executed,
                                             elapsed_ms=elapsed_ms,
                                             success=True,
                                             error=None,
+                                            selected_patient_source_id=sel_src,
+                                            started_event_seq=info.get("started_event_seq"),
                                         )
-                                    except Exception:
-                                        # Audit failure must never break the run.
-                                        pass
 
-                                # Pop the analytics adapter's SQL log so
-                                # the next tool call starts clean. Tools
-                                # run sequentially; whatever ran since the
-                                # last pop is attributable to this tool.
-                                sql_executed: list[dict] = []
-                                adapter = getattr(deps, "analytics_db", None)
-                                if adapter is not None and hasattr(adapter, "pop_sql_log"):
+                                    # Reuse the same dict we built for summarize_result
+                                    # so we don't dump the model twice.
+                                    result_payload: dict | None = None
                                     try:
-                                        sql_executed = adapter.pop_sql_log()
+                                        if isinstance(summary_input, dict):
+                                            result_payload = summary_input
                                     except Exception:
-                                        sql_executed = []
+                                        result_payload = None
 
-                                # Reuse the same dict we built for summarize_result
-                                # so we don't dump the model twice.
-                                result_payload: dict | None = None
-                                try:
-                                    if isinstance(summary_input, dict):
-                                        result_payload = summary_input
-                                except Exception:
-                                    result_payload = None
+                                    yield ToolCallCompleted(
+                                        tool_name=info["tool_name"],
+                                        result_summary=summary,
+                                        success=True,
+                                        elapsed_ms=elapsed_ms,
+                                        error=None,
+                                        reliability_note=reliability_note,
+                                        sql_executed=sql_executed,
+                                        result_payload=result_payload,
+                                    )
 
-                                yield ToolCallCompleted(
-                                    tool_name=info["tool_name"],
-                                    result_summary=summary,
-                                    success=True,
-                                    elapsed_ms=elapsed_ms,
-                                    error=None,
-                                    reliability_note=reliability_note,
-                                    sql_executed=sql_executed,
-                                    result_payload=result_payload,
+                                    # Auto-surface the disambiguation chooser
+                                    # right after find_patient succeeds, so the
+                                    # UI does not depend on the model attaching
+                                    # an artifact to final_result (smaller models
+                                    # often skip that step).
+                                    if info["tool_name"] == "find_patient":
+                                        payload = _to_jsonable(result_content)
+                                        if isinstance(payload, dict) and payload.get("total_unique", 0) > 0:
+                                            yield PatientChooserEvent(payload=payload)
+                                            if logger is not None:
+                                                logger.log_chooser_candidates(payload)
+
+                                    # Auto-surface the cohort sample as a DataFrame
+                                    # after search_patients_by_criteria succeeds, for
+                                    # the same reason as the find_patient chooser:
+                                    # don't depend on the LLM attaching an artifact.
+                                    if info["tool_name"] == "search_patients_by_criteria":
+                                        payload = _to_jsonable(result_content)
+                                        if (
+                                            isinstance(payload, dict)
+                                            and isinstance(payload.get("sample"), list)
+                                            and len(payload["sample"]) > 0
+                                        ):
+                                            yield CohortSampleEvent(payload=payload)
+
+                    elif Agent.is_end_node(node):
+                        output = getattr(node.data, "output", None)
+                        if isinstance(output, AgentResponse):
+                            all_msgs = (
+                                list(run.result.all_messages()) if getattr(run, "result", None) is not None else []
+                            )
+                            try:
+                                import streamlit as st
+
+                                _sync_last_dataframe_to_session_state(deps.last_dataframe, st.session_state)
+                            except Exception:
+                                pass
+                            usage = _usage_dict(run)
+                            if logger is not None:
+                                logger.finalize_run(
+                                    status="success",
+                                    final_answer_text=output.text,
+                                    usage=usage,
+                                    total_elapsed_ms=int((loop.time() - start) * 1000),
+                                    cap_reached=None,
                                 )
+                            yield FinalResponseEvent(response=output, all_messages=all_msgs, usage=usage)
+                            return
+        except Exception as exc:
+            if logger is not None:
+                import traceback
 
-                                # Auto-surface the disambiguation chooser
-                                # right after find_patient succeeds, so the
-                                # UI does not depend on the model attaching
-                                # an artifact to final_result (smaller models
-                                # often skip that step).
-                                if info["tool_name"] == "find_patient":
-                                    payload = _to_jsonable(result_content)
-                                    if isinstance(payload, dict) and payload.get("total_unique", 0) > 0:
-                                        yield PatientChooserEvent(payload=payload)
-
-                                # Auto-surface the cohort sample as a DataFrame
-                                # after search_patients_by_criteria succeeds, for
-                                # the same reason as the find_patient chooser:
-                                # don't depend on the LLM attaching an artifact.
-                                if info["tool_name"] == "search_patients_by_criteria":
-                                    payload = _to_jsonable(result_content)
-                                    if (
-                                        isinstance(payload, dict)
-                                        and isinstance(payload.get("sample"), list)
-                                        and len(payload["sample"]) > 0
-                                    ):
-                                        yield CohortSampleEvent(payload=payload)
-
-                elif Agent.is_end_node(node):
-                    output = getattr(node.data, "output", None)
-                    if isinstance(output, AgentResponse):
-                        all_msgs = list(run.result.all_messages()) if getattr(run, "result", None) is not None else []
-                        try:
-                            import streamlit as st
-
-                            _sync_last_dataframe_to_session_state(deps.last_dataframe, st.session_state)
-                        except Exception:
-                            pass
-                        yield FinalResponseEvent(response=output, all_messages=all_msgs)
-                        return
+                logger.finalize_run(
+                    status="failed",
+                    final_answer_text=None,
+                    usage=None,
+                    total_elapsed_ms=int((loop.time() - start) * 1000),
+                    cap_reached=None,
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                    stack_trace=traceback.format_exc(),
+                )
+            raise
 
         # Fallback: if iteration exited without an End node (shouldn't happen
         # in practice), surface whatever the run produced.
@@ -457,7 +591,17 @@ class AgenticRunner:
                     _sync_last_dataframe_to_session_state(deps.last_dataframe, st.session_state)
                 except Exception:
                     pass
+                usage = _usage_dict(run)
+                if logger is not None:
+                    logger.finalize_run(
+                        status="success",
+                        final_answer_text=output.text,
+                        usage=usage,
+                        total_elapsed_ms=int((loop.time() - start) * 1000),
+                        cap_reached=None,
+                    )
                 yield FinalResponseEvent(
                     response=output,
                     all_messages=list(run.result.all_messages()),
+                    usage=usage,
                 )

--- a/agent/state.py
+++ b/agent/state.py
@@ -48,6 +48,9 @@ class FinalResponseEvent(BaseModel):
     # this module's public surface; the runtime treats it as an opaque
     # list of pydantic-ai ModelMessage instances.
     all_messages: list[Any] = Field(default_factory=list)
+    # Token usage for this run, from pydantic-ai run.usage(). None when the
+    # provider doesn't report usage. Keys: input_tokens, output_tokens, total_tokens.
+    usage: Optional[dict] = None
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/alembic/versions/f95a95e2dbb1_agentic_run_logging.py
+++ b/alembic/versions/f95a95e2dbb1_agentic_run_logging.py
@@ -1,0 +1,211 @@
+"""agentic run logging
+
+Revision ID: f95a95e2dbb1
+Revises: f235fb6fdd7f
+Create Date: 2026-05-27 13:36:06.653614
+
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f95a95e2dbb1"
+down_revision: Union[str, Sequence[str], None] = "f235fb6fdd7f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+    tool_cols = {c["name"] for c in inspector.get_columns("thrive_tool_call")}
+
+    # --- ToolCall enrichment columns (additive, all nullable / defaulted) ---
+    new_tool_columns = [
+        sa.Column("run_id", sa.String(length=36), nullable=True),
+        sa.Column("tool_call_id", sa.String(length=100), nullable=True),
+        sa.Column("call_index", sa.Integer(), nullable=True),
+        sa.Column("turn_index", sa.Integer(), nullable=True),
+        sa.Column("attempt_index", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("started_event_seq", sa.Integer(), nullable=True),
+        sa.Column("completed_event_seq", sa.Integer(), nullable=True),
+        sa.Column("result_json", sa.Text(), nullable=True),
+        sa.Column("result_truncated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("result_bytes", sa.Integer(), nullable=True),
+        sa.Column("result_hash", sa.String(length=64), nullable=True),
+        sa.Column("sql_executed_json", sa.Text(), nullable=True),
+        sa.Column("sql_executed_truncated", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("sql_executed_bytes", sa.Integer(), nullable=True),
+        sa.Column("sql_executed_hash", sa.String(length=64), nullable=True),
+    ]
+    for col in new_tool_columns:
+        if col.name not in tool_cols:
+            op.add_column("thrive_tool_call", col)
+    if "run_id" not in tool_cols:
+        op.create_index("ix_thrive_tool_call_run_id", "thrive_tool_call", ["run_id"])
+        op.create_index("ix_thrive_tool_call_run_call", "thrive_tool_call", ["run_id", "call_index"])
+        op.create_index("ix_thrive_tool_call_tool_call_id", "thrive_tool_call", ["tool_call_id"])
+
+    if "thrive_agent_run" not in existing_tables:
+        op.create_table(
+            "thrive_agent_run",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("run_id", sa.String(length=36), nullable=False),
+            sa.Column("session_id", sa.String(length=64), nullable=False),
+            sa.Column("group_id", sa.String(length=50), nullable=True),
+            sa.Column("parent_run_id", sa.String(length=36), nullable=True),
+            sa.Column("resume_reason", sa.String(length=40), nullable=True),
+            sa.Column("user_message_id", sa.Integer(), nullable=True),
+            sa.Column("final_message_id", sa.Integer(), nullable=True),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("user_role", sa.Integer(), nullable=False),
+            sa.Column("question", sa.Text(), nullable=True),
+            sa.Column("selected_patient_source_id", sa.String(length=50), nullable=True),
+            sa.Column("selected_patient_display_name", sa.String(length=255), nullable=True),
+            sa.Column("selected_patient_dob", sa.String(length=50), nullable=True),
+            sa.Column("selected_patient_selection_origin", sa.String(length=32), nullable=True),
+            sa.Column("llm_provider", sa.String(length=50), nullable=True),
+            sa.Column("llm_model", sa.String(length=100), nullable=True),
+            sa.Column("model_settings_json", sa.Text(), nullable=True),
+            sa.Column("system_prompt_hash", sa.String(length=64), nullable=True),
+            sa.Column("tool_schema_hash", sa.String(length=64), nullable=True),
+            sa.Column("message_history_json", sa.Text(), nullable=True),
+            sa.Column("final_answer_text", sa.Text(), nullable=True),
+            sa.Column("input_tokens", sa.Integer(), nullable=True),
+            sa.Column("output_tokens", sa.Integer(), nullable=True),
+            sa.Column("total_tokens", sa.Integer(), nullable=True),
+            sa.Column("tool_call_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("event_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("total_elapsed_ms", sa.Integer(), nullable=True),
+            sa.Column("cap_reached", sa.String(length=20), nullable=True),
+            sa.Column("status", sa.String(length=20), nullable=False, server_default="open"),
+            sa.Column("success", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("error_type", sa.String(length=100), nullable=True),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.Column("stack_trace", sa.Text(), nullable=True),
+            sa.Column("review_status", sa.String(length=20), nullable=False, server_default="unreviewed"),
+            sa.Column("reviewed_by", sa.Integer(), nullable=True),
+            sa.Column("reviewed_at", sa.TIMESTAMP(), nullable=True),
+            sa.Column("review_notes", sa.Text(), nullable=True),
+            sa.Column("issue_url", sa.Text(), nullable=True),
+            sa.Column("logging_mode", sa.String(length=20), nullable=False, server_default="full"),
+            sa.Column("schema_version", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("app_git_sha", sa.String(length=40), nullable=True),
+            sa.Column("environment", sa.String(length=50), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=False),
+            sa.Column("completed_at", sa.TIMESTAMP(), nullable=True),
+            sa.ForeignKeyConstraint(["user_id"], ["thrive_user.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_thrive_agent_run_run_id", "thrive_agent_run", ["run_id"], unique=True)
+        op.create_index("ix_thrive_agent_run_session_id", "thrive_agent_run", ["session_id"])
+        op.create_index("ix_thrive_agent_run_user_id", "thrive_agent_run", ["user_id"])
+        op.create_index("ix_thrive_agent_run_created_at", "thrive_agent_run", ["created_at"])
+        op.create_index("ix_thrive_agent_run_group_id", "thrive_agent_run", ["group_id"])
+        op.create_index("ix_thrive_agent_run_selected_patient", "thrive_agent_run", ["selected_patient_source_id"])
+        op.create_index("ix_thrive_agent_run_status", "thrive_agent_run", ["status"])
+        op.create_index("ix_thrive_agent_run_review_status", "thrive_agent_run", ["review_status"])
+
+    if "thrive_agent_run_event" not in existing_tables:
+        op.create_table(
+            "thrive_agent_run_event",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("run_id", sa.String(length=36), nullable=False),
+            sa.Column("seq", sa.Integer(), nullable=False),
+            sa.Column("event_type", sa.String(length=50), nullable=False),
+            sa.Column("turn_index", sa.Integer(), nullable=True),
+            sa.Column("tool_call_id", sa.String(length=100), nullable=True),
+            sa.Column("tool_name", sa.String(length=64), nullable=True),
+            sa.Column("payload_json", sa.Text(), nullable=True),
+            sa.Column("payload_summary", sa.Text(), nullable=True),
+            sa.Column("payload_truncated", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("payload_bytes", sa.Integer(), nullable=True),
+            sa.Column("payload_hash", sa.String(length=64), nullable=True),
+            sa.Column("elapsed_ms", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_thrive_agent_run_event_run_seq", "thrive_agent_run_event", ["run_id", "seq"], unique=True)
+        op.create_index("ix_thrive_agent_run_event_run_id", "thrive_agent_run_event", ["run_id"])
+        op.create_index("ix_thrive_agent_run_event_type", "thrive_agent_run_event", ["event_type"])
+        op.create_index("ix_thrive_agent_run_event_tool_name", "thrive_agent_run_event", ["tool_name"])
+        op.create_index("ix_thrive_agent_run_event_created_at", "thrive_agent_run_event", ["created_at"])
+
+    if "thrive_agent_patient_access" not in existing_tables:
+        op.create_table(
+            "thrive_agent_patient_access",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("run_id", sa.String(length=36), nullable=True),
+            sa.Column("tool_call_id", sa.String(length=100), nullable=True),
+            sa.Column("event_seq", sa.Integer(), nullable=True),
+            sa.Column("session_id", sa.String(length=64), nullable=False),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("source_id", sa.String(length=50), nullable=False),
+            sa.Column("display_name", sa.String(length=255), nullable=True),
+            sa.Column("access_type", sa.String(length=40), nullable=False),
+            sa.Column("access_origin", sa.String(length=40), nullable=False),
+            sa.Column("tool_name", sa.String(length=64), nullable=True),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["thrive_user.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_thrive_agent_patient_access_source", "thrive_agent_patient_access", ["source_id"])
+        op.create_index("ix_thrive_agent_patient_access_user", "thrive_agent_patient_access", ["user_id"])
+        op.create_index("ix_thrive_agent_patient_access_run", "thrive_agent_patient_access", ["run_id"])
+        op.create_index("ix_thrive_agent_patient_access_tool_call", "thrive_agent_patient_access", ["tool_call_id"])
+        op.create_index("ix_thrive_agent_patient_access_created", "thrive_agent_patient_access", ["created_at"])
+        op.create_index("ix_thrive_agent_patient_access_type", "thrive_agent_patient_access", ["access_type"])
+
+    if "thrive_patient_selection_event" not in existing_tables:
+        op.create_table(
+            "thrive_patient_selection_event",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("session_id", sa.String(length=64), nullable=False),
+            sa.Column("run_id", sa.String(length=36), nullable=True),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("source_id", sa.String(length=50), nullable=True),
+            sa.Column("previous_source_id", sa.String(length=50), nullable=True),
+            sa.Column("display_name", sa.String(length=255), nullable=True),
+            sa.Column("selection_origin", sa.String(length=32), nullable=False),
+            sa.Column("action", sa.String(length=20), nullable=False),
+            sa.Column("created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(["user_id"], ["thrive_user.id"]),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        op.create_index("ix_thrive_patient_selection_session", "thrive_patient_selection_event", ["session_id"])
+        op.create_index("ix_thrive_patient_selection_user", "thrive_patient_selection_event", ["user_id"])
+        op.create_index("ix_thrive_patient_selection_source", "thrive_patient_selection_event", ["source_id"])
+        op.create_index("ix_thrive_patient_selection_created", "thrive_patient_selection_event", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("thrive_patient_selection_event")
+    op.drop_table("thrive_agent_patient_access")
+    op.drop_table("thrive_agent_run_event")
+    op.drop_table("thrive_agent_run")
+    with op.batch_alter_table("thrive_tool_call") as batch:
+        for ix in ("ix_thrive_tool_call_tool_call_id", "ix_thrive_tool_call_run_call", "ix_thrive_tool_call_run_id"):
+            batch.drop_index(ix)
+        for col in (
+            "sql_executed_hash",
+            "sql_executed_bytes",
+            "sql_executed_truncated",
+            "sql_executed_json",
+            "result_hash",
+            "result_bytes",
+            "result_truncated",
+            "result_json",
+            "completed_event_seq",
+            "started_event_seq",
+            "attempt_index",
+            "turn_index",
+            "call_index",
+            "tool_call_id",
+            "run_id",
+        ):
+            batch.drop_column(col)

--- a/app.py
+++ b/app.py
@@ -87,8 +87,14 @@ if st.session_state.get("user_role") == 0:  # RoleTypeEnum.ADMIN.value = 0
         title="Feedback Dashboard",
         icon="💬",
     )
+    agent_analytics_page = st.Page(
+        page="views/agent_analytics.py",
+        title="Agentic Analytics",
+        icon="🧠",
+    )
     pages.append(analytics_page)
     pages.append(feedback_page)
+    pages.append(agent_analytics_page)
 
 pg = st.navigation(pages=pages)
 

--- a/orm/agent_logging_functions.py
+++ b/orm/agent_logging_functions.py
@@ -290,3 +290,33 @@ def log_agent_run_viewed(admin_id: int | None, run_id: str) -> bool:
     except Exception as e:
         logger.warning("log_agent_run_viewed failed: %s", e)
         return False
+
+
+def prune_agent_logs(retention_days: int) -> dict:
+    """Delete agent logs older than retention_days. Children before parents.
+    retention_days <= 0 is a no-op (keep indefinitely). Returns counts deleted."""
+    if retention_days <= 0:
+        return {"runs": 0, "events": 0, "tool_calls": 0, "patient_access": 0}
+    cutoff = datetime.now() - timedelta(days=retention_days)
+    counts = {"runs": 0, "events": 0, "tool_calls": 0, "patient_access": 0}
+    try:
+        with SessionLocal() as s:
+            old_ids = [r.run_id for r in s.query(AgentRun.run_id).filter(AgentRun.created_at < cutoff).all()]
+            if not old_ids:
+                return counts
+            counts["events"] = (
+                s.query(AgentRunEvent).filter(AgentRunEvent.run_id.in_(old_ids)).delete(synchronize_session=False)
+            )
+            counts["tool_calls"] = (
+                s.query(ToolCall).filter(ToolCall.run_id.in_(old_ids)).delete(synchronize_session=False)
+            )
+            counts["patient_access"] = (
+                s.query(AgentPatientAccess)
+                .filter(AgentPatientAccess.run_id.in_(old_ids))
+                .delete(synchronize_session=False)
+            )
+            counts["runs"] = s.query(AgentRun).filter(AgentRun.run_id.in_(old_ids)).delete(synchronize_session=False)
+            s.commit()
+    except Exception as e:
+        logger.warning("prune_agent_logs failed: %s", e)
+    return counts

--- a/orm/agent_logging_functions.py
+++ b/orm/agent_logging_functions.py
@@ -1,0 +1,68 @@
+"""Read + pin-event write helpers for agentic run logging."""
+
+from __future__ import annotations
+
+from orm.models import AgentPatientAccess, PatientSelectionEvent, SessionLocal
+from utils.quick_logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def log_patient_selection(
+    *,
+    session_id: str,
+    user_id: int,
+    source_id: str | None,
+    display_name: str | None,
+    selection_origin: str,
+    action: str,
+    previous_source_id: str | None = None,
+    run_id: str | None = None,
+) -> None:
+    """Record a pin set/clear.
+
+    Always writes PatientSelectionEvent. Writes AgentPatientAccess for both
+    selection_chosen and selection_cleared so the Patient Access tab can answer
+    who selected or cleared a pinned patient without scanning event JSON.
+    """
+    try:
+        with SessionLocal() as session:
+            session.add(
+                PatientSelectionEvent(
+                    session_id=session_id,
+                    run_id=run_id,
+                    user_id=user_id,
+                    source_id=source_id,
+                    previous_source_id=previous_source_id,
+                    display_name=display_name,
+                    selection_origin=selection_origin,
+                    action=action,
+                )
+            )
+            if action == "selected" and source_id:
+                session.add(
+                    AgentPatientAccess(
+                        run_id=run_id,
+                        session_id=session_id,
+                        user_id=user_id,
+                        source_id=source_id,
+                        display_name=display_name,
+                        access_type="selection_chosen",
+                        access_origin=selection_origin,
+                    )
+                )
+            if action == "cleared" and previous_source_id:
+                session.add(
+                    AgentPatientAccess(
+                        run_id=run_id,
+                        session_id=session_id,
+                        user_id=user_id,
+                        source_id=previous_source_id,
+                        display_name=None,
+                        access_type="selection_cleared",
+                        access_origin=selection_origin,
+                    )
+                )
+            session.commit()
+    except Exception as e:
+        logger.warning("Failed to log patient selection: %s", e)

--- a/orm/agent_logging_functions.py
+++ b/orm/agent_logging_functions.py
@@ -2,7 +2,20 @@
 
 from __future__ import annotations
 
-from orm.models import AgentPatientAccess, PatientSelectionEvent, SessionLocal
+from datetime import datetime, timedelta
+
+from sqlalchemy import case
+from sqlalchemy import func as sqla_func
+
+from orm.models import (
+    AdminAction,
+    AgentPatientAccess,
+    AgentRun,
+    AgentRunEvent,
+    PatientSelectionEvent,
+    SessionLocal,
+    ToolCall,
+)
 from utils.quick_logger import get_logger
 
 logger = get_logger(__name__)
@@ -66,3 +79,214 @@ def log_patient_selection(
             session.commit()
     except Exception as e:
         logger.warning("Failed to log patient selection: %s", e)
+
+
+def get_agent_run_stats(days: int = 30) -> dict:
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            base = s.query(AgentRun).filter(AgentRun.created_at >= since)
+            total = base.count() or 0
+            successes = base.filter(AgentRun.success == True).count() or 0  # noqa: E712
+            capped = base.filter(AgentRun.status == "cap_reached").count() or 0
+            avg_tools = (
+                s.query(sqla_func.avg(AgentRun.tool_call_count)).filter(AgentRun.created_at >= since).scalar() or 0
+            )
+            avg_latency = (
+                s.query(sqla_func.avg(AgentRun.total_elapsed_ms)).filter(AgentRun.created_at >= since).scalar() or 0
+            )
+            total_tokens = (
+                s.query(sqla_func.sum(AgentRun.total_tokens)).filter(AgentRun.created_at >= since).scalar() or 0
+            )
+            return {
+                "total_runs": total,
+                "success_rate": round(successes / total * 100, 1) if total else 0.0,
+                "cap_rate": round(capped / total * 100, 1) if total else 0.0,
+                "avg_tool_calls": round(float(avg_tools), 2),
+                "avg_latency_ms": float(avg_latency),
+                "total_tokens": int(total_tokens),
+            }
+    except Exception as e:
+        logger.warning("get_agent_run_stats failed: %s", e)
+        return {
+            "total_runs": 0,
+            "success_rate": 0.0,
+            "cap_rate": 0.0,
+            "avg_tool_calls": 0.0,
+            "avg_latency_ms": 0.0,
+            "total_tokens": 0,
+        }
+
+
+def get_recent_agent_runs(days: int = 7, limit: int = 100) -> list[dict]:
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            rows = (
+                s.query(AgentRun)
+                .filter(AgentRun.created_at >= since)
+                .order_by(AgentRun.created_at.desc())
+                .limit(limit)
+                .all()
+            )
+            return [
+                {
+                    "run_id": r.run_id,
+                    "created_at": r.created_at,
+                    "user_id": r.user_id,
+                    "question": r.question,
+                    "llm_model": r.llm_model,
+                    "selected_patient_source_id": r.selected_patient_source_id,
+                    "selected_patient_display_name": r.selected_patient_display_name,
+                    "tool_call_count": r.tool_call_count,
+                    "total_elapsed_ms": r.total_elapsed_ms,
+                    "total_tokens": r.total_tokens,
+                    "status": r.status,
+                    "cap_reached": r.cap_reached,
+                    "review_status": r.review_status,
+                }
+                for r in rows
+            ]
+    except Exception as e:
+        logger.warning("get_recent_agent_runs failed: %s", e)
+        return []
+
+
+def get_agent_run_detail(run_id: str) -> dict:
+    try:
+        with SessionLocal() as s:
+            run = s.query(AgentRun).filter_by(run_id=run_id).first()
+            if run is None:
+                return {}
+            events = s.query(AgentRunEvent).filter_by(run_id=run_id).order_by(AgentRunEvent.seq).all()
+            tools = s.query(ToolCall).filter_by(run_id=run_id).order_by(ToolCall.call_index).all()
+            access = s.query(AgentPatientAccess).filter_by(run_id=run_id).all()
+            return {
+                "run": {c.name: getattr(run, c.name) for c in run.__table__.columns},
+                "events": [{c.name: getattr(e, c.name) for c in e.__table__.columns} for e in events],
+                "tool_calls": [{c.name: getattr(t, c.name) for c in t.__table__.columns} for t in tools],
+                "patient_access": [{c.name: getattr(a, c.name) for c in a.__table__.columns} for a in access],
+            }
+    except Exception as e:
+        logger.warning("get_agent_run_detail failed: %s", e)
+        return {}
+
+
+def get_tool_breakdown(days: int = 30) -> list[dict]:
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            rows = (
+                s.query(
+                    ToolCall.tool_name,
+                    sqla_func.count(ToolCall.id).label("count"),
+                    sqla_func.avg(ToolCall.elapsed_ms).label("avg_ms"),
+                    sqla_func.sum(case((ToolCall.success == True, 0), else_=1)).label("failures"),  # noqa: E712
+                )
+                .filter(ToolCall.created_at >= since, ToolCall.run_id.isnot(None))
+                .group_by(ToolCall.tool_name)
+                .order_by(sqla_func.count(ToolCall.id).desc())
+                .all()
+            )
+            return [
+                {
+                    "tool_name": r.tool_name,
+                    "count": r.count,
+                    "avg_ms": float(r.avg_ms or 0),
+                    "failures": int(r.failures or 0),
+                }
+                for r in rows
+            ]
+    except Exception as e:
+        logger.warning("get_tool_breakdown failed: %s", e)
+        return []
+
+
+def get_patient_access(
+    source_id: str | None = None, user_id: int | None = None, days: int = 30, limit: int = 200
+) -> list[dict]:
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            q = s.query(AgentPatientAccess).filter(AgentPatientAccess.created_at >= since)
+            if source_id:
+                q = q.filter(AgentPatientAccess.source_id == source_id)
+            if user_id:
+                q = q.filter(AgentPatientAccess.user_id == user_id)
+            rows = q.order_by(AgentPatientAccess.created_at.desc()).limit(limit).all()
+            return [{c.name: getattr(a, c.name) for c in a.__table__.columns} for a in rows]
+    except Exception as e:
+        logger.warning("get_patient_access failed: %s", e)
+        return []
+
+
+def get_runs_over_time(days: int = 30) -> list[dict]:
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            date_expr = sqla_func.strftime("%Y-%m-%d", AgentRun.created_at)
+            rows = (
+                s.query(
+                    date_expr.label("date"),
+                    sqla_func.count(AgentRun.id).label("runs"),
+                    sqla_func.avg(AgentRun.total_elapsed_ms).label("avg_latency"),
+                )
+                .filter(AgentRun.created_at >= since)
+                .group_by(date_expr)
+                .order_by(date_expr)
+                .all()
+            )
+            return [{"date": r.date, "runs": r.runs, "avg_latency": float(r.avg_latency or 0)} for r in rows]
+    except Exception as e:
+        logger.warning("get_runs_over_time failed: %s", e)
+        return []
+
+
+def set_run_review_status(
+    run_id: str,
+    *,
+    review_status: str,
+    reviewed_by: int | None = None,
+    notes: str | None = None,
+    issue_url: str | None = None,
+) -> bool:
+    try:
+        with SessionLocal() as s:
+            run = s.query(AgentRun).filter_by(run_id=run_id).first()
+            if run is None:
+                return False
+            run.review_status = review_status
+            run.reviewed_by = reviewed_by
+            run.reviewed_at = datetime.now()
+            if notes is not None:
+                run.review_notes = notes
+            if issue_url is not None:
+                run.issue_url = issue_url
+            s.commit()
+            return True
+    except Exception as e:
+        logger.warning("set_run_review_status failed: %s", e)
+        return False
+
+
+def log_agent_run_viewed(admin_id: int | None, run_id: str) -> bool:
+    """Audit that an admin opened a full-fidelity run trace."""
+    if admin_id is None:
+        return False
+    try:
+        with SessionLocal() as s:
+            s.add(
+                AdminAction(
+                    admin_id=admin_id,
+                    action_type="agent_run_view",
+                    target_entity_type="agent_run",
+                    target_entity_id=run_id,
+                    description=f"Viewed agentic run trace {run_id}",
+                    success=True,
+                )
+            )
+            s.commit()
+            return True
+    except Exception as e:
+        logger.warning("log_agent_run_viewed failed: %s", e)
+        return False

--- a/orm/models.py
+++ b/orm/models.py
@@ -505,6 +505,9 @@ class ToolCall(Base):
         Index("ix_thrive_tool_call_created_at", "created_at"),
         Index("ix_thrive_tool_call_tool_name", "tool_name"),
         Index("ix_thrive_tool_call_selected_patient", "selected_patient_source_id"),
+        Index("ix_thrive_tool_call_run_id", "run_id"),
+        Index("ix_thrive_tool_call_run_call", "run_id", "call_index"),
+        Index("ix_thrive_tool_call_tool_call_id", "tool_call_id"),
     )
     id = Column(Integer, primary_key=True)
     session_id = Column(String(64), nullable=False)
@@ -517,6 +520,169 @@ class ToolCall(Base):
     elapsed_ms = Column(Integer, nullable=False)
     success = Column(Boolean, nullable=False)
     error = Column(Text, nullable=True)
+    # --- Agentic run logging enrichment (2026-05 design) ---
+    run_id = Column(String(36), nullable=True)
+    tool_call_id = Column(String(100), nullable=True)
+    call_index = Column(Integer, nullable=True)
+    turn_index = Column(Integer, nullable=True)
+    attempt_index = Column(Integer, nullable=False, default=1)
+    started_event_seq = Column(Integer, nullable=True)
+    completed_event_seq = Column(Integer, nullable=True)
+    result_json = Column(Text, nullable=True)
+    result_truncated = Column(Boolean, nullable=False, default=False)
+    result_bytes = Column(Integer, nullable=True)
+    result_hash = Column(String(64), nullable=True)
+    sql_executed_json = Column(Text, nullable=True)
+    sql_executed_truncated = Column(Boolean, nullable=False, default=False)
+    sql_executed_bytes = Column(Integer, nullable=True)
+    sql_executed_hash = Column(String(64), nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+
+class AgentRun(Base):
+    """One row per agentic question/turn. Query-friendly rollup over the
+    append-only AgentRunEvent timeline."""
+
+    __tablename__ = "thrive_agent_run"
+    __table_args__ = (
+        Index("ix_thrive_agent_run_run_id", "run_id", unique=True),
+        Index("ix_thrive_agent_run_session_id", "session_id"),
+        Index("ix_thrive_agent_run_user_id", "user_id"),
+        Index("ix_thrive_agent_run_created_at", "created_at"),
+        Index("ix_thrive_agent_run_group_id", "group_id"),
+        Index("ix_thrive_agent_run_selected_patient", "selected_patient_source_id"),
+        Index("ix_thrive_agent_run_status", "status"),
+        Index("ix_thrive_agent_run_review_status", "review_status"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    run_id = Column(String(36), nullable=False)
+    session_id = Column(String(64), nullable=False)
+    group_id = Column(String(50), nullable=True)
+    parent_run_id = Column(String(36), nullable=True)
+    resume_reason = Column(String(40), nullable=True)
+    user_message_id = Column(Integer, nullable=True)
+    final_message_id = Column(Integer, nullable=True)
+    user_id = Column(Integer, ForeignKey("thrive_user.id"), nullable=False)
+    user_role = Column(Integer, nullable=False)
+    question = Column(Text, nullable=True)
+
+    selected_patient_source_id = Column(String(50), nullable=True)
+    selected_patient_display_name = Column(String(255), nullable=True)
+    selected_patient_dob = Column(String(50), nullable=True)
+    selected_patient_selection_origin = Column(String(32), nullable=True)
+
+    llm_provider = Column(String(50), nullable=True)
+    llm_model = Column(String(100), nullable=True)
+    model_settings_json = Column(Text, nullable=True)
+    system_prompt_hash = Column(String(64), nullable=True)
+    tool_schema_hash = Column(String(64), nullable=True)
+    message_history_json = Column(Text, nullable=True)
+
+    final_answer_text = Column(Text, nullable=True)
+    input_tokens = Column(Integer, nullable=True)
+    output_tokens = Column(Integer, nullable=True)
+    total_tokens = Column(Integer, nullable=True)
+    tool_call_count = Column(Integer, nullable=False, default=0)
+    event_count = Column(Integer, nullable=False, default=0)
+    total_elapsed_ms = Column(Integer, nullable=True)
+    cap_reached = Column(String(20), nullable=True)
+    status = Column(String(20), nullable=False, default="open")
+    success = Column(Boolean, nullable=False, default=False)
+    error_type = Column(String(100), nullable=True)
+    error = Column(Text, nullable=True)
+    stack_trace = Column(Text, nullable=True)
+
+    review_status = Column(String(20), nullable=False, default="unreviewed")
+    reviewed_by = Column(Integer, nullable=True)
+    reviewed_at = Column(TIMESTAMP, nullable=True)
+    review_notes = Column(Text, nullable=True)
+    issue_url = Column(Text, nullable=True)
+
+    logging_mode = Column(String(20), nullable=False, default="full")
+    schema_version = Column(Integer, nullable=False, default=1)
+    app_git_sha = Column(String(40), nullable=True)
+    environment = Column(String(50), nullable=True)
+
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+    completed_at = Column(TIMESTAMP, nullable=True)
+
+
+class AgentRunEvent(Base):
+    """Append-only ordered timeline; the source of truth for the inspector."""
+
+    __tablename__ = "thrive_agent_run_event"
+    __table_args__ = (
+        Index("ix_thrive_agent_run_event_run_seq", "run_id", "seq", unique=True),
+        Index("ix_thrive_agent_run_event_run_id", "run_id"),
+        Index("ix_thrive_agent_run_event_type", "event_type"),
+        Index("ix_thrive_agent_run_event_tool_name", "tool_name"),
+        Index("ix_thrive_agent_run_event_created_at", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    run_id = Column(String(36), nullable=False)
+    seq = Column(Integer, nullable=False)
+    event_type = Column(String(50), nullable=False)
+    turn_index = Column(Integer, nullable=True)
+    tool_call_id = Column(String(100), nullable=True)
+    tool_name = Column(String(64), nullable=True)
+    payload_json = Column(Text, nullable=True)
+    payload_summary = Column(Text, nullable=True)
+    payload_truncated = Column(Boolean, nullable=False, default=False)
+    payload_bytes = Column(Integer, nullable=True)
+    payload_hash = Column(String(64), nullable=True)
+    elapsed_ms = Column(Integer, nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+
+class AgentPatientAccess(Base):
+    """Queryable record of every patient 'touch' for the Patient Access tab."""
+
+    __tablename__ = "thrive_agent_patient_access"
+    __table_args__ = (
+        Index("ix_thrive_agent_patient_access_source", "source_id"),
+        Index("ix_thrive_agent_patient_access_user", "user_id"),
+        Index("ix_thrive_agent_patient_access_run", "run_id"),
+        Index("ix_thrive_agent_patient_access_tool_call", "tool_call_id"),
+        Index("ix_thrive_agent_patient_access_created", "created_at"),
+        Index("ix_thrive_agent_patient_access_type", "access_type"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    run_id = Column(String(36), nullable=True)
+    tool_call_id = Column(String(100), nullable=True)
+    event_seq = Column(Integer, nullable=True)
+    session_id = Column(String(64), nullable=False)
+    user_id = Column(Integer, ForeignKey("thrive_user.id"), nullable=False)
+    source_id = Column(String(50), nullable=False)
+    display_name = Column(String(255), nullable=True)
+    access_type = Column(String(40), nullable=False)
+    access_origin = Column(String(40), nullable=False)
+    tool_name = Column(String(64), nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+
+class PatientSelectionEvent(Base):
+    """One row each time a patient pin is set or cleared."""
+
+    __tablename__ = "thrive_patient_selection_event"
+    __table_args__ = (
+        Index("ix_thrive_patient_selection_session", "session_id"),
+        Index("ix_thrive_patient_selection_user", "user_id"),
+        Index("ix_thrive_patient_selection_source", "source_id"),
+        Index("ix_thrive_patient_selection_created", "created_at"),
+    )
+
+    id = Column(Integer, primary_key=True)
+    session_id = Column(String(64), nullable=False)
+    run_id = Column(String(36), nullable=True)
+    user_id = Column(Integer, ForeignKey("thrive_user.id"), nullable=False)
+    source_id = Column(String(50), nullable=True)
+    previous_source_id = Column(String(50), nullable=True)
+    display_name = Column(String(255), nullable=True)
+    selection_origin = Column(String(32), nullable=False)
+    action = Column(String(20), nullable=False)
     created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
 
 

--- a/scripts/agent_replay.py
+++ b/scripts/agent_replay.py
@@ -39,7 +39,6 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 
 from datetime import date, datetime  # noqa: E402
 
-from agent.audit import AuditLogger  # noqa: E402
 from agent.db.analytics_adapter import AnalyticsDbAdapter  # noqa: E402
 from agent.deps import AgentDeps, SelectedPatient  # noqa: E402
 from agent.rag.chroma_adapter import ChromaRagAdapter  # noqa: E402
@@ -176,12 +175,7 @@ def _build_deps(role: str) -> AgentDeps:
         analytics_db=analytics_db,
         rag=rag,
         sqlite_session=sqlite_session,
-        audit_logger=AuditLogger(
-            session=sqlite_session,
-            session_id=session_id,
-            user_id=0,
-            user_role=int(user_role.value),
-        ),
+        run_logger=None,
     )
 
 

--- a/scripts/run_representative_regression.py
+++ b/scripts/run_representative_regression.py
@@ -39,7 +39,6 @@ from agent.state import (
     ToolCallStarted,
     ToolCallCompleted,
 )
-from unittest.mock import MagicMock
 
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -104,7 +103,7 @@ def _build_live_deps() -> AgentDeps:
         analytics_db=_build_synthetic_analytics_db(),
         rag=rag,
         sqlite_session=SessionLocal(),
-        audit_logger=MagicMock(),  # regression runs don't write to audit
+        run_logger=None,
     )
 
 

--- a/tests/agent/flows/test_cohort_flow.py
+++ b/tests/agent/flows/test_cohort_flow.py
@@ -56,7 +56,7 @@ def _deps(engine) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/flows/test_disambiguation_flow.py
+++ b/tests/agent/flows/test_disambiguation_flow.py
@@ -101,7 +101,7 @@ def _deps(engine) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/flows/test_geo_cohort_e2e.py
+++ b/tests/agent/flows/test_geo_cohort_e2e.py
@@ -58,7 +58,7 @@ def _deps(engine) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/flows/test_message_history_threading.py
+++ b/tests/agent/flows/test_message_history_threading.py
@@ -85,7 +85,7 @@ def _deps(engine) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/flows/test_run_logging_e2e.py
+++ b/tests/agent/flows/test_run_logging_e2e.py
@@ -1,0 +1,98 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from agent.db.analytics_adapter import AnalyticsDbAdapter
+from agent.deps import AgentDeps
+from agent.logging_config import AgentLoggingConfig
+from agent.run_logger import AgentRunLogger
+from agent.runner import AgenticRunner
+from orm.models import AgentRun, AgentRunEvent, Base, ToolCall
+
+
+_SQL_FILE = Path(__file__).parents[2] / "agent" / "redshift_synthetic.sql"
+
+
+def _make_threadsafe_db():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    sql = _SQL_FILE.read_text()
+    with engine.begin() as conn:
+        for stmt in sql.split(";"):
+            stmt = stmt.strip()
+            if stmt:
+                conn.execute(text(stmt))
+    return engine
+
+
+def _scripted_llm():
+    turn = {"n": 0}
+
+    async def behavior(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        turn["n"] += 1
+        if turn["n"] == 1:
+            return ModelResponse(
+                parts=[ToolCallPart(tool_name="find_patient", args={"last_name": "Smith"}, tool_call_id="call-1")]
+            )
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"text": "Found 3 patients.", "followups": [], "clear_selection": False, "cap_reached": False},
+                    tool_call_id="call-2",
+                )
+            ]
+        )
+
+    return FunctionModel(behavior, model_name="scripted")
+
+
+@pytest.fixture
+def logged_deps():
+    app_engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(app_engine)
+    session = sessionmaker(bind=app_engine)()
+    run_logger = AgentRunLogger(
+        session=session, config=AgentLoggingConfig(), run_id="run-e2e", session_id="s1", user_id=1, user_role=1
+    )
+    deps = AgentDeps(
+        user_id=1,
+        user_role=MagicMock(value=1),
+        session_id="s1",
+        selected_patient=None,
+        last_dataframe=None,
+        last_sql=None,
+        last_query_meta=None,
+        analytics_db=AnalyticsDbAdapter(engine=_make_threadsafe_db(), dialect="sqlite"),
+        rag=MagicMock(),
+        sqlite_session=session,
+        run_logger=run_logger,
+        group_id="g1",
+        user_message_id=None,
+        parent_run_id=None,
+        resume_reason=None,
+    )
+    runner = AgenticRunner(model=_scripted_llm())
+    return session, deps, runner
+
+
+@pytest.mark.asyncio
+async def test_full_run_persists_run_events_and_toolcalls(logged_deps):
+    session, deps, runner = logged_deps
+    async for _ in runner.stream("find patient Ann", deps=deps):
+        pass
+    run = session.query(AgentRun).filter_by(run_id=deps.run_logger.run_id).one()
+    assert run.status in ("success", "cap_reached")
+    events = session.query(AgentRunEvent).order_by(AgentRunEvent.seq).all()
+    assert events[0].event_type == "run_started"
+    assert events[-1].event_type == "run_completed"
+    assert session.query(ToolCall).filter_by(run_id=run.run_id).count() >= 1

--- a/tests/agent/flows/test_streaming_events.py
+++ b/tests/agent/flows/test_streaming_events.py
@@ -78,7 +78,7 @@ def _scripted_llm():
     return FunctionModel(behavior, model_name="scripted")
 
 
-def _deps(engine, audit_logger=None) -> AgentDeps:
+def _deps(engine, run_logger=None) -> AgentDeps:
     return AgentDeps(
         user_id=1,
         user_role=MagicMock(value=1),
@@ -90,7 +90,7 @@ def _deps(engine, audit_logger=None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=audit_logger or MagicMock(),
+        run_logger=run_logger or MagicMock(),
     )
 
 
@@ -189,19 +189,19 @@ async def test_chooser_event_fires_before_final_response():
 
 
 @pytest.mark.asyncio
-async def test_stream_calls_audit_logger_once_per_tool_call():
+async def test_stream_calls_run_logger_once_per_tool_call():
     engine = _make_threadsafe_db()
-    audit_logger = MagicMock()
+    run_logger = MagicMock()
     runner = AgenticRunner(model=_scripted_llm())
-    deps = _deps(engine, audit_logger=audit_logger)
+    deps = _deps(engine, run_logger=run_logger)
     async for _ in runner.stream("Smith", deps=deps):
         pass
 
-    # Exactly one audit call for find_patient. final_result is the
-    # output-bearing tool and should not be audited.
-    audited_tools = [c.kwargs.get("tool_name") for c in audit_logger.log.call_args_list]
-    assert "find_patient" in audited_tools
-    assert "final_result" not in audited_tools
+    # Exactly one log_tool_completed call for find_patient. final_result is the
+    # output-bearing tool and should not be logged as a tool call.
+    logged_tools = [c.kwargs.get("tool_name") for c in run_logger.log_tool_completed.call_args_list]
+    assert logged_tools == ["find_patient"]
+    assert "final_result" not in logged_tools
 
 
 @pytest.mark.asyncio
@@ -236,7 +236,7 @@ async def test_completed_event_carries_reliability_note():
     runner._agent.tool(stub_tool)
 
     deps = MagicMock(spec=AgentDeps)
-    deps.audit_logger = None
+    deps.run_logger = None
     deps.selected_patient = None
 
     events = []

--- a/tests/agent/flows/test_tool_call_observability.py
+++ b/tests/agent/flows/test_tool_call_observability.py
@@ -84,7 +84,7 @@ def _deps(engine):
         analytics_db=AnalyticsDbAdapter(engine=engine, dialect="sqlite"),
         rag=MagicMock(),
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/test_deps.py
+++ b/tests/agent/test_deps.py
@@ -39,7 +39,7 @@ def test_agent_deps_construction():
         analytics_db=None,
         rag=None,
         sqlite_session=None,
-        audit_logger=None,
+        run_logger=None,
     )
     assert deps.user_id == 1
     assert deps.selected_patient is None

--- a/tests/agent/test_deps_builder.py
+++ b/tests/agent/test_deps_builder.py
@@ -50,3 +50,53 @@ def test_build_agent_deps_reads_cookie_user_id(rag_mock, db_mock):
 
     assert deps.user_id == 42
     assert deps.user_role == RoleTypeEnum.NURSE
+
+
+def test_build_deps_attaches_run_logger(monkeypatch):
+    import streamlit as st
+    from agent.deps_builder import build_agent_deps
+    from agent.run_logger import AgentRunLogger
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from orm.models import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    st.session_state.clear()
+    st.session_state["user_id"] = 1
+    st.session_state["user_role"] = 1
+    st.session_state["current_group_id"] = "g-xyz"
+
+    monkeypatch.setattr("agent.deps_builder._analytics_db", lambda: object())
+    monkeypatch.setattr("agent.deps_builder._rag", lambda: object())
+
+    deps = build_agent_deps(session)
+    assert isinstance(deps.run_logger, AgentRunLogger)
+    assert deps.run_logger.run_id
+    assert deps.group_id == "g-xyz"
+
+
+def test_build_deps_run_logger_none_when_disabled(monkeypatch):
+    import streamlit as st
+    from agent.deps_builder import build_agent_deps
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from orm.models import Base
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    st.session_state.clear()
+    st.session_state["user_id"] = 1
+    st.session_state["user_role"] = 1
+    monkeypatch.setattr("agent.deps_builder._analytics_db", lambda: object())
+    monkeypatch.setattr("agent.deps_builder._rag", lambda: object())
+    monkeypatch.setattr(
+        "agent.logging_config.AgentLoggingConfig.from_streamlit",
+        classmethod(lambda cls: cls(mode="disabled")),
+    )
+
+    deps = build_agent_deps(session)
+    assert deps.run_logger is None

--- a/tests/agent/test_final_event_usage.py
+++ b/tests/agent/test_final_event_usage.py
@@ -1,0 +1,13 @@
+from agent.state import FinalResponseEvent, AgentResponse
+
+
+def test_final_event_carries_optional_usage():
+    ev = FinalResponseEvent(
+        response=AgentResponse(text="hi"), usage={"input_tokens": 3, "output_tokens": 2, "total_tokens": 5}
+    )
+    assert ev.usage["total_tokens"] == 5
+
+
+def test_final_event_usage_defaults_none():
+    ev = FinalResponseEvent(response=AgentResponse(text="hi"))
+    assert ev.usage is None

--- a/tests/agent/test_logging_config.py
+++ b/tests/agent/test_logging_config.py
@@ -1,0 +1,49 @@
+# tests/agent/test_logging_config.py
+import json
+from agent.logging_config import AgentLoggingConfig, cap_json
+
+
+def test_config_defaults_when_no_secrets():
+    cfg = AgentLoggingConfig.from_secrets({})
+    assert cfg.mode == "full"
+    assert cfg.max_logged_result_bytes == 5_000_000
+    assert cfg.max_logged_event_bytes == 5_000_000
+    assert cfg.retention_days == 0
+    assert cfg.enabled is True
+
+
+def test_config_reads_values_and_disabled_flag():
+    cfg = AgentLoggingConfig.from_secrets({"mode": "disabled", "max_logged_result_bytes": 10, "retention_days": 30})
+    assert cfg.mode == "disabled"
+    assert cfg.enabled is False
+    assert cfg.max_logged_result_bytes == 10
+
+
+def test_config_rejects_unknown_mode():
+    cfg = AgentLoggingConfig.from_secrets({"mode": "bogus"})
+    assert cfg.mode == "full"  # falls back to safe default
+
+
+def test_cap_json_under_limit_passes_through():
+    text, truncated, nbytes, digest = cap_json({"a": 1}, max_bytes=1000)
+    assert json.loads(text) == {"a": 1}
+    assert truncated is False
+    assert nbytes == len(text.encode("utf-8"))
+    assert len(digest) == 64
+
+
+def test_cap_json_over_limit_truncates_and_flags():
+    big = {"rows": ["x" * 100 for _ in range(100)]}
+    text, truncated, nbytes, digest = cap_json(big, max_bytes=200)
+    assert truncated is True
+    assert nbytes > 200  # original size recorded
+    assert len(text.encode("utf-8")) <= 200 + 64  # stored text is bounded
+    assert len(digest) == 64  # hash of ORIGINAL payload
+
+
+def test_cap_json_handles_none():
+    text, truncated, nbytes, digest = cap_json(None, max_bytes=1000)
+    assert text is None
+    assert truncated is False
+    assert nbytes == 0
+    assert digest is None

--- a/tests/agent/test_patient_access_extract.py
+++ b/tests/agent/test_patient_access_extract.py
@@ -1,0 +1,38 @@
+# tests/agent/test_patient_access_extract.py
+from agent.run_logger import extract_source_ids
+
+
+def test_extracts_from_matches_list():
+    payload = {
+        "matches": [
+            {"source_id": "src-1", "display_name": "Ann B"},
+            {"source_id": "src-2", "display_name": "Cy D"},
+        ],
+        "total_unique": 2,
+    }
+    found = extract_source_ids(payload)
+    assert ("src-1", "Ann B") in found
+    assert ("src-2", "Cy D") in found
+
+
+def test_extracts_from_nested_items_and_sample():
+    payload = {"sample": [{"source_id": "src-9", "display_name": "Zed"}], "items": [{"source_id": "src-7"}]}
+    found = dict(extract_source_ids(payload))
+    assert found["src-9"] == "Zed"
+    assert found["src-7"] is None
+
+
+def test_dedupes_and_ignores_non_source_id():
+    payload = {
+        "matches": [{"source_id": "src-1"}, {"source_id": "src-1"}],
+        "row_count": 5,
+        "data_availability": "data_present",
+    }
+    found = extract_source_ids(payload)
+    assert found == [("src-1", None)]
+
+
+def test_handles_none_and_non_dict():
+    assert extract_source_ids(None) == []
+    assert extract_source_ids("nope") == []
+    assert extract_source_ids(42) == []

--- a/tests/agent/test_run_logger.py
+++ b/tests/agent/test_run_logger.py
@@ -1,0 +1,176 @@
+import json
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agent.logging_config import AgentLoggingConfig
+from agent.run_logger import AgentRunLogger
+from orm.models import AgentPatientAccess, AgentRun, AgentRunEvent, Base, ToolCall
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _logger(session, mode="full"):
+    return AgentRunLogger(
+        session=session,
+        config=AgentLoggingConfig(mode=mode),
+        run_id="r1",
+        session_id="s1",
+        user_id=1,
+        user_role=1,
+    )
+
+
+def test_start_run_creates_open_run_and_first_event():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(
+        question="who is Ann?", llm_provider="anthropic", llm_model="claude", selected_patient=None, group_id="g1"
+    )
+    run = s.query(AgentRun).one()
+    assert run.status == "open"
+    assert run.question == "who is Ann?"
+    assert run.group_id == "g1"
+    ev = s.query(AgentRunEvent).filter_by(event_type="run_started").one()
+    assert ev.seq == 1
+
+
+def test_pinned_patient_at_start_writes_access_row():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(
+        question="q",
+        llm_provider="x",
+        llm_model="y",
+        selected_patient={"source_id": "src-1", "display_name": "Ann", "selection_origin": "user_click"},
+        group_id=None,
+    )
+    acc = s.query(AgentPatientAccess).one()
+    assert acc.source_id == "src-1"
+    assert acc.access_type == "pinned_at_run_start"
+
+
+def test_log_event_increments_seq():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    lg.log_event("thinking_completed", payload={"text": "hmm"}, turn_index=1, elapsed_ms=10)
+    seqs = [e.seq for e in s.query(AgentRunEvent).order_by(AgentRunEvent.seq).all()]
+    assert seqs == [1, 2]
+
+
+def test_log_tool_completed_writes_toolcall_event_and_access():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    lg.log_tool_completed(
+        tool_name="find_patient",
+        tool_call_id="tc-1",
+        turn_index=1,
+        arguments={"first_name": "Ann"},
+        result_obj={"matches": [{"source_id": "src-1", "display_name": "Ann B"}], "total_unique": 1},
+        sql_executed=[{"sql": "SELECT 1", "params": {}}],
+        elapsed_ms=12,
+        success=True,
+        error=None,
+        selected_patient_source_id=None,
+    )
+    tc = s.query(ToolCall).one()
+    assert tc.run_id == "r1"
+    assert tc.call_index == 1
+    assert tc.tool_call_id == "tc-1"
+    assert json.loads(tc.result_json)["total_unique"] == 1  # full result stored
+    assert json.loads(tc.arguments_json)["first_name"] == "Ann"  # verbatim
+    assert s.query(AgentRunEvent).filter_by(event_type="tool_call_completed").count() == 1
+    assert s.query(AgentPatientAccess).filter_by(access_type="tool_result").one().source_id == "src-1"
+
+
+def test_scrubbed_mode_hashes_sql_literals_and_drops_full_result():
+    s = _session()
+    lg = _logger(s, mode="scrubbed")
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    lg.log_tool_completed(
+        tool_name="run_sql",
+        tool_call_id="tc-1",
+        turn_index=1,
+        arguments={"sql": "SELECT * FROM p WHERE name = 'John Smith'"},
+        result_obj={"row_count": 1, "data_availability": "data_present", "dataframe": [{"name": "John Smith"}]},
+        sql_executed=[],
+        elapsed_ms=1,
+        success=True,
+        error=None,
+        selected_patient_source_id=None,
+    )
+    tc = s.query(ToolCall).one()
+    assert "John Smith" not in tc.arguments_json
+    assert tc.result_json is None  # scrubbed: no full payload
+    assert "row_count=1" in tc.result_summary
+
+
+def test_finalize_run_sets_terminal_status_and_totals():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    lg.log_tool_completed(
+        tool_name="t",
+        tool_call_id="c",
+        turn_index=1,
+        arguments={},
+        result_obj={"row_count": 0},
+        sql_executed=[],
+        elapsed_ms=1,
+        success=True,
+        error=None,
+        selected_patient_source_id=None,
+    )
+    lg.finalize_run(
+        status="success",
+        final_answer_text="done",
+        usage={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        total_elapsed_ms=99,
+        cap_reached=None,
+    )
+    run = s.query(AgentRun).one()
+    assert run.status == "success"
+    assert run.success is True
+    assert run.final_answer_text == "done"
+    assert run.input_tokens == 10 and run.total_tokens == 15
+    assert run.tool_call_count == 1
+    assert run.total_elapsed_ms == 99
+    assert run.completed_at is not None
+    assert s.query(AgentRunEvent).filter_by(event_type="run_completed").count() == 1
+
+
+def test_finalize_failure_records_error_and_terminal_event():
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    lg.finalize_run(
+        status="failed",
+        final_answer_text=None,
+        usage=None,
+        total_elapsed_ms=5,
+        cap_reached=None,
+        error_type="ValueError",
+        error="boom",
+        stack_trace="trace",
+    )
+    run = s.query(AgentRun).one()
+    assert run.status == "failed"
+    assert run.success is False
+    assert run.error_type == "ValueError"
+    assert s.query(AgentRunEvent).filter_by(event_type="run_failed").count() == 1
+    assert s.query(AgentRunEvent).filter_by(event_type="run_completed").count() == 1
+
+
+def test_logging_failure_never_raises(monkeypatch):
+    s = _session()
+    lg = _logger(s)
+    lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
+    # Force a write error; the call must swallow it.
+    monkeypatch.setattr(lg, "_session", None)
+    lg.log_event("thinking_completed", payload={"t": "x"}, turn_index=1, elapsed_ms=1)  # no raise

--- a/tests/agent/test_run_logger.py
+++ b/tests/agent/test_run_logger.py
@@ -172,5 +172,5 @@ def test_logging_failure_never_raises(monkeypatch):
     lg = _logger(s)
     lg.start_run(question="q", llm_provider="x", llm_model="y", selected_patient=None, group_id=None)
     # Force a write error; the call must swallow it.
-    monkeypatch.setattr(lg, "_session", None)
+    monkeypatch.setattr(lg, "session", None)
     lg.log_event("thinking_completed", payload={"t": "x"}, turn_index=1, elapsed_ms=1)  # no raise

--- a/tests/agent/test_runner.py
+++ b/tests/agent/test_runner.py
@@ -103,7 +103,7 @@ async def test_runner_injects_selection_into_instructions():
         selected_at=datetime(2026, 5, 6),
         selection_origin="user_click",
     )
-    deps.audit_logger = None
+    deps.run_logger = None
 
     await runner.run("anything", deps=deps)
     assert "src-john-1962" in captured["prompt_text"]

--- a/tests/agent/test_runner_thinking_stream.py
+++ b/tests/agent/test_runner_thinking_stream.py
@@ -63,7 +63,7 @@ async def test_thinking_only_turn_emits_deltas_and_completed():
 
     runner = AgenticRunner(model=FunctionModel(stream_function=stream))
     deps = MagicMock(spec=AgentDeps)
-    deps.audit_logger = None
+    deps.run_logger = None
     deps.analytics_db = None
     deps.selected_patient = None
     deps.last_dataframe = None
@@ -105,7 +105,7 @@ async def test_text_deltas_emitted_for_plain_text_parts():
 
     runner = AgenticRunner(model=FunctionModel(stream_function=stream))
     deps = MagicMock(spec=AgentDeps)
-    deps.audit_logger = None
+    deps.run_logger = None
     deps.analytics_db = None
     deps.selected_patient = None
     deps.last_dataframe = None
@@ -140,7 +140,7 @@ async def test_no_thinking_no_text_emits_nothing_extra():
 
     runner = AgenticRunner(model=FunctionModel(stream_function=stream))
     deps = MagicMock(spec=AgentDeps)
-    deps.audit_logger = None
+    deps.run_logger = None
     deps.analytics_db = None
     deps.selected_patient = None
     deps.last_dataframe = None
@@ -197,7 +197,7 @@ async def test_turn_index_increments_across_model_requests():
     try:
         runner = AgenticRunner(model=FunctionModel(stream_function=stream))
         deps = MagicMock(spec=AgentDeps)
-        deps.audit_logger = None
+        deps.run_logger = None
         deps.analytics_db = None
         deps.selected_patient = None
         deps.last_dataframe = None

--- a/tests/agent/test_state_shapes.py
+++ b/tests/agent/test_state_shapes.py
@@ -70,32 +70,36 @@ def test_surgeries_query_in_discriminated_union():
 
 def test_surgeries_query_with_filters():
     adapter = TypeAdapter(PatientClinicalQuery)
-    q = adapter.validate_python({
-        "domain": "surgeries",
-        "cpt_codes": ["27447"],
-        "procedure_text": "knee",
-        "date_range": {"start": "2025-01-01"},
-    })
+    q = adapter.validate_python(
+        {
+            "domain": "surgeries",
+            "cpt_codes": ["27447"],
+            "procedure_text": "knee",
+            "date_range": {"start": "2025-01-01"},
+        }
+    )
     assert isinstance(q, SurgeriesQuery)
     assert q.cpt_codes == ["27447"]
 
 
 def test_surgery_item_in_clinical_item_union():
     adapter = TypeAdapter(ClinicalItem)
-    item = adapter.validate_python({
-        "item_type": "surgery",
-        "source": "orders",
-        "source_id": "src-1",
-        "code": "27447",
-        "code_type": "CPT",
-        "description": "Total knee arthroplasty",
-        "event_date": "2025-06-15",
-        "place_of_service": "21",
-        "provider_npi": None,
-        "performing_provider": "Dr. Ortho",
-        "provider_ambiguous": False,
-        "facility_name": None,
-    })
+    item = adapter.validate_python(
+        {
+            "item_type": "surgery",
+            "source": "orders",
+            "source_id": "src-1",
+            "code": "27447",
+            "code_type": "CPT",
+            "description": "Total knee arthroplasty",
+            "event_date": "2025-06-15",
+            "place_of_service": "21",
+            "provider_npi": None,
+            "performing_provider": "Dr. Ortho",
+            "provider_ambiguous": False,
+            "facility_name": None,
+        }
+    )
     assert isinstance(item, SurgeryItem)
     assert item.performing_provider == "Dr. Ortho"
     assert item.provider_ambiguous is False

--- a/tests/agent/tools/test_find_patient.py
+++ b/tests/agent/tools/test_find_patient.py
@@ -26,7 +26,7 @@ def deps_factory(synthetic_db):
             analytics_db=adapter,
             rag=None,
             sqlite_session=None,
-            audit_logger=MagicMock(),
+            run_logger=MagicMock(),
         )
 
     return _make

--- a/tests/agent/tools/test_get_patient_clinical_data.py
+++ b/tests/agent/tools/test_get_patient_clinical_data.py
@@ -26,7 +26,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/tools/test_list_patient_documents.py
+++ b/tests/agent/tools/test_list_patient_documents.py
@@ -25,7 +25,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/tools/test_make_chart.py
+++ b/tests/agent/tools/test_make_chart.py
@@ -32,7 +32,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/tools/test_run_sql.py
+++ b/tests/agent/tools/test_run_sql.py
@@ -37,7 +37,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/tools/test_search_patients_by_criteria.py
+++ b/tests/agent/tools/test_search_patients_by_criteria.py
@@ -35,7 +35,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None = None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/agent/tools/test_summarize_results.py
+++ b/tests/agent/tools/test_summarize_results.py
@@ -32,7 +32,7 @@ def _deps(synthetic_db, selected: SelectedPatient | None) -> AgentDeps:
         analytics_db=AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite"),
         rag=None,
         sqlite_session=None,
-        audit_logger=MagicMock(),
+        run_logger=MagicMock(),
     )
 
 

--- a/tests/orm/test_agent_logging_functions.py
+++ b/tests/orm/test_agent_logging_functions.py
@@ -1,0 +1,139 @@
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from orm.models import Base, AgentRun, AgentRunEvent, ToolCall, AgentPatientAccess, AdminAction
+
+
+def _seed(monkeypatch):
+    from orm import agent_logging_functions as alf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(alf, "SessionLocal", Session)
+    s = Session()
+    s.add(
+        AgentRun(
+            run_id="r1",
+            session_id="s1",
+            user_id=1,
+            user_role=1,
+            question="q1",
+            llm_provider="anthropic",
+            llm_model="claude",
+            tool_call_count=2,
+            event_count=5,
+            total_elapsed_ms=1200,
+            input_tokens=10,
+            output_tokens=5,
+            total_tokens=15,
+            status="success",
+            success=True,
+            logging_mode="full",
+            schema_version=1,
+            review_status="unreviewed",
+            selected_patient_source_id="src-1",
+        )
+    )
+    s.add(
+        AgentRun(
+            run_id="r2",
+            session_id="s1",
+            user_id=1,
+            user_role=1,
+            question="q2",
+            llm_model="claude",
+            status="failed",
+            success=False,
+            tool_call_count=0,
+            event_count=2,
+            logging_mode="full",
+            schema_version=1,
+            review_status="unreviewed",
+        )
+    )
+    s.add(AgentRunEvent(run_id="r1", seq=1, event_type="run_started", payload_truncated=False))
+    s.add(AgentRunEvent(run_id="r1", seq=2, event_type="run_completed", payload_truncated=False))
+    s.add(
+        ToolCall(
+            session_id="s1",
+            user_id=1,
+            user_role=1,
+            tool_name="run_sql",
+            arguments_json="{}",
+            result_summary="row_count=3",
+            elapsed_ms=50,
+            success=True,
+            run_id="r1",
+            call_index=1,
+            attempt_index=1,
+        )
+    )
+    s.add(
+        AgentPatientAccess(
+            run_id="r1",
+            session_id="s1",
+            user_id=1,
+            source_id="src-1",
+            display_name="Ann",
+            access_type="tool_result",
+            access_origin="tool",
+        )
+    )
+    s.commit()
+    return alf
+
+
+def test_get_agent_run_stats(monkeypatch):
+    alf = _seed(monkeypatch)
+    stats = alf.get_agent_run_stats(days=30)
+    assert stats["total_runs"] == 2
+    assert stats["success_rate"] == 50.0
+    assert stats["avg_tool_calls"] == 1.0  # (2 + 0) / 2
+
+
+def test_get_recent_runs(monkeypatch):
+    alf = _seed(monkeypatch)
+    rows = alf.get_recent_agent_runs(days=30, limit=10)
+    assert len(rows) == 2
+    assert {r["run_id"] for r in rows} == {"r1", "r2"}
+
+
+def test_get_run_detail_bundles_events_and_tools(monkeypatch):
+    alf = _seed(monkeypatch)
+    detail = alf.get_agent_run_detail("r1")
+    assert detail["run"]["question"] == "q1"
+    assert [e["event_type"] for e in detail["events"]] == ["run_started", "run_completed"]
+    assert detail["tool_calls"][0]["tool_name"] == "run_sql"
+
+
+def test_get_tool_breakdown(monkeypatch):
+    alf = _seed(monkeypatch)
+    rows = alf.get_tool_breakdown(days=30)
+    assert any(r["tool_name"] == "run_sql" and r["count"] == 1 for r in rows)
+
+
+def test_get_patient_access_for_source(monkeypatch):
+    alf = _seed(monkeypatch)
+    rows = alf.get_patient_access(source_id="src-1", days=30)
+    assert rows[0]["source_id"] == "src-1"
+
+
+def test_set_run_review_status(monkeypatch):
+    alf = _seed(monkeypatch)
+    alf.set_run_review_status("r1", review_status="verified", reviewed_by=9, notes="looks right")
+    detail = alf.get_agent_run_detail("r1")
+    assert detail["run"]["review_status"] == "verified"
+    assert detail["run"]["review_notes"] == "looks right"
+
+
+def test_log_agent_run_viewed_writes_admin_action(monkeypatch):
+    alf = _seed(monkeypatch)
+    assert alf.log_agent_run_viewed(admin_id=9, run_id="r1") is True
+    from orm import agent_logging_functions as alf_module
+
+    s = alf_module.SessionLocal()
+    row = s.query(AdminAction).one()
+    assert row.action_type == "agent_run_view"
+    assert row.target_entity_type == "agent_run"
+    assert row.target_entity_id == "r1"

--- a/tests/orm/test_agent_logging_functions.py
+++ b/tests/orm/test_agent_logging_functions.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from orm.models import Base, AgentRun, AgentRunEvent, ToolCall, AgentPatientAccess, AdminAction

--- a/tests/orm/test_agent_logging_functions.py
+++ b/tests/orm/test_agent_logging_functions.py
@@ -137,3 +137,76 @@ def test_log_agent_run_viewed_writes_admin_action(monkeypatch):
     assert row.action_type == "agent_run_view"
     assert row.target_entity_type == "agent_run"
     assert row.target_entity_id == "r1"
+
+
+def test_prune_agent_logs_removes_old_children_first(monkeypatch):
+    from datetime import datetime, timedelta
+    from orm import agent_logging_functions as alf
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from orm.models import Base, AgentRun, AgentRunEvent, ToolCall, AgentPatientAccess
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(alf, "SessionLocal", Session)
+    s = Session()
+    old = datetime.now() - timedelta(days=100)
+    s.add(
+        AgentRun(
+            run_id="old",
+            session_id="s",
+            user_id=1,
+            user_role=1,
+            status="success",
+            success=True,
+            logging_mode="full",
+            schema_version=1,
+            created_at=old,
+        )
+    )
+    s.add(AgentRunEvent(run_id="old", seq=1, event_type="run_started", created_at=old))
+    s.add(
+        ToolCall(
+            session_id="s",
+            user_id=1,
+            user_role=1,
+            tool_name="t",
+            arguments_json="{}",
+            result_summary="x",
+            elapsed_ms=1,
+            success=True,
+            run_id="old",
+            created_at=old,
+        )
+    )
+    s.add(
+        AgentPatientAccess(
+            run_id="old",
+            session_id="s",
+            user_id=1,
+            source_id="src",
+            access_type="tool_result",
+            access_origin="tool",
+            created_at=old,
+        )
+    )
+    s.add(
+        AgentRun(
+            run_id="new",
+            session_id="s",
+            user_id=1,
+            user_role=1,
+            status="success",
+            success=True,
+            logging_mode="full",
+            schema_version=1,
+        )
+    )
+    s.commit()
+
+    removed = alf.prune_agent_logs(retention_days=30)
+    assert removed["runs"] == 1
+    assert s.query(AgentRun).count() == 1
+    assert s.query(AgentRunEvent).count() == 0
+    assert s.query(ToolCall).filter_by(run_id="old").count() == 0

--- a/tests/orm/test_agent_logging_models.py
+++ b/tests/orm/test_agent_logging_models.py
@@ -1,0 +1,101 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import (
+    AgentRun,
+    AgentRunEvent,
+    AgentPatientAccess,
+    PatientSelectionEvent,
+    ToolCall,
+    Base,
+)
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_agent_run_roundtrip():
+    s = _session()
+    run = AgentRun(
+        run_id="r1",
+        session_id="s1",
+        user_id=1,
+        user_role=1,
+        question="hi",
+        llm_provider="anthropic",
+        llm_model="claude",
+        tool_call_count=0,
+        event_count=1,
+        status="open",
+        success=False,
+        logging_mode="full",
+        schema_version=1,
+    )
+    s.add(run)
+    s.commit()
+    assert s.query(AgentRun).one().run_id == "r1"
+
+
+def test_agent_run_event_roundtrip():
+    s = _session()
+    ev = AgentRunEvent(run_id="r1", seq=1, event_type="run_started", payload_truncated=False)
+    s.add(ev)
+    s.commit()
+    assert s.query(AgentRunEvent).one().event_type == "run_started"
+
+
+def test_tool_call_has_new_columns():
+    s = _session()
+    tc = ToolCall(
+        session_id="s1",
+        user_id=1,
+        user_role=1,
+        tool_name="run_sql",
+        arguments_json="{}",
+        result_summary="row_count=1",
+        elapsed_ms=5,
+        success=True,
+        run_id="r1",
+        call_index=1,
+        turn_index=1,
+        attempt_index=1,
+        result_json='{"row_count":1}',
+        result_truncated=False,
+        sql_executed_json="[]",
+        sql_executed_truncated=False,
+    )
+    s.add(tc)
+    s.commit()
+    row = s.query(ToolCall).one()
+    assert row.run_id == "r1"
+    assert row.result_json == '{"row_count":1}'
+    assert row.call_index == 1
+
+
+def test_patient_access_and_selection_roundtrip():
+    s = _session()
+    s.add(
+        AgentPatientAccess(
+            run_id="r1",
+            session_id="s1",
+            user_id=1,
+            source_id="src-1",
+            access_type="pinned_at_run_start",
+            access_origin="run_context",
+        )
+    )
+    s.add(
+        PatientSelectionEvent(
+            session_id="s1",
+            user_id=1,
+            source_id="src-1",
+            selection_origin="user_click",
+            action="selected",
+        )
+    )
+    s.commit()
+    assert s.query(AgentPatientAccess).one().source_id == "src-1"
+    assert s.query(PatientSelectionEvent).one().action == "selected"

--- a/tests/orm/test_patient_selection_logging.py
+++ b/tests/orm/test_patient_selection_logging.py
@@ -1,0 +1,53 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from orm.models import Base, PatientSelectionEvent, AgentPatientAccess
+
+
+def test_log_patient_selection_writes_event_and_access(monkeypatch):
+    from orm import agent_logging_functions as alf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(alf, "SessionLocal", Session)
+
+    alf.log_patient_selection(
+        session_id="s1",
+        user_id=1,
+        source_id="src-1",
+        display_name="Ann",
+        selection_origin="user_click",
+        action="selected",
+        previous_source_id=None,
+        run_id=None,
+    )
+    s = Session()
+    assert s.query(PatientSelectionEvent).one().source_id == "src-1"
+    assert s.query(AgentPatientAccess).filter_by(access_type="selection_chosen").one().source_id == "src-1"
+
+
+def test_log_patient_clear_writes_clear_event_and_access(monkeypatch):
+    from orm import agent_logging_functions as alf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(alf, "SessionLocal", Session)
+
+    alf.log_patient_selection(
+        session_id="s1",
+        user_id=1,
+        source_id=None,
+        display_name=None,
+        selection_origin="clear_button",
+        action="cleared",
+        previous_source_id="src-old",
+        run_id=None,
+    )
+    s = Session()
+    event = s.query(PatientSelectionEvent).one()
+    assert event.action == "cleared"
+    assert event.source_id is None
+    assert event.previous_source_id == "src-old"
+    access = s.query(AgentPatientAccess).filter_by(access_type="selection_cleared").one()
+    assert access.source_id == "src-old"

--- a/tests/orm/test_tool_call.py
+++ b/tests/orm/test_tool_call.py
@@ -1,5 +1,3 @@
-import pytest
-from datetime import datetime
 from orm.models import ToolCall
 
 

--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -17,10 +17,7 @@ class TestParseQuestionSqlResponse:
     def test_valid_format(self):
         from utils.vanna_calls import _parse_question_sql_response
 
-        text = (
-            "QUESTION: How many patients are in the database?\n"
-            "SQL: SELECT COUNT(*) FROM patients;"
-        )
+        text = "QUESTION: How many patients are in the database?\nSQL: SELECT COUNT(*) FROM patients;"
         question, sql = _parse_question_sql_response(text)
         assert question == "How many patients are in the database?"
         assert sql == "SELECT COUNT(*) FROM patients;"
@@ -44,10 +41,7 @@ class TestParseQuestionSqlResponse:
     def test_sql_with_markdown_fencing(self):
         from utils.vanna_calls import _parse_question_sql_response
 
-        text = (
-            "QUESTION: Count rows\n"
-            "SQL: ```sql\nSELECT COUNT(*) FROM t;\n```"
-        )
+        text = "QUESTION: Count rows\nSQL: ```sql\nSELECT COUNT(*) FROM t;\n```"
         question, sql = _parse_question_sql_response(text)
         assert question == "Count rows"
         assert sql == "SELECT COUNT(*) FROM t;"
@@ -97,10 +91,7 @@ class TestParseQuestionSqlResponse:
     def test_markdown_bold_colon_outside(self):
         from utils.vanna_calls import _parse_question_sql_response
 
-        text = (
-            "**Question**: How many allergies?\n"
-            "**SQL**:\n```sql\nSELECT COUNT(*) FROM allergies;\n```"
-        )
+        text = "**Question**: How many allergies?\n**SQL**:\n```sql\nSELECT COUNT(*) FROM allergies;\n```"
         question, sql = _parse_question_sql_response(text)
         assert question == "How many allergies?"
         assert sql == "SELECT COUNT(*) FROM allergies;"
@@ -196,9 +187,7 @@ class TestAutoGenerateSqlPairs:
         mock_st.progress.return_value = MagicMock()
         mock_st.empty.return_value = MagicMock()
 
-        mock_vanna_service.submit_prompt.return_value = (
-            "QUESTION: Get secret data\nSQL: SELECT * FROM secret_table;"
-        )
+        mock_vanna_service.submit_prompt.return_value = "QUESTION: Get secret data\nSQL: SELECT * FROM secret_table;"
 
         with patch("utils.security_validator.security_validator") as mock_sv:
             mock_sv.validate_sql_content.return_value = (False, ["Forbidden table reference: secret_table"])
@@ -220,9 +209,7 @@ class TestAutoGenerateSqlPairs:
         mock_st.progress.return_value = MagicMock()
         mock_st.empty.return_value = MagicMock()
 
-        mock_vanna_service.submit_prompt.return_value = (
-            "QUESTION: Bad query\nSQL: SELECT * FROM nonexistent;"
-        )
+        mock_vanna_service.submit_prompt.return_value = "QUESTION: Bad query\nSQL: SELECT * FROM nonexistent;"
         mock_vanna_service.check_references.return_value = "SELECT * FROM nonexistent;"
         mock_vanna_service.vn.run_sql.side_effect = Exception("relation does not exist")
 
@@ -246,9 +233,7 @@ class TestAutoGenerateSqlPairs:
         mock_st.progress.return_value = MagicMock()
         mock_st.empty.return_value = MagicMock()
 
-        mock_vanna_service.submit_prompt.return_value = (
-            "QUESTION: Empty?\nSQL: SELECT * FROM patients WHERE 1=0;"
-        )
+        mock_vanna_service.submit_prompt.return_value = "QUESTION: Empty?\nSQL: SELECT * FROM patients WHERE 1=0;"
         mock_vanna_service.check_references.return_value = "SELECT * FROM patients WHERE 1=0;"
         mock_vanna_service.vn.run_sql.return_value = pd.DataFrame()
 
@@ -320,9 +305,7 @@ class TestAutoGenerateSqlPairs:
         mock_st.empty.return_value = MagicMock()
 
         # LLM generates a question that already exists in training data
-        mock_vanna_service.submit_prompt.return_value = (
-            "QUESTION: Existing question\nSQL: SELECT 1;"
-        )
+        mock_vanna_service.submit_prompt.return_value = "QUESTION: Existing question\nSQL: SELECT 1;"
 
         with patch("utils.security_validator.security_validator") as mock_sv:
             mock_sv.validate_sql_content.return_value = (True, [])
@@ -344,9 +327,7 @@ class TestAutoGenerateSqlPairs:
         mock_st.progress.return_value = MagicMock()
         mock_st.empty.return_value = MagicMock()
 
-        mock_vanna_service.submit_prompt.return_value = (
-            "QUESTION: Get data\nSQL: SELECT * FROM forbidden_table;"
-        )
+        mock_vanna_service.submit_prompt.return_value = "QUESTION: Get data\nSQL: SELECT * FROM forbidden_table;"
         mock_vanna_service.check_references.return_value = None  # blocked
 
         with patch("utils.security_validator.security_validator") as mock_sv:

--- a/tests/views/test_agent_analytics.py
+++ b/tests/views/test_agent_analytics.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_module_imports_and_exposes_main():
+    mod = importlib.import_module("views.agent_analytics")
+    assert hasattr(mod, "main")
+    assert hasattr(mod, "_guard_admin")
+
+
+def test_render_run_timeline_orders_events():
+    from views.agent_analytics import _timeline_rows
+
+    detail = {
+        "events": [
+            {
+                "seq": 2,
+                "event_type": "tool_call_completed",
+                "tool_name": "run_sql",
+                "payload_json": '{"result": {"row_count": 3}}',
+                "turn_index": 1,
+            },
+            {
+                "seq": 1,
+                "event_type": "run_started",
+                "payload_json": '{"question": "q"}',
+                "turn_index": None,
+            },
+        ],
+    }
+    rows = _timeline_rows(detail)
+    assert [r["seq"] for r in rows] == [1, 2]

--- a/utils/renderers/patient_chooser.py
+++ b/utils/renderers/patient_chooser.py
@@ -58,10 +58,10 @@ def render_patient_chooser(message, index: int) -> None:
                     previous_source_id=previous_source_id,
                     run_id=parent_run_id,
                 )
-                st.session_state["agent_parent_run_id"] = parent_run_id
-                st.session_state["agent_resume_reason"] = "patient_selection_resume"
             except Exception:
                 pass
+            st.session_state["agent_parent_run_id"] = parent_run_id
+            st.session_state["agent_resume_reason"] = "patient_selection_resume"
             # Re-fire the original question so the agent continues with
             # the slot now filled. agent.runtime stashes this before each
             # run; if missing (e.g. stale chooser from a prior session),

--- a/utils/renderers/patient_chooser.py
+++ b/utils/renderers/patient_chooser.py
@@ -38,11 +38,30 @@ def render_patient_chooser(message, index: int) -> None:
             _format_match(m),
             key=f"chooser-msg{msg_id}-{i}-{m.get('source_id')}",
         ):
+            previous_source_id = st.session_state.get("selected_patient_source_id")
+            parent_run_id = st.session_state.get("agent_current_run_id")
             st.session_state["selected_patient_source_id"] = m["source_id"]
             st.session_state["selected_patient_display_name"] = m.get("display_name", "")
             st.session_state["selected_patient_dob"] = m.get("dob")
             st.session_state["selection_origin"] = "user_click"
             st.session_state["selected_at"] = datetime.now().isoformat()
+            try:
+                from orm.agent_logging_functions import log_patient_selection
+
+                log_patient_selection(
+                    session_id=st.session_state.get("agent_session_id", ""),
+                    user_id=int(st.session_state.get("user_id") or 0),
+                    source_id=m["source_id"],
+                    display_name=m.get("display_name", ""),
+                    selection_origin="user_click",
+                    action="selected",
+                    previous_source_id=previous_source_id,
+                    run_id=parent_run_id,
+                )
+                st.session_state["agent_parent_run_id"] = parent_run_id
+                st.session_state["agent_resume_reason"] = "patient_selection_resume"
+            except Exception:
+                pass
             # Re-fire the original question so the agent continues with
             # the slot now filled. agent.runtime stashes this before each
             # run; if missing (e.g. stale chooser from a prior session),

--- a/views/agent_analytics.py
+++ b/views/agent_analytics.py
@@ -1,0 +1,225 @@
+"""Agentic Analytics — full-fidelity visibility into agent runs.
+
+Admin-only. Surfaces run-level rollups, per-run inspector (the QA payoff),
+tool breakdowns, and patient-access tracking from the agentic logging tables.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import streamlit as st
+
+from orm.models import RoleTypeEnum
+from orm.agent_logging_functions import (
+    get_agent_run_detail,
+    get_agent_run_stats,
+    get_patient_access,
+    get_recent_agent_runs,
+    get_runs_over_time,
+    get_tool_breakdown,
+    log_agent_run_viewed,
+    set_run_review_status,
+)
+from agent.logging_config import AgentLoggingConfig
+
+
+def _guard_admin() -> None:
+    if st.session_state.get("user_role") != RoleTypeEnum.ADMIN.value:
+        st.error("Admin access required.")
+        st.stop()
+
+
+def _kpi(label: str, value, help_text: str | None = None) -> None:
+    st.metric(label, value, help=help_text)
+
+
+def _timeline_rows(detail: dict) -> list[dict]:
+    """Return the run's events sorted by seq for the inspector."""
+    return sorted(detail.get("events", []), key=lambda e: e["seq"])
+
+
+def _render_runs_tab(days: int) -> None:
+    stats = get_agent_run_stats(days)
+    c1, c2, c3, c4, c5 = st.columns(5)
+    with c1:
+        _kpi("Runs", stats["total_runs"])
+    with c2:
+        _kpi("Success rate", f"{stats['success_rate']}%")
+    with c3:
+        _kpi("Cap-reached", f"{stats['cap_rate']}%")
+    with c4:
+        _kpi("Avg tools/run", stats["avg_tool_calls"])
+    with c5:
+        _kpi("Total tokens", f"{stats['total_tokens']:,}")
+
+    over_time = get_runs_over_time(days)
+    if over_time:
+        df = pd.DataFrame(over_time)
+        st.line_chart(df.set_index("date")[["runs"]])
+
+    st.subheader("Recent Runs")
+    runs = get_recent_agent_runs(days, limit=200)
+    if not runs:
+        st.info("No agent runs logged in this window.")
+        return
+    table = pd.DataFrame(runs)
+    st.dataframe(
+        table[
+            [
+                "created_at",
+                "question",
+                "llm_model",
+                "tool_call_count",
+                "total_elapsed_ms",
+                "total_tokens",
+                "status",
+                "review_status",
+                "selected_patient_display_name",
+                "run_id",
+            ]
+        ],
+        use_container_width=True,
+        hide_index=True,
+    )
+
+    run_ids = [r["run_id"] for r in runs]
+    selected = st.selectbox("Inspect a run", options=["—"] + run_ids)
+    if selected and selected != "—":
+        _render_run_inspector(selected)
+
+
+def _render_run_inspector(run_id: str) -> None:
+    detail = get_agent_run_detail(run_id)
+    if not detail:
+        st.warning("Run not found.")
+        return
+    log_agent_run_viewed(st.session_state.get("user_id"), run_id)
+    run = detail["run"]
+    st.markdown(f"### Run `{run_id}`")
+    st.markdown(f"**Question:** {run.get('question')}")
+    if run.get("selected_patient_source_id"):
+        st.info(
+            f"📌 Pinned patient: {run.get('selected_patient_display_name')} "
+            f"(`{run.get('selected_patient_source_id')}`, {run.get('selected_patient_selection_origin')})"
+        )
+    st.caption(
+        f"Model: {run.get('llm_model')} · Status: {run.get('status')} · "
+        f"Tokens: {run.get('total_tokens')} · {run.get('total_elapsed_ms')} ms"
+    )
+
+    for ev in _timeline_rows(detail):
+        etype = ev["event_type"]
+        payload = json.loads(ev["payload_json"]) if ev.get("payload_json") else {}
+        if etype == "thinking_completed":
+            with st.expander(f"🤔 Thinking (turn {ev.get('turn_index')})", expanded=False):
+                st.markdown(payload.get("text", ""))
+        elif etype == "tool_call_started":
+            st.markdown(f"**→ calling `{ev.get('tool_name')}`**")
+            st.json(payload.get("arguments", {}))
+        elif etype == "tool_call_completed":
+            with st.expander(f"🔧 {ev.get('tool_name')} result", expanded=False):
+                if ev.get("payload_truncated"):
+                    st.caption(f"⚠️ truncated — {ev.get('payload_bytes')} bytes, sha256 {ev.get('payload_hash')}")
+                result = payload.get("result")
+                sql = payload.get("sql_executed")
+                if sql:
+                    st.code("\n".join(x.get("sql", "") for x in sql), language="sql")
+                _render_result(result)
+        elif etype == "assistant_text_completed":
+            st.markdown(payload.get("text", ""))
+        elif etype in ("cap_reached", "run_failed"):
+            st.error(f"{etype}: {payload}")
+
+    st.markdown("### Final answer")
+    st.success(run.get("final_answer_text") or "(no final text)")
+
+    _render_review_panel(run)
+
+
+def _render_result(result) -> None:
+    """Render a tool result: dataframe when tabular, else JSON."""
+    if isinstance(result, dict):
+        for key in ("sample", "items", "matches", "rows"):
+            if isinstance(result.get(key), list) and result[key]:
+                st.dataframe(pd.DataFrame(result[key]), use_container_width=True, hide_index=True)
+                break
+        st.json(result)
+    elif result is not None:
+        st.write(result)
+
+
+def _render_review_panel(run: dict) -> None:
+    st.markdown("### QA Review")
+    with st.form(f"review-{run['run_id']}"):
+        options = ["unreviewed", "verified", "issue", "ignored"]
+        current = run.get("review_status", "unreviewed")
+        status = st.selectbox(
+            "Review status",
+            options,
+            index=options.index(current) if current in options else 0,
+        )
+        notes = st.text_area("Notes", value=run.get("review_notes") or "")
+        issue_url = st.text_input("Issue URL", value=run.get("issue_url") or "")
+        if st.form_submit_button("Save review"):
+            set_run_review_status(
+                run["run_id"],
+                review_status=status,
+                reviewed_by=st.session_state.get("user_id"),
+                notes=notes,
+                issue_url=issue_url or None,
+            )
+            st.success("Review saved.")
+            st.rerun()
+
+
+def _render_tools_tab(days: int) -> None:
+    rows = get_tool_breakdown(days)
+    if not rows:
+        st.info("No tool calls logged.")
+        return
+    df = pd.DataFrame(rows)
+    df["avg_ms"] = df["avg_ms"].round(0)
+    st.dataframe(df, use_container_width=True, hide_index=True)
+    st.bar_chart(df.set_index("tool_name")[["count"]])
+
+
+def _render_patient_access_tab(days: int) -> None:
+    col1, col2 = st.columns(2)
+    source_id = col1.text_input("Filter by source_id")
+    user_id_raw = col2.text_input("Filter by user_id")
+    user_id = int(user_id_raw) if user_id_raw.strip().isdigit() else None
+    rows = get_patient_access(source_id=source_id or None, user_id=user_id, days=days)
+    if not rows:
+        st.info("No patient-access records for this filter.")
+        return
+    st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+
+
+def main() -> None:
+    _guard_admin()
+    st.title("🧠 Agentic Analytics")
+
+    cfg = AgentLoggingConfig.from_streamlit()
+    if cfg.mode == "full":
+        st.warning(
+            "⚠️ **Full PHI logging enabled** — tool arguments, results, and "
+            "patient identity are stored verbatim. Protect this database like the "
+            "clinical source."
+        )
+    elif cfg.mode == "disabled":
+        st.error("Agentic logging is **disabled** in config — no new runs are being recorded.")
+
+    days = st.selectbox("Time window (days)", [1, 7, 30, 90], index=2)
+    tabs = st.tabs(["Runs", "Tools", "Patient Access"])
+    with tabs[0]:
+        _render_runs_tab(days)
+    with tabs[1]:
+        _render_tools_tab(days)
+    with tabs[2]:
+        _render_patient_access_tab(days)
+
+
+if __name__ == "__main__":
+    main()

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -61,6 +61,23 @@ logger = get_logger(__name__)
 
 
 def _clear_selected_patient() -> None:
+    previous_source_id = st.session_state.get("selected_patient_source_id")
+    try:
+        if previous_source_id:
+            from orm.agent_logging_functions import log_patient_selection
+
+            log_patient_selection(
+                session_id=st.session_state.get("agent_session_id", ""),
+                user_id=int(st.session_state.get("user_id") or 0),
+                source_id=None,
+                display_name=None,
+                selection_origin="clear_button",
+                action="cleared",
+                previous_source_id=previous_source_id,
+                run_id=st.session_state.get("agent_current_run_id"),
+            )
+    except Exception:
+        pass
     for k in (
         "selected_patient_source_id",
         "selected_patient_display_name",


### PR DESCRIPTION
## Summary

Adds full-fidelity, queryable visibility into every **agentic** run, surfaced in a new admin **Agentic Analytics** page — built as a verification/QA tool for active development (inspect any question end-to-end and confirm the agent pulled the right data and didn't hallucinate).

- **Data model** (migration `f95a95e2dbb1`): new `AgentRun` (per-question rollup), `AgentRunEvent` (append-only ordered timeline = source of truth), `AgentPatientAccess` (queryable patient touches), `PatientSelectionEvent`; plus enrichment columns on `ToolCall` (`run_id`, `turn_index`, verbatim args, full `result_json`, executed SQL, truncation/hash metadata). Additive + nullable so legacy `ToolCall` rows stay valid.
- **`AgentRunLogger`** (`agent/run_logger.py`) constructed per-run in `deps_builder` and driven from `runner.stream()`: logs run start, per-turn thinking, tool calls (params + executed SQL + full results), token usage, cap/failure terminal states, and patient pinning. Never breaks a run (guarded, commit-per-call).
- **Logging modes** via `[agent_logging].mode`: `full` (verbatim PHI, byte-capped + sha256), `scrubbed` (reuses the existing audit scrubber, metadata-only), `disabled`. Each run stamps `logging_mode` + `schema_version` so modes coexist. Byte caps truncate with preserved original size + hash.
- **Patient pinning**: stamped on runs/tool calls; pin set/clear logged as `PatientSelectionEvent` + `AgentPatientAccess` from the chooser click and the sidebar clear button; resume lineage (`parent_run_id`/`resume_reason`) carried into the next run.
- **Admin page** `views/agent_analytics.py` (admin-gated): Runs (KPIs, trend, recent-runs table, **run inspector** = thinking → tool+params → SQL → results → final answer + QA review panel), Tools (per-tool rollup), Patient Access. A "Full PHI logging enabled" banner shows in `full` mode; opening a trace is itself audited as an `AdminAction`.
- **Retention**: `prune_agent_logs(retention_days)` (children-before-parents); default off.
- Docs: `[agent_logging]` documented in `CLAUDE.md` (the `llmdocs/` reference docs are gitignored/local-only per repo convention and were updated locally).

## Privacy note
Per stakeholder decision, `full` mode (default) stores verbatim PHI (tool args, result rows, pinned-patient identity) in the app SQLite DB — appropriate for the locked-down, admin-only deployment. This consciously overrides the spec §8.7 PHI-minimization for the agentic path. **Protect DB backups at the same level as the clinical source.**

## Test Plan
- [x] `uv run pytest tests/agent tests/orm tests/views` → 562 passed (1 pre-existing unrelated failure: `test_surgeries_claims_broadly_inclusive`, fails on main too)
- [x] New coverage: config/cap helpers, ORM round-trips, migration up/down/re-up + model parity, `AgentRunLogger` (full/scrubbed/disabled, finalize success/cap/failure, never-raises), end-to-end run persistence flow, read functions, pin-selection logging, analytics page import/timeline, prune helper
- [x] `tests/agent/test_audit_compliance.py` still green (scrubbed-mode helpers intact)
- [x] Manual smoke: log in as admin, ask an agentic question, open Agentic Analytics → inspect the run timeline

## Known minor follow-ups (non-blocking)
- `scrubbed` mode stores ~200 chars of thinking/text in `payload_summary` (slight exposure in the PHI-reduction mode)
- `AgentRun.event_count` is off-by-one on cap/failed terminations (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)