### PR TITLE
feat(agent-analytics): enrich "Inspect a run" selectbox labels

### DIFF
--- a/views/agent_analytics.py
+++ b/views/agent_analytics.py
@@ -84,8 +84,17 @@ def _render_runs_tab(days: int) -> None:
         hide_index=True,
     )
 
+    run_by_id = {r["run_id"]: r for r in runs}
+
+    def _format_run(run_id: str) -> str:
+        if run_id == "—":
+            return "—"
+        r = run_by_id[run_id]
+        question = (r.get("question") or "").strip()[:200]
+        return f"{run_id[:8]} · {r.get('tool_call_count')} tools · {r.get('status')} · {question}"
+
     run_ids = [r["run_id"] for r in runs]
-    selected = st.selectbox("Inspect a run", options=["—"] + run_ids)
+    selected = st.selectbox("Inspect a run", options=["—"] + run_ids, format_func=_format_run)
     if selected and selected != "—":
         _render_run_inspector(selected)
 


### PR DESCRIPTION
## Summary
The "Inspect a run" selectbox in Agentic Analytics previously showed only the bare run UUID. It now surfaces, per option:

```
{uuid[:8]} · {tool_call_count} tools · {status} · {question[:200]}
```

## Implementation
- Uses a `format_func` on `st.selectbox`; **options remain full `run_id` strings**, so `selected` still returns the complete UUID and `_render_run_inspector(selected)` is unchanged.
- The `"—"` placeholder is handled in the formatter.
- No data-layer changes — `question`, `tool_call_count`, and `status` already come back from `get_recent_agent_runs`.

## Verification
- `ruff check` passes; `ruff format` applied.
- File parses under the project interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)