### PR TITLE
test: make flaky/non-hermetic tests deterministic (full suite green)

### DIFF
--- a/tests/agent/db/test_surgeries_queries.py
+++ b/tests/agent/db/test_surgeries_queries.py
@@ -56,16 +56,6 @@ def test_surgeries_excludes_inspection_pcs(synthetic_db):
     assert "0WJG4ZZ" not in problem_codes
 
 
-def test_surgeries_claims_broadly_inclusive(synthetic_db):
-    """Claims branch includes 0DTJ4ZZ (Resection) but excludes 0WJG4ZZ (Inspection)."""
-    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
-    sql, params = surgeries_sql(source_id="src-john-1962")
-    rows = adapter.fetch_all(sql, params)
-    claims_codes = {r["code"] for r in rows if r["source"] == "claims"}
-    assert "0DTJ4ZZ" in claims_codes
-    assert "0WJG4ZZ" not in claims_codes
-
-
 def test_surgeries_performing_provider_lists_all_when_ambiguous(synthetic_db):
     """The knee arthroplasty on 2025-06-15 matches two encounters → comma-joined list."""
     adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,10 +41,21 @@ def test_temp_dir():
 # In-memory ChromaDB client for tests
 @pytest.fixture
 def in_memory_chromadb_client():
-    """Provides an in-memory ChromaDB client that doesn't persist to disk."""
+    """Provides an in-memory ChromaDB client that doesn't persist to disk.
+
+    chromadb.Client() returns a process-wide shared in-memory instance (chromadb
+    caches the ephemeral system by a constant identifier, so separate Client()
+    calls share collections). Wipe any collections left by earlier tests so each
+    test starts clean — otherwise a collection created with one embedding
+    dimension leaks into a test using another and inserts fail silently
+    ("Collection expecting embedding with dimension of 8, got 3").
+    """
     import chromadb
 
-    return chromadb.Client()
+    client = chromadb.Client()
+    for col in client.list_collections():
+        client.delete_collection(col.name if hasattr(col, "name") else col)
+    return client
 
 
 # Test-specific temporary ChromaDB path

--- a/tests/scripts/test_init_analytics_db.py
+++ b/tests/scripts/test_init_analytics_db.py
@@ -43,10 +43,16 @@ def test_init_analytics_db_is_idempotent(tmp_path: Path) -> None:
     target = tmp_path / "analytics.sqlite3"
 
     init_analytics_db(target)
-    init_analytics_db(target)  # second run must not raise
-
     engine = create_engine(f"sqlite:///{target}")
     with engine.connect() as conn:
-        count = conn.execute(text("SELECT COUNT(*) FROM internal_patient_profile_v")).scalar()
-    # idempotent reseed should produce the same row count, not double it
-    assert count == 3
+        first = conn.execute(text("SELECT COUNT(*) FROM internal_patient_profile_v")).scalar()
+
+    init_analytics_db(target)  # second run must not raise
+    with engine.connect() as conn:
+        second = conn.execute(text("SELECT COUNT(*) FROM internal_patient_profile_v")).scalar()
+
+    # The seed drops-and-recreates, so a reseed must produce the same row count,
+    # not double it. Asserting against the first run (rather than a hardcoded
+    # literal) keeps this green as the synthetic seed data grows.
+    assert first and first > 0
+    assert second == first

--- a/tests/utils/test_milvus_role_integration.py
+++ b/tests/utils/test_milvus_role_integration.py
@@ -8,6 +8,14 @@ from utils.milvus_vector import ThriveAI_Milvus
 from utils.vanna_calls import UserContext, VannaService
 
 
+@pytest.fixture(autouse=True)
+def _enable_role_restriction(monkeypatch):
+    """Force role-restricted RAG retrieval ON. The dev .streamlit/secrets.toml
+    sets security.restrict_rag_by_role = false, which collapses every effective
+    role to 0 and defeats the RBAC assertions below."""
+    monkeypatch.setattr(ThriveAI_Milvus, "_is_role_restriction_enabled", lambda self: True)
+
+
 @pytest.mark.milvus
 @pytest.mark.skipif(pytest.importorskip("pymilvus", reason="pymilvus not installed") is None, reason="pymilvus missing")
 def test_vannaservice_with_milvus_rbac(tmp_path):

--- a/tests/utils/test_milvus_unit.py
+++ b/tests/utils/test_milvus_unit.py
@@ -5,6 +5,14 @@ pymilvus = pytest.importorskip("pymilvus")
 from utils.milvus_vector import ThriveAI_Milvus
 
 
+@pytest.fixture(autouse=True)
+def _enable_role_restriction(monkeypatch):
+    """Force role-restricted RAG retrieval ON. The dev .streamlit/secrets.toml
+    sets security.restrict_rag_by_role = false, which collapses every effective
+    role to 0 and defeats the role-filter assertions below."""
+    monkeypatch.setattr(ThriveAI_Milvus, "_is_role_restriction_enabled", lambda self: True)
+
+
 def _make_store(tmp_path, role: int):
     return ThriveAI_Milvus(
         user_role=role,

--- a/tests/utils/test_ollama_temperature.py
+++ b/tests/utils/test_ollama_temperature.py
@@ -84,6 +84,11 @@ def test_vanna_calls_injects_temperature_from_secrets(monkeypatch):
             "ai_keys": {
                 "ollama_model": "llama3",
                 "ollama_temperature": 0.7,
+                # MyVannaOllama wraps VannaDB_VectorStore, whose init args read
+                # these two keys directly from secrets (evaluated before the
+                # patched no-op __init__ runs), so they must be present.
+                "vanna_model": "mock_vanna_model",
+                "vanna_api": "mock_vanna_api",
             },
             "postgres": {"schema_name": "public", "dialect": "postgresql"},
         },

--- a/tests/utils/test_user_questions.py
+++ b/tests/utils/test_user_questions.py
@@ -1,29 +1,30 @@
-import json
+"""Developer integration smoke test for the user-questions queries.
+
+This exercises get_user_recent_questions / get_user_questions_page against the
+local dev SQLite DB (./pgDatabase/db.sqlite3) and a known seeded user. It is
+inherently non-hermetic, so it skips cleanly when that DB or user isn't present
+(e.g. CI or a fresh checkout) rather than failing the suite.
+"""
+
 from pathlib import Path
 
-import streamlit as st
+import pytest
 
 from orm.functions import get_user_questions_page, get_user_recent_questions
 from orm.models import SessionLocal, User
 
 
-def _set_sqlite_for_tests(db_path: str):
-    # Override st.secrets sqlite to point to provided path
-    # Note: In this repo, orm.models reads st.secrets['sqlite'] at import time.
-    # So we refresh by reloading orm.models if needed.
-    st.secrets["sqlite"] = {"database": db_path}
-
-
 def test_recent_questions_for_known_user_kr():
-    db_file = str(Path("./pgDatabase/db.sqlite3").resolve())
-    assert Path(db_file).exists(), "Expected SQLite db at ./pgDatabase/db.sqlite3"
+    db_file = Path("./pgDatabase/db.sqlite3").resolve()
+    if not db_file.exists():
+        pytest.skip(f"Local SQLite DB not present at {db_file}; developer-only smoke test")
 
-    _set_sqlite_for_tests(db_file)
-
-    # Find user id for thriveai-kr
+    # orm.models.SessionLocal is already bound to the configured DB at import,
+    # so no secrets mutation is needed (and st.secrets is read-only anyway).
     with SessionLocal() as session:
         user = session.query(User).filter(User.username == "thriveai-kr").first()
-        assert user is not None, "User thriveai-kr must exist in the database"
+        if user is None:
+            pytest.skip("User 'thriveai-kr' not present in local DB; developer-only smoke test")
         user_id = user.id
 
     # Recent questions (deduped)
@@ -36,7 +37,7 @@ def test_recent_questions_for_known_user_kr():
     assert "items" in page and "total" in page
     items = page["items"]
     assert isinstance(items, list)
-    # When there is history for this user, we expect some items. If empty, this will still pass but be informative.
+    # When there is history for this user, we expect well-formed rows.
     if items:
         row = items[0]
         assert "question" in row and "created_at" in row

--- a/tests/utils/test_vanna_ddl_training.py
+++ b/tests/utils/test_vanna_ddl_training.py
@@ -10,6 +10,18 @@ from utils.chromadb_vector import ThriveAI_ChromaDB
 from utils.vanna_calls import VannaService, train_ddl, train_ddl_describe_to_rag
 
 
+@pytest.fixture(autouse=True)
+def _enable_role_restriction(monkeypatch):
+    """Force role-restricted RAG retrieval ON for this module.
+
+    The dev .streamlit/secrets.toml sets security.restrict_rag_by_role = false,
+    which collapses every effective role to 0 (_get_effective_role) and defeats
+    the role-filter assertions here. Pinning the toggle keeps these tests
+    hermetic w.r.t. whatever the local secrets happen to say.
+    """
+    monkeypatch.setattr(ThriveAI_ChromaDB, "_is_role_restriction_enabled", lambda self: True)
+
+
 # Mock the streamlit secrets for testing
 @pytest.fixture(scope="function")  # Changed from module to function
 def mock_streamlit_secrets_ddl(test_chromadb_path):
@@ -173,8 +185,11 @@ def test_train_ddl_adds_to_chromadb_with_user_role(
         assert len(results["ids"]) == 2  # Two DDL statements added
 
         added_ddls = results["documents"]
-        expected_ddl_users = "\nCREATE TABLE users (\n    id integer NOT NULL,\n    name varchar NULL\n);"  # Note: VannaService.train joins DDL list with " "
-        expected_ddl_orders = "\nCREATE TABLE orders (\n    order_id integer NOT NULL,\n    item varchar NOT NULL\n);"
+        # DDL is schema-qualified now (CREATE TABLE <schema>.<table>); schema is "public".
+        expected_ddl_users = "\nCREATE TABLE public.users (\n    id integer NOT NULL,\n    name varchar NULL\n);"  # Note: VannaService.train joins DDL list with " "
+        expected_ddl_orders = (
+            "\nCREATE TABLE public.orders (\n    order_id integer NOT NULL,\n    item varchar NOT NULL\n);"
+        )
 
         # Check if the formatted DDL strings are present (order might vary)
         # The actual DDL sent to train is " ".join(ddl_list_for_table)
@@ -184,14 +199,14 @@ def test_train_ddl_adds_to_chromadb_with_user_role(
 
         first_call_ddl = call_args_list[0].kwargs["ddl"]
         first_call_metadata = call_args_list[0].kwargs["metadata"]
-        assert "CREATE TABLE users (" in first_call_ddl
+        assert "CREATE TABLE public.users (" in first_call_ddl
         assert "id integer NOT NULL" in first_call_ddl
         assert "name varchar NULL" in first_call_ddl
         assert first_call_metadata["user_role"] == expected_user_role
 
         second_call_ddl = call_args_list[1].kwargs["ddl"]
         second_call_metadata = call_args_list[1].kwargs["metadata"]
-        assert "CREATE TABLE orders (" in second_call_ddl
+        assert "CREATE TABLE public.orders (" in second_call_ddl
         assert "order_id integer NOT NULL" in second_call_ddl
         assert "item varchar NOT NULL" in second_call_ddl
         assert second_call_metadata["user_role"] == expected_user_role
@@ -201,9 +216,9 @@ def test_train_ddl_adds_to_chromadb_with_user_role(
         found_orders_ddl = False
         for doc_meta in zip(results["documents"], results["metadatas"]):
             doc, meta = doc_meta
-            if "CREATE TABLE users (" in doc:
+            if "CREATE TABLE public.users (" in doc:
                 found_users_ddl = True
-            if "CREATE TABLE orders (" in doc:
+            if "CREATE TABLE public.orders (" in doc:
                 found_orders_ddl = True
             assert meta["user_role"] == expected_user_role
 

--- a/tests/utils/test_vanna_implementations.py
+++ b/tests/utils/test_vanna_implementations.py
@@ -167,12 +167,13 @@ class TestTrainDDL:
 
         # Verify the calls contain the expected DDL statements
         first_call_args = mock_service.train.call_args_list[0][1]
-        assert "CREATE TABLE users" in first_call_args["ddl"]
+        # DDL is schema-qualified now (CREATE TABLE <schema>.<table>); schema is "public".
+        assert "CREATE TABLE public.users" in first_call_args["ddl"]
         assert "id integer NOT NULL" in first_call_args["ddl"]
         assert "name varchar NULL" in first_call_args["ddl"]
 
         second_call_args = mock_service.train.call_args_list[1][1]
-        assert "CREATE TABLE posts" in second_call_args["ddl"]
+        assert "CREATE TABLE public.posts" in second_call_args["ddl"]
         assert "id integer NOT NULL" in second_call_args["ddl"]
         assert "title varchar NOT NULL" in second_call_args["ddl"]
 


### PR DESCRIPTION
## Problem

A recurring set of tests failed "every time" locally because they weren't hermetic — they bled in the developer's real `secrets.toml`, local SQLite DBs, and a shared in-process ChromaDB. 16 failures in the default (`not milvus`) run, plus 1 milvus-marked and 1 deselected.

## Root causes (no product bugs)

Investigated each; everything in the product is working as intended:

| Failure(s) | Root cause |
|---|---|
| milvus + chromadb role-filter tests | Inherited dev `restrict_rag_by_role = false`, collapsing every effective role to 0 |
| chromadb cluster (8 ordering-only failures) | `chromadb.Client()` is a process-wide shared singleton; a collection created at one embedding dim leaked into a test using another → silent insert failures (`expecting dimension 8, got 3`) |
| `test_train_ddl*` assertions | Product emits schema-qualified DDL (`CREATE TABLE public.users`); assertions were stale |
| `test_init_analytics_db_is_idempotent` | Seed grew 3→8 rows; assertion hardcoded `== 3` (script is genuinely idempotent) |
| `test_ollama_temperature` | Mocked secrets missing `vanna_model`/`vanna_api` that `MyVannaOllama.__init__` reads |
| `test_user_questions` | Depended on local `./pgDatabase/db.sqlite3` + seeded user; wrote to now-immutable `st.secrets` |
| `test_surgeries_claims_broadly_inclusive` | Claims branch is intentionally disabled (`claims_filter = "AND 1 = 0"`; the warehouse view has no patient identifier) |

## Fixes

- Autouse fixtures pin `restrict_rag_by_role` ON for the role-filter tests (milvus unit/integration + chromadb).
- `in_memory_chromadb_client` fixture wipes leftover collections at setup (kills the cross-test dimension pollution for all consumers).
- Updated stale DDL assertions to the schema-qualified form.
- `test_init_analytics_db_is_idempotent` asserts reseed == first-run count (resilient to seed growth).
- Completed the `test_ollama_temperature` mocked secrets.
- `test_user_questions` now skip-guards when the local DB/user is absent and drops the broken `st.secrets` write.
- Deleted the surgeries claims test (claims branch is a deliberate no-op; orders/problems siblings cover the logic).

## Verification

Complete suite (including milvus-marked): **1000 passed, 4 skipped, 0 failed**. No deselects required. All test-only changes; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)