### PR TITLE
fix(agent): resolve "event loop is already running" under concurrent runs

### DIFF
--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -7,6 +7,7 @@ when the user has agentic_mode=True.
 from __future__ import annotations
 import asyncio
 import json
+import queue
 import threading
 from typing import Any, Coroutine
 
@@ -40,11 +41,12 @@ def _runner() -> AgenticRunner:
 
 
 _LOOP: asyncio.AbstractEventLoop | None = None
+_LOOP_THREAD: threading.Thread | None = None
 _LOOP_LOCK = threading.Lock()
 
 
 def _persistent_loop() -> asyncio.AbstractEventLoop:
-    """Process-wide event loop reused across requests.
+    """Process-wide event loop, running forever on its own daemon thread.
 
     Pydantic AI's OpenAI / Anthropic providers hold long-lived httpx
     connection pools whose TCP transports are bound to the loop on
@@ -53,47 +55,45 @@ def _persistent_loop() -> asyncio.AbstractEventLoop:
     on the second request — visible as
     "RuntimeError: unable to perform operation on <TCPTransport closed>".
     Pinning a single loop keeps those transports alive.
+
+    The loop runs via run_forever() on a dedicated thread rather than
+    being driven with run_until_complete from each caller. Callers
+    submit coroutines with run_coroutine_threadsafe (see _run_async).
+    This is what makes concurrent Streamlit script threads safe: two
+    sessions (or a rerun that fires while a prior run is still
+    unwinding) would otherwise both call run_until_complete on this one
+    loop, and the second raises "this event loop is already running".
+    A single run_forever loop multiplexes any number of submissions.
     """
-    global _LOOP
+    global _LOOP, _LOOP_THREAD
     with _LOOP_LOCK:
         if _LOOP is None or _LOOP.is_closed():
             _LOOP = asyncio.new_event_loop()
+            _LOOP_THREAD = threading.Thread(
+                target=_LOOP.run_forever,
+                name="agent-asyncio-loop",
+                daemon=True,
+            )
+            _LOOP_THREAD.start()
         return _LOOP
 
 
 def _run_async(coro: Coroutine[Any, Any, Any]) -> Any:
-    """Safely execute a coroutine to completion regardless of caller context.
+    """Run a coroutine to completion on the persistent loop, from any thread.
 
-    Three paths:
-    1. No running loop on this thread → run on the persistent loop via
-       run_until_complete (the common Streamlit script-thread case).
-    2. Already inside a running loop on this thread (e.g. tests with
-       pytest-asyncio) → spawn a worker thread with a fresh asyncio.run
-       so we do not deadlock the caller's loop.
+    Submits to the dedicated loop thread and blocks the caller on the
+    result. Works whether or not the calling thread has its own running
+    loop (e.g. pytest-asyncio), and is safe under concurrency: the loop
+    multiplexes overlapping submissions instead of colliding the way
+    run_until_complete would.
+
+    Note the coroutine BODY executes on the loop thread, which has no
+    Streamlit ScriptRunContext. Code that must touch st.session_state or
+    render widgets has to run on the calling script thread instead — see
+    run_agentic_message_flow, which keeps streaming on the loop thread
+    but renders on the caller.
     """
-    try:
-        asyncio.get_running_loop()
-        in_loop = True
-    except RuntimeError:
-        in_loop = False
-
-    if not in_loop:
-        return _persistent_loop().run_until_complete(coro)
-
-    box: dict[str, Any] = {}
-
-    def _worker() -> None:
-        try:
-            box["value"] = asyncio.run(coro)
-        except BaseException as exc:  # propagate to caller thread
-            box["error"] = exc
-
-    t = threading.Thread(target=_worker, daemon=True)
-    t.start()
-    t.join()
-    if "error" in box:
-        raise box["error"]
-    return box.get("value")
+    return asyncio.run_coroutine_threadsafe(coro, _persistent_loop()).result()
 
 
 def run_agentic_message_flow(my_question: str) -> None:
@@ -118,40 +118,92 @@ def run_agentic_message_flow(my_question: str) -> None:
     # call raises — otherwise the chat_bot.py loop would re-fire the
     # same question on the next rerun and the user would see no response.
     try:
+        # The session is created here but used ONLY on the loop thread
+        # (audit writes, commit, close all live in produce()). SQLite's
+        # default check_same_thread forbids using one connection from two
+        # threads, and SQLAlchemy sessions aren't thread-safe — so we must
+        # not touch it from this (calling) thread once produce() owns it.
         sqlite_session = SessionLocal()
+        deps = build_agent_deps(sqlite_session)
+        runner = _runner()
+        prior_history = st.session_state.get("agent_message_history") or None
+
+        # Hand events from the loop thread back to this script thread. We
+        # render here, not inside the coroutine: _render_event calls
+        # st.* / add_message, which need this thread's ScriptRunContext.
+        # The loop thread has none.
+        events: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+
+        async def produce() -> None:
+            # Runs on the dedicated loop thread. Owns the session lifecycle
+            # so all of its DB I/O stays on one thread (see note above).
+            try:
+                async for event in runner.stream(my_question, deps=deps, message_history=prior_history):
+                    events.put(("event", event))
+                sqlite_session.commit()
+            finally:
+                sqlite_session.close()
+                events.put(("done", None))
+
+        future = asyncio.run_coroutine_threadsafe(produce(), _persistent_loop())
+
+        # Per-flow state for live placeholders. Two buckets keyed by
+        # turn_index so thinking and plain assistant text get distinct
+        # chat_message containers (different headers, different lifecycles).
+        # The finally block drains anything still open if the stream dies
+        # mid-flight — otherwise a partial "🤔 Thinking..." panel would
+        # stay frozen on screen.
+        renderer_state: dict[str, Any] = {"thinking": {}, "text": {}}
         try:
-            deps = build_agent_deps(sqlite_session)
-            runner = _runner()
-            prior_history = st.session_state.get("agent_message_history") or None
-
-            async def consume() -> None:
-                # Per-flow state for live placeholders. Two buckets keyed by
-                # turn_index so thinking and plain assistant text get distinct
-                # chat_message containers (different headers, different
-                # lifecycles). The finally block drains anything still open
-                # if the generator dies mid-stream — otherwise a partial
-                # "🤔 Thinking..." panel would stay frozen on screen.
-                renderer_state: dict[str, Any] = {"thinking": {}, "text": {}}
+            while True:
                 try:
-                    async for event in runner.stream(my_question, deps=deps, message_history=prior_history):
-                        _render_event(event, renderer_state)
-                finally:
-                    _drain_placeholders(renderer_state)
-
-            _run_async(consume())
-            sqlite_session.commit()
+                    kind, event = events.get(timeout=1.0)
+                except queue.Empty:
+                    # No event this second. produce() always emits its "done"
+                    # sentinel from a finally, so the only way the queue goes
+                    # quiet for good is a dead loop thread (interpreter
+                    # shutdown, or the loop closed mid-run). Bail in that case
+                    # so the script thread can't wedge forever. A slow-but-
+                    # alive producer keeps the future pending, so this never
+                    # fires during a long LLM turn between events.
+                    if future.done():
+                        break
+                    continue
+                if kind == "done":
+                    break
+                _render_event(event, renderer_state)
+            # Surface any exception raised inside produce() (and thus the
+            # agent run) to the caller, matching the old _run_async behavior.
+            future.result()
+            # runner.stream's own df-sync ran on the loop thread with no
+            # ScriptRunContext, so it was a no-op there (it's wrapped in a
+            # bare except). Redo it here on the script thread so magic
+            # functions and the Vanna flow see the final DataFrame.
+            _sync_last_dataframe_to_session_state(deps)
         finally:
-            sqlite_session.close()
+            _drain_placeholders(renderer_state)
     finally:
         # Parity with the Vanna flow at chat_bot_helper.py:1417.
         st.session_state["my_question"] = None
 
 
+def _sync_last_dataframe_to_session_state(deps: Any) -> None:
+    """Mirror deps.last_dataframe into st.session_state['df'] on the script
+    thread. runner.stream attempts this itself, but under the loop-thread
+    design that attempt has no ScriptRunContext and silently no-ops, so we
+    repeat it here where session_state is real. Tolerant of deps shapes
+    without last_dataframe (e.g. the exception-path unit test)."""
+    df = getattr(deps, "last_dataframe", None)
+    if df is not None:
+        st.session_state["df"] = df
+
+
 def _drain_placeholders(state: dict[str, Any]) -> None:
-    """Clear any open transient placeholders. Called from a finally block in
-    consume() so a mid-stream death (CapReachedEvent, exception, network
-    drop) doesn't leave a partial "🤔 Thinking..." panel frozen on screen.
-    Idempotent — safe to call multiple times."""
+    """Clear any open transient placeholders. Called from the finally block of
+    the consumer loop in run_agentic_message_flow (and from FinalResponseEvent /
+    CapReachedEvent handling) so a mid-stream death (exception, network drop,
+    cap reached) doesn't leave a partial "🤔 Thinking..." panel frozen on
+    screen. Idempotent — safe to call multiple times."""
     for bucket in ("thinking", "text"):
         slots = state.get(bucket) or {}
         for slot in slots.values():

--- a/orm/models.py
+++ b/orm/models.py
@@ -53,7 +53,18 @@ def _get_database_url() -> str:
 
 
 DATABASE_URL = _get_database_url()
-engine = create_engine(DATABASE_URL)
+# The agentic flow (agent/runtime.py) writes this DB from two threads at once:
+# the agent's audit rows on a dedicated asyncio loop thread, and Message.save on
+# the Streamlit script thread. They can hold overlapping write transactions, so
+# SQLite's busy-wait is functionally relied upon here. SQLAlchemy's pysqlite
+# dialect already allows cross-thread pooled connections and the sqlite3 busy
+# timeout already defaults to 5s, so the original engine was adequate; we set
+# these explicitly to record that cross-thread use is intended and to widen the
+# write-lock wait to 30s for headroom under contention.
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False, "timeout": 30},
+)
 
 # Create a configured "Session" class
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/agent/test_runtime_async_bridge.py
+++ b/tests/agent/test_runtime_async_bridge.py
@@ -1,9 +1,10 @@
 """Tests for the asyncio bridge used in agent/runtime.py.
 
-Streamlit's script thread sometimes has a running event loop (Tornado),
-sometimes does not. The bridge must:
-- Detect a running loop and run the coroutine in a worker thread.
-- Otherwise use a fresh loop (asyncio.run-equivalent).
+The bridge runs a single persistent event loop forever on a dedicated daemon
+thread; callers on any thread submit coroutines with run_coroutine_threadsafe
+and block on the result. This keeps pydantic-ai's httpx transports bound to one
+live loop and lets concurrent Streamlit script threads share it without the
+"this event loop is already running" collision that run_until_complete caused.
 """
 
 import asyncio
@@ -65,6 +66,47 @@ def test_run_async_reuses_a_persistent_loop_across_calls():
     a = _run_async(get_loop_id())
     b = _run_async(get_loop_id())
     assert a == b
+
+
+def test_run_async_handles_concurrent_calls_from_multiple_threads():
+    """Regression for 'RuntimeError: this event loop is already running'.
+
+    Two Streamlit script threads can drive the shared loop at the same
+    time (two sessions, or a rerun firing while a long run is still
+    unwinding). The old bridge used asyncio.get_running_loop(), which
+    only sees a loop on the *current* thread, then called
+    run_until_complete on the shared loop — which raises if that loop is
+    already running on another thread. Concurrent calls must succeed.
+    """
+    import threading
+
+    from agent.runtime import _run_async
+
+    # Force overlap: both threads enter _run_async together and stay busy
+    # for the same window.
+    barrier = threading.Barrier(2)
+    results: dict[int, object] = {}
+    errors: dict[int, BaseException] = {}
+
+    async def work(tag: int) -> int:
+        await asyncio.sleep(0.3)
+        return tag
+
+    def run(tag: int) -> None:
+        barrier.wait()
+        try:
+            results[tag] = _run_async(work(tag))
+        except BaseException as exc:  # noqa: BLE001 - capture for assertion
+            errors[tag] = exc
+
+    threads = [threading.Thread(target=run, args=(i,)) for i in (0, 1)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    assert results == {0: 0, 1: 1}
 
 
 def test_run_agentic_flow_closes_sqlite_session_on_exception(monkeypatch):

--- a/tests/orm/test_engine_multithread.py
+++ b/tests/orm/test_engine_multithread.py
@@ -1,0 +1,59 @@
+"""The agentic flow (agent/runtime.py) writes the app DB from two threads at
+once: the agent's audit rows on a dedicated asyncio loop thread, and
+Message.save on the Streamlit script thread. This guards the property that
+flow depends on — concurrent writers against one SQLite file both succeed
+(cross-thread connections are allowed and a writer waits for the lock instead
+of raising "database is locked"). Mirrors the connect_args in orm/models.py.
+"""
+
+import threading
+
+from sqlalchemy import Column, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+_Base = declarative_base()
+
+
+class _Row(_Base):
+    __tablename__ = "concurrent_rows"
+    id = Column(Integer, primary_key=True)
+    tag = Column(String, nullable=False)
+
+
+def test_concurrent_writers_from_two_threads_all_commit(tmp_path):
+    db = tmp_path / "concurrent.sqlite3"
+    engine = create_engine(
+        f"sqlite:///{db}",
+        connect_args={"check_same_thread": False, "timeout": 30},
+    )
+    _Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+
+    writes_per_thread = 50
+    errors: dict[str, BaseException] = {}
+    barrier = threading.Barrier(2)
+
+    def writer(tag: str) -> None:
+        barrier.wait()  # maximize overlap / lock contention
+        try:
+            for _ in range(writes_per_thread):
+                session = Session()
+                try:
+                    session.add(_Row(tag=tag))
+                    session.commit()
+                finally:
+                    session.close()
+        except BaseException as exc:  # noqa: BLE001 - capture for assertion
+            errors[tag] = exc
+
+    threads = [threading.Thread(target=writer, args=(t,)) for t in ("loop", "script")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors
+    with Session() as session:
+        assert session.query(_Row).count() == 2 * writes_per_thread
+
+    engine.dispose()


### PR DESCRIPTION
## Problem

Intermittent `RuntimeError: this event loop is already running` from the agentic message flow:

```
File "agent/runtime.py", line 141, in run_agentic_message_flow
    _run_async(consume())
File "agent/runtime.py", line 81, in _run_async
    return _persistent_loop().run_until_complete(coro)
...
RuntimeError: this event loop is already running
```

## Root cause

`agent/runtime.py` kept a single process-wide asyncio loop and drove it with `loop.run_until_complete()` from Streamlit script threads. `asyncio.get_running_loop()` only detects a loop bound to the **current** thread, so when two agentic runs overlapped — two sessions, or (more often) a rerun firing on a fresh script thread while a prior long run was still unwinding — a second thread saw "no loop on me," grabbed the same shared loop, and called `run_until_complete` on a loop already running on another thread. Hence the intermittent crash.

## Fix

- **Dedicated loop thread.** The persistent loop now runs forever on its own daemon thread; callers on any thread submit via `asyncio.run_coroutine_threadsafe(...).result()`. One `run_forever` loop multiplexes overlapping submissions instead of colliding, while keeping pydantic-ai's httpx transports bound to a single live loop.
- **Queue handoff.** `run_agentic_message_flow` streams the agent on the loop thread and pushes events onto a `queue.Queue`; the calling script thread drains and renders, because `_render_event`/`add_message`/`st.*` need Streamlit's thread-local `ScriptRunContext`. The consumer polls with a 1s timeout and bails if the producer future is already done, so a dead loop thread can't wedge the UI. The SQLite session's commit/close moved onto the loop thread (single-thread session I/O); the `st.session_state["df"]` sync is re-done on the script thread after the run.
- **Engine connect_args.** `orm/models.py` sets `check_same_thread=False, timeout=30` explicitly — the agent's audit writes and `Message.save` now hold overlapping write transactions, so SQLite's busy-wait is relied upon (SQLAlchemy's defaults already supplied a 5s wait; we widen it and document the cross-thread intent).

## Tests

- `test_run_async_handles_concurrent_calls_from_multiple_threads` — reproduces the crash on the old bridge, passes now.
- `test_concurrent_writers_from_two_threads_all_commit` — two threads × 50 commits to one SQLite file.
- All existing bridge contracts (no-loop, in-loop, exception propagation, persistent-loop reuse, session-close-on-exception) still pass. Full agent + orm suite: 495 passed.

Reviewed by a code-reviewer agent; Important findings (un-timed `events.get()`, comment accuracy) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)