### PR TITLE
feat(agent): single-dimension population breakdowns for search_patients_by_criteria

### DIFF
--- a/agent/dataframe_adapters.py
+++ b/agent/dataframe_adapters.py
@@ -50,12 +50,15 @@ def run_sql_result_to_df(result: "RunSqlResult") -> pd.DataFrame:
 
 
 def cohort_result_to_df(result: "CohortResult") -> pd.DataFrame:
-    """Flatten CohortResult.sample into a DataFrame with the
-    canonical cohort columns.
+    """Flatten a CohortResult into a DataFrame.
 
-    Empty sample returns a zero-row DataFrame (consistent with the
-    other adapters in this module).
+    Breakdown results (non-empty `buckets`) take precedence and render as
+    one row per bucket — the per-patient sample is suppressed in breakdown
+    mode. Otherwise flatten `sample`. Empty either way returns a zero-row
+    DataFrame (consistent with the other adapters in this module).
     """
+    if getattr(result, "buckets", None):
+        return pd.DataFrame([b.model_dump(mode="json") for b in result.buckets])
     if not result.sample:
         return pd.DataFrame()
     return pd.DataFrame([match.model_dump(mode="json") for match in result.sample])

--- a/agent/db/queries/cohort.py
+++ b/agent/db/queries/cohort.py
@@ -43,6 +43,95 @@ def _state_aliases(state_input: str) -> tuple[str, ...]:
     return _STATE_ALIAS_MAP.get(key, (key,))
 
 
+def _diagnosis_event_where(criteria) -> tuple[list[str], dict] | None:
+    """Build the WHERE fragment for the diagnosis-event subquery.
+
+    Returns (filter_clauses, params) when a diagnosis criterion is active
+    (codes and/or an active date window), else None. Shared by cohort_sql
+    (DISTINCT patient_id join) and the breakdown builder (event-level join
+    that preserves start_date). Param keys: dx_<i>, dx_start, dx_end.
+    """
+    _dr = getattr(criteria, "diagnosis_date_range", None)
+    _dr_active = _dr is not None and (getattr(_dr, "start", None) or getattr(_dr, "end", None))
+    if not (getattr(criteria, "diagnosis_codes", None) or _dr_active):
+        return None
+
+    params: dict = {}
+    dx_filter = ["code_type IN ('ICD-10', 'ICD10', 'SNOMED')"]
+    if getattr(criteria, "diagnosis_codes", None):
+        codes = list(criteria.diagnosis_codes)
+        placeholders = ", ".join(f":dx_{i}" for i in range(len(codes)))
+        for i, c in enumerate(codes):
+            params[f"dx_{i}"] = c
+        dx_filter.insert(0, f"code IN ({placeholders})")
+    if _dr_active:
+        if getattr(_dr, "start", None):
+            dx_filter.append("start_date >= :dx_start")
+            params["dx_start"] = _dr.start.isoformat()
+        if getattr(_dr, "end", None):
+            dx_filter.append("start_date <= :dx_end")
+            params["dx_end"] = _dr.end.isoformat()
+    return dx_filter, params
+
+
+def _build_non_diagnosis_filters(criteria, schema_prefix: str) -> tuple[list[str], list[str], dict]:
+    """Build (medication joins, where clauses, params) for everything except
+    the diagnosis filter. Shared by cohort_sql and the breakdown builder so
+    geo/demographic/medication logic lives in exactly one place.
+    """
+    params: dict = {}
+    join_clauses: list[str] = []
+    where_clauses: list[str] = []
+
+    if getattr(criteria, "medication_rxnorm_codes", None):
+        codes = list(criteria.medication_rxnorm_codes)
+        placeholders = ", ".join(f":med_{i}" for i in range(len(codes)))
+        for i, c in enumerate(codes):
+            params[f"med_{i}"] = c
+        join_clauses.append(
+            f"JOIN (SELECT DISTINCT patient_id FROM {schema_prefix}metric_federated_data_v "
+            f"WHERE code IN ({placeholders}) "
+            f"AND code_type IN ('RxNorm', 'NDC')) med ON med.patient_id = p.patient_id"
+        )
+
+    if getattr(criteria, "zip_code", None):
+        where_clauses.append("p.zip_code = :geo_zip")
+        params["geo_zip"] = criteria.zip_code
+    if getattr(criteria, "city", None):
+        where_clauses.append("LOWER(p.city) LIKE :geo_city")
+        params["geo_city"] = f"%{criteria.city.lower()}%"
+    if getattr(criteria, "state", None):
+        forms = _state_aliases(criteria.state)
+        placeholders = ", ".join(f":geo_state_{i}" for i in range(len(forms)))
+        where_clauses.append(f"UPPER(p.state) IN ({placeholders})")
+        for i, form in enumerate(forms):
+            params[f"geo_state_{i}"] = form
+
+    if getattr(criteria, "age_min", None) is not None:
+        where_clauses.append("p.age >= :age_min")
+        params["age_min"] = criteria.age_min
+    if getattr(criteria, "age_max", None) is not None:
+        where_clauses.append("p.age <= :age_max")
+        params["age_max"] = criteria.age_max
+    if getattr(criteria, "gender", None):
+        where_clauses.append("p.gender = :gender")
+        params["gender"] = criteria.gender
+    if getattr(criteria, "facility", None):
+        where_clauses.append("LOWER(p.practice_name) LIKE :facility")
+        params["facility"] = f"%{criteria.facility.lower()}%"
+    if getattr(criteria, "last_visit_after", None):
+        where_clauses.append("p.last_date_of_visit >= :lv_after")
+        params["lv_after"] = criteria.last_visit_after.isoformat()
+    if getattr(criteria, "last_visit_before", None):
+        where_clauses.append("p.last_date_of_visit <= :lv_before")
+        params["lv_before"] = criteria.last_visit_before.isoformat()
+    if getattr(criteria, "condition_text", None):
+        where_clauses.append("LOWER(p.conditions) LIKE :cond_text")
+        params["cond_text"] = f"%{criteria.condition_text.lower()}%"
+
+    return join_clauses, where_clauses, params
+
+
 def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
     """Build the SELECT for search_patients_by_criteria.
 
@@ -80,95 +169,22 @@ def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
     params: dict = {}
     join_clauses: list[str] = []
     # 1=1 is a structural placeholder so the WHERE always parses when
-    # only JOIN-based filters (codes) are active. The criterion guard
-    # above guarantees this is never an unfiltered scan.
+    # only JOIN-based filters (codes) are active.
     where_clauses: list[str] = ["1=1"]
 
-    # --- diagnosis: codes and/or date window --------------------------
-    # The diagnosis JOIN fires when codes are given, a date window is given,
-    # or both. With only a window we drop the code IN clause and count any
-    # ICD-10/SNOMED problem whose start_date falls in range; medication rows
-    # (RxNorm/NDC) are excluded by the code_type filter so "any diagnosis"
-    # never counts a prescription.
-    if getattr(criteria, "diagnosis_codes", None) or _dr_active:
-        dx_filter = ["code_type IN ('ICD-10', 'ICD10', 'SNOMED')"]
-        if getattr(criteria, "diagnosis_codes", None):
-            codes = list(criteria.diagnosis_codes)
-            placeholders = ", ".join(f":dx_{i}" for i in range(len(codes)))
-            for i, c in enumerate(codes):
-                params[f"dx_{i}"] = c
-            dx_filter.insert(0, f"code IN ({placeholders})")
-        if _dr_active:
-            if getattr(_dr, "start", None):
-                dx_filter.append("start_date >= :dx_start")
-                params["dx_start"] = _dr.start.isoformat()
-            if getattr(_dr, "end", None):
-                dx_filter.append("start_date <= :dx_end")
-                params["dx_end"] = _dr.end.isoformat()
+    dx = _diagnosis_event_where(criteria)
+    if dx is not None:
+        dx_filter, dx_params = dx
+        params.update(dx_params)
         join_clauses.append(
             f"JOIN (SELECT DISTINCT patient_id FROM {schema_prefix}metric_federated_data_v "
             f"WHERE {' AND '.join(dx_filter)}) dx ON dx.patient_id = p.patient_id"
         )
 
-    # --- medication codes ---------------------------------------------
-    if getattr(criteria, "medication_rxnorm_codes", None):
-        codes = list(criteria.medication_rxnorm_codes)
-        placeholders = ", ".join(f":med_{i}" for i in range(len(codes)))
-        for i, c in enumerate(codes):
-            params[f"med_{i}"] = c
-        join_clauses.append(
-            f"JOIN (SELECT DISTINCT patient_id FROM {schema_prefix}metric_federated_data_v "
-            f"WHERE code IN ({placeholders}) "
-            f"AND code_type IN ('RxNorm', 'NDC')) med ON med.patient_id = p.patient_id"
-        )
-
-    # --- geographic filters (direct on internal_patient_profile_v) -----
-    # Live probe (May 2026) confirmed zip_code/city/state are structured
-    # columns on internal_patient_profile_v with 100% zip coverage. No
-    # JOIN to federated_demographic_v is needed; that view has the same
-    # data but the cohort path already lands on internal_patient_profile_v.
-    if getattr(criteria, "zip_code", None):
-        where_clauses.append("p.zip_code = :geo_zip")
-        params["geo_zip"] = criteria.zip_code
-    if getattr(criteria, "city", None):
-        # City strings are inconsistent ("BUFFALO" vs "Buffalo" vs "TN OF TONA");
-        # case-insensitive substring is the safest match.
-        where_clauses.append("LOWER(p.city) LIKE :geo_city")
-        params["geo_city"] = f"%{criteria.city.lower()}%"
-    if getattr(criteria, "state", None):
-        # internal_patient_profile_v.state holds both 2-letter codes
-        # ("NY") and full names ("NEW YORK") inconsistently. Match either
-        # form when we can map the input to its alias; fall back to a
-        # single-form exact match for unknown inputs. Without this,
-        # state="NY" silently misses every "NEW YORK" row and vice versa.
-        forms = _state_aliases(criteria.state)
-        placeholders = ", ".join(f":geo_state_{i}" for i in range(len(forms)))
-        where_clauses.append(f"UPPER(p.state) IN ({placeholders})")
-        for i, form in enumerate(forms):
-            params[f"geo_state_{i}"] = form
-
-    # --- demographic / visit filters ----------------------------------
-    if getattr(criteria, "age_min", None) is not None:
-        where_clauses.append("p.age >= :age_min")
-        params["age_min"] = criteria.age_min
-    if getattr(criteria, "age_max", None) is not None:
-        where_clauses.append("p.age <= :age_max")
-        params["age_max"] = criteria.age_max
-    if getattr(criteria, "gender", None):
-        where_clauses.append("p.gender = :gender")
-        params["gender"] = criteria.gender
-    if getattr(criteria, "facility", None):
-        where_clauses.append("LOWER(p.practice_name) LIKE :facility")
-        params["facility"] = f"%{criteria.facility.lower()}%"
-    if getattr(criteria, "last_visit_after", None):
-        where_clauses.append("p.last_date_of_visit >= :lv_after")
-        params["lv_after"] = criteria.last_visit_after.isoformat()
-    if getattr(criteria, "last_visit_before", None):
-        where_clauses.append("p.last_date_of_visit <= :lv_before")
-        params["lv_before"] = criteria.last_visit_before.isoformat()
-    if getattr(criteria, "condition_text", None):
-        where_clauses.append("LOWER(p.conditions) LIKE :cond_text")
-        params["cond_text"] = f"%{criteria.condition_text.lower()}%"
+    other_joins, other_where, other_params = _build_non_diagnosis_filters(criteria, schema_prefix)
+    join_clauses.extend(other_joins)
+    where_clauses.extend(other_where)
+    params.update(other_params)
 
     sample_size = getattr(criteria, "sample_size", 20)
     join_block = "\n        ".join(join_clauses)

--- a/agent/db/queries/cohort.py
+++ b/agent/db/queries/cohort.py
@@ -43,6 +43,15 @@ def _state_aliases(state_input: str) -> tuple[str, ...]:
     return _STATE_ALIAS_MAP.get(key, (key,))
 
 
+def _has_diagnosis_criterion(criteria) -> bool:
+    """True when a diagnosis filter is active: codes and/or an active date window.
+    An all-None diagnosis_date_range carries no filter and does not count.
+    """
+    _dr = getattr(criteria, "diagnosis_date_range", None)
+    _dr_active = _dr is not None and (getattr(_dr, "start", None) or getattr(_dr, "end", None))
+    return bool(getattr(criteria, "diagnosis_codes", None) or _dr_active)
+
+
 def _diagnosis_event_where(criteria) -> tuple[list[str], dict] | None:
     """Build the WHERE fragment for the diagnosis-event subquery.
 
@@ -53,7 +62,7 @@ def _diagnosis_event_where(criteria) -> tuple[list[str], dict] | None:
     """
     _dr = getattr(criteria, "diagnosis_date_range", None)
     _dr_active = _dr is not None and (getattr(_dr, "start", None) or getattr(_dr, "end", None))
-    if not (getattr(criteria, "diagnosis_codes", None) or _dr_active):
+    if not _has_diagnosis_criterion(criteria):
         return None
 
     params: dict = {}
@@ -75,7 +84,7 @@ def _diagnosis_event_where(criteria) -> tuple[list[str], dict] | None:
 
 
 def _build_non_diagnosis_filters(criteria, schema_prefix: str) -> tuple[list[str], list[str], dict]:
-    """Build (medication joins, where clauses, params) for everything except
+    """Build (join_clauses, where_clauses, params) for everything except
     the diagnosis filter. Shared by cohort_sql and the breakdown builder so
     geo/demographic/medication logic lives in exactly one place.
     """
@@ -141,16 +150,9 @@ def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
 
     Returns (sql, params). The caller passes both into adapter.fetch_all.
     """
-    # A diagnosis_date_range with a start or end bound is a standalone
-    # criterion ("any diagnosis in this window"); an all-None DateRange
-    # carries no filter and does not count.
-    _dr = getattr(criteria, "diagnosis_date_range", None)
-    _dr_active = _dr is not None and (getattr(_dr, "start", None) or getattr(_dr, "end", None))
-
     if not any(
         (
-            getattr(criteria, "diagnosis_codes", None),
-            _dr_active,
+            _has_diagnosis_criterion(criteria),
             getattr(criteria, "medication_rxnorm_codes", None),
             getattr(criteria, "condition_text", None),
             getattr(criteria, "age_min", None) is not None,

--- a/agent/db/queries/cohort.py
+++ b/agent/db/queries/cohort.py
@@ -198,10 +198,15 @@ def cohort_sql(criteria, schema_prefix: str = "") -> Tuple[str, dict]:
         # window over the full result before applying the LIMIT, which
         # for broad cohorts (e.g. all-NY + 3 diagnosis codes) can run
         # for many minutes. A pure aggregate is cheap regardless of
-        # population size and never touches per-source-id fan-out from
-        # the isr join (so the count is unique-people, not source-rows).
+        # population size.
+        #
+        # Count distinct source_id (the EMPI-resolved canonical person
+        # identifier, ~1 per person). Using patient_id here would
+        # over-count people who have multiple internal patient_ids. This
+        # matches the sample path's COUNT(*) OVER () grain and the
+        # breakdown path's COUNT(DISTINCT source_id).
         sql = f"""
-            SELECT COUNT(DISTINCT p.patient_id) AS total_count
+            SELECT COUNT(DISTINCT isr.source_id) AS total_count
             FROM {schema_prefix}internal_patient_profile_v p
             JOIN {schema_prefix}internal_source_reference_v isr
               ON isr.patient_id = p.patient_id

--- a/agent/db/queries/cohort_breakdown.py
+++ b/agent/db/queries/cohort_breakdown.py
@@ -1,0 +1,86 @@
+"""Single-dimension breakdown SQL for search_patients_by_criteria.
+
+Design: docs/superpowers/specs/2026-05-27-cohort-breakdown-dimensions-design.md
+
+Builds a GROUP BY query over the same filtered cohort that cohort_sql
+produces, counting COUNT(DISTINCT isr.source_id) per bucket. Time axes
+(diagnosis month/quarter/year) are multi-valued: a patient appears in
+every bucket they were active, so buckets overlap and do NOT sum to the
+population total (non_additive=True). Gender / age band are single-valued
+and additive.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+
+from agent.db.queries.cohort import (  # noqa: F401
+    _build_non_diagnosis_filters,
+    _diagnosis_event_where,
+)
+
+
+class BreakdownDimension(str, Enum):
+    DIAGNOSIS_MONTH = "diagnosis_month"
+    DIAGNOSIS_QUARTER = "diagnosis_quarter"
+    DIAGNOSIS_YEAR = "diagnosis_year"
+    GENDER = "gender"
+    AGE_BAND = "age_band"
+
+
+@dataclass(frozen=True)
+class BucketSpec:
+    group_expr: str  # SQL expression used in SELECT + GROUP BY, aliased to bucket_label
+    non_additive: bool
+    requires_diagnosis_anchor: bool
+
+
+_AGE_BAND_CASE = (
+    "CASE "
+    "WHEN p.age IS NULL THEN 'Unknown' "
+    "WHEN p.age < 18 THEN '0-17' "
+    "WHEN p.age < 35 THEN '18-34' "
+    "WHEN p.age < 50 THEN '35-49' "
+    "WHEN p.age < 65 THEN '50-64' "
+    "ELSE '65+' END"
+)
+
+# null gender and the 'U' (unknown) sentinel both collapse to one bucket.
+_GENDER_CASE = "CASE WHEN p.gender IN ('M', 'F') THEN p.gender ELSE 'Unknown' END"
+
+
+def _time_expr(unit: str, dialect: str) -> str:
+    """Stable string label for a diagnosis-date bucket, per dialect.
+
+    unit: 'month' | 'quarter' | 'year'. Operates on dx.start_date (the
+    diagnosis-event subquery alias).
+    """
+    col = "dx.start_date"
+    if dialect == "sqlite":
+        if unit == "month":
+            return f"strftime('%Y-%m', {col})"
+        if unit == "year":
+            return f"strftime('%Y', {col})"
+        # quarter: 'YYYY-Qn'
+        return f"strftime('%Y', {col}) || '-Q' || ((CAST(strftime('%m', {col}) AS INTEGER) + 2) / 3)"
+    if dialect in ("postgres", "redshift"):
+        if unit == "month":
+            return f"TO_CHAR(DATE_TRUNC('month', {col}), 'YYYY-MM')"
+        if unit == "year":
+            return f"TO_CHAR({col}, 'YYYY')"
+        return f"TO_CHAR(DATE_TRUNC('quarter', {col}), 'YYYY-\"Q\"Q')"
+    raise ValueError(f"Unsupported dialect for breakdown: {dialect!r}")
+
+
+def breakdown_bucket(dimension: BreakdownDimension, dialect: str) -> BucketSpec:
+    """Resolve a dimension to its SQL bucket expression for the given dialect."""
+    if dimension == BreakdownDimension.GENDER:
+        return BucketSpec(_GENDER_CASE, non_additive=False, requires_diagnosis_anchor=False)
+    if dimension == BreakdownDimension.AGE_BAND:
+        return BucketSpec(_AGE_BAND_CASE, non_additive=False, requires_diagnosis_anchor=False)
+    unit = {
+        BreakdownDimension.DIAGNOSIS_MONTH: "month",
+        BreakdownDimension.DIAGNOSIS_QUARTER: "quarter",
+        BreakdownDimension.DIAGNOSIS_YEAR: "year",
+    }[dimension]
+    return BucketSpec(_time_expr(unit, dialect), non_additive=True, requires_diagnosis_anchor=True)

--- a/agent/db/queries/cohort_breakdown.py
+++ b/agent/db/queries/cohort_breakdown.py
@@ -158,9 +158,3 @@ def cohort_breakdown_sql(
     )
     total_sql = f"SELECT COUNT(DISTINCT isr.source_id) AS total_count\n        {from_block}"
     return bucket_sql, total_sql, params
-
-
-def parse_dimension(value: str) -> BreakdownDimension:
-    """Map a raw enum string to BreakdownDimension (pydantic already validates,
-    but the tool stores list[str] from the model and needs the enum)."""
-    return BreakdownDimension(value)

--- a/agent/db/queries/cohort_breakdown.py
+++ b/agent/db/queries/cohort_breakdown.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from agent.db.queries.cohort import (  # noqa: F401
+from agent.db.queries.cohort import (
     _build_non_diagnosis_filters,
     _diagnosis_event_where,
 )
@@ -84,3 +84,83 @@ def breakdown_bucket(dimension: BreakdownDimension, dialect: str) -> BucketSpec:
         BreakdownDimension.DIAGNOSIS_YEAR: "year",
     }[dimension]
     return BucketSpec(_time_expr(unit, dialect), non_additive=True, requires_diagnosis_anchor=True)
+
+
+class MissingDiagnosisAnchorError(ValueError):
+    """A diagnosis-time breakdown was requested without a diagnosis anchor."""
+
+
+def cohort_breakdown_sql(
+    criteria,
+    dimension: BreakdownDimension,
+    schema_prefix: str = "",
+    dialect: str = "postgres",
+) -> tuple[str, str, dict]:
+    """Build (bucket_sql, total_sql, params) for a single-dimension breakdown.
+
+    bucket_sql: SELECT <bucket_expr> AS bucket_label,
+                COUNT(DISTINCT isr.source_id) AS patient_count ... GROUP BY 1 ORDER BY 1
+    total_sql:  SELECT COUNT(DISTINCT isr.source_id) AS total_count over the same cohort
+                (same grain so additive buckets sum to total).
+
+    Raises MissingDiagnosisAnchorError when a time dimension is requested
+    but no diagnosis criterion is active.
+    """
+    spec = breakdown_bucket(dimension, dialect)
+
+    dx = _diagnosis_event_where(criteria)
+    if spec.requires_diagnosis_anchor and dx is None:
+        raise MissingDiagnosisAnchorError(
+            "A diagnosis-time breakdown needs a diagnosis anchor: pass diagnosis_codes or a diagnosis_date_range."
+        )
+
+    params: dict = {}
+    join_clauses: list[str] = []
+    where_clauses: list[str] = ["1=1"]
+
+    if dx is not None:
+        dx_filter, dx_params = dx
+        params.update(dx_params)
+        if spec.requires_diagnosis_anchor:
+            # Event-level join: keep start_date so we can bucket on it.
+            join_clauses.append(
+                f"JOIN (SELECT patient_id, start_date FROM {schema_prefix}metric_federated_data_v "
+                f"WHERE {' AND '.join(dx_filter)}) dx ON dx.patient_id = p.patient_id"
+            )
+        else:
+            # Diagnosis used only as a filter; DISTINCT keeps the cohort one row/patient.
+            join_clauses.append(
+                f"JOIN (SELECT DISTINCT patient_id FROM {schema_prefix}metric_federated_data_v "
+                f"WHERE {' AND '.join(dx_filter)}) dx ON dx.patient_id = p.patient_id"
+            )
+
+    other_joins, other_where, other_params = _build_non_diagnosis_filters(criteria, schema_prefix)
+    join_clauses.extend(other_joins)
+    where_clauses.extend(other_where)
+    params.update(other_params)
+
+    join_block = "\n        ".join(join_clauses)
+    where_block = " AND ".join(where_clauses)
+    from_block = (
+        f"FROM {schema_prefix}internal_patient_profile_v p\n"
+        f"        JOIN {schema_prefix}internal_source_reference_v isr\n"
+        f"          ON isr.patient_id = p.patient_id AND isr.empi_rank != 99\n"
+        f"        {join_block}\n"
+        f"        WHERE {where_block}"
+    )
+
+    bucket_sql = (
+        f"SELECT {spec.group_expr} AS bucket_label, "
+        f"COUNT(DISTINCT isr.source_id) AS patient_count\n"
+        f"        {from_block}\n"
+        f"        GROUP BY {spec.group_expr}\n"
+        f"        ORDER BY {spec.group_expr}"
+    )
+    total_sql = f"SELECT COUNT(DISTINCT isr.source_id) AS total_count\n        {from_block}"
+    return bucket_sql, total_sql, params
+
+
+def parse_dimension(value: str) -> BreakdownDimension:
+    """Map a raw enum string to BreakdownDimension (pydantic already validates,
+    but the tool stores list[str] from the model and needs the enum)."""
+    return BreakdownDimension(value)

--- a/agent/db/sql_literals.py
+++ b/agent/db/sql_literals.py
@@ -1,0 +1,33 @@
+"""Inline named bind params into a SQL string for display/handoff only.
+
+The breakdown tool returns generated_sql so the LLM can paste it into
+run_sql, which accepts a bare SQL string (no bind params). Values here are
+simple scalars produced by our own builders (str, int, ISO date strings),
+never free user text, and run_sql's AST guard re-validates before execution.
+"""
+
+from __future__ import annotations
+import re
+from typing import Any
+
+
+def _literal(value: Any) -> str:
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float)):
+        return str(value)
+    # strings / ISO date strings: single-quote, double embedded quotes
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def inline_sql_literals(sql: str, params: dict) -> str:
+    """Replace :name placeholders in `sql` with quoted literals from `params`.
+
+    Keys are applied longest-first and matched with a trailing word boundary
+    so :dx_1 never clobbers :dx_10. Placeholders with no matching param are
+    left untouched.
+    """
+    out = sql
+    for name in sorted(params, key=len, reverse=True):
+        out = re.sub(rf":{re.escape(name)}\b", _literal(params[name]), out)
+    return out

--- a/agent/db/sql_literals.py
+++ b/agent/db/sql_literals.py
@@ -20,14 +20,19 @@ def _literal(value: Any) -> str:
     return "'" + str(value).replace("'", "''") + "'"
 
 
-def inline_sql_literals(sql: str, params: dict) -> str:
+def inline_sql_literals(sql: str, params: dict[str, Any]) -> str:
     """Replace :name placeholders in `sql` with quoted literals from `params`.
 
-    Keys are applied longest-first and matched with a trailing word boundary
-    so :dx_1 never clobbers :dx_10. Placeholders with no matching param are
-    left untouched.
+    Single-pass: the original SQL is scanned exactly once, so an inserted
+    literal can never be re-matched (a param value that happens to contain a
+    ":identifier" substring is left intact). Placeholders with no matching
+    param are left untouched.
     """
-    out = sql
-    for name in sorted(params, key=len, reverse=True):
-        out = re.sub(rf":{re.escape(name)}\b", _literal(params[name]), out)
-    return out
+
+    def _sub(match: "re.Match") -> str:
+        name = match.group(1)
+        if name in params:
+            return _literal(params[name])
+        return match.group(0)
+
+    return re.sub(r":(\w+)", _sub, sql)

--- a/agent/rag/seed.py
+++ b/agent/rag/seed.py
@@ -314,6 +314,30 @@ EXAMPLES_DOCS: List[_Doc] = [
             "and returns zero. Surface the geo reliability note from the result."
         ),
     },
+    {
+        "view": "internal_patient_profile_v",
+        "kind": "examples",
+        "text": (
+            "Q: 'How many people had any diagnosis in 2024? Break it out by month.' "
+            "A: Call search_patients_by_criteria with "
+            "diagnosis_date_range={start:'2024-01-01', end:'2024-12-31'} and "
+            "breakdown=['diagnosis_month']. Do NOT write a run_sql GROUP BY. The "
+            "result returns one bucket per month; surface the note that buckets "
+            "count distinct active patients and OVERLAP (a patient diagnosed in "
+            "two months is counted in both, so months do not sum to the total)."
+        ),
+    },
+    {
+        "view": "internal_patient_profile_v",
+        "kind": "examples",
+        "text": (
+            "Q: 'Diabetic patients by gender.' "
+            "A: search_patients_by_criteria(diagnosis_codes=['E11.9'], "
+            "breakdown=['gender']). Gender is single-valued so buckets sum to the "
+            "total. For TWO dimensions (e.g. month AND gender) the tool returns a "
+            "generated_sql template to extend in run_sql."
+        ),
+    },
 ]
 
 
@@ -366,6 +390,25 @@ RUN_SQL_EXAMPLES: List[_Doc] = [
             "    AND code = '4548-4' AND code_type = 'LOINC'\n"
             "  ORDER BY datetime DESC\n"
             "  LIMIT 1;"
+        ),
+    },
+    {
+        "view": "",
+        "kind": "examples",
+        "text": (
+            "Q: Count distinct patients with any diagnosis, broken out by month.\n"
+            "SQL:\n"
+            "  SELECT TO_CHAR(DATE_TRUNC('month', dx.start_date), 'YYYY-MM') AS bucket_label,\n"
+            "         COUNT(DISTINCT isr.source_id) AS patient_count\n"
+            "  FROM {p}internal_patient_profile_v p\n"
+            "  JOIN {p}internal_source_reference_v isr\n"
+            "    ON isr.patient_id = p.patient_id AND isr.empi_rank != 99\n"
+            "  JOIN (SELECT patient_id, start_date FROM {p}metric_federated_data_v\n"
+            "        WHERE code_type IN ('ICD-10','ICD10','SNOMED')\n"
+            "          AND start_date >= :start AND start_date <= :end) dx\n"
+            "    ON dx.patient_id = p.patient_id\n"
+            "  GROUP BY 1 ORDER BY 1;\n"
+            "Note: a patient diagnosed in multiple months appears in each — buckets overlap."
         ),
     },
 ]

--- a/agent/rag/seed.py
+++ b/agent/rag/seed.py
@@ -392,25 +392,6 @@ RUN_SQL_EXAMPLES: List[_Doc] = [
             "  LIMIT 1;"
         ),
     },
-    {
-        "view": "",
-        "kind": "examples",
-        "text": (
-            "Q: Count distinct patients with any diagnosis, broken out by month.\n"
-            "SQL:\n"
-            "  SELECT TO_CHAR(DATE_TRUNC('month', dx.start_date), 'YYYY-MM') AS bucket_label,\n"
-            "         COUNT(DISTINCT isr.source_id) AS patient_count\n"
-            "  FROM {p}internal_patient_profile_v p\n"
-            "  JOIN {p}internal_source_reference_v isr\n"
-            "    ON isr.patient_id = p.patient_id AND isr.empi_rank != 99\n"
-            "  JOIN (SELECT patient_id, start_date FROM {p}metric_federated_data_v\n"
-            "        WHERE code_type IN ('ICD-10','ICD10','SNOMED')\n"
-            "          AND start_date >= :start AND start_date <= :end) dx\n"
-            "    ON dx.patient_id = p.patient_id\n"
-            "  GROUP BY 1 ORDER BY 1;\n"
-            "Note: a patient diagnosed in multiple months appears in each — buckets overlap."
-        ),
-    },
 ]
 
 

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -536,10 +536,9 @@ class AgenticRunner:
                                     # don't depend on the LLM attaching an artifact.
                                     if info["tool_name"] == "search_patients_by_criteria":
                                         payload = _to_jsonable(result_content)
-                                        if (
-                                            isinstance(payload, dict)
-                                            and isinstance(payload.get("sample"), list)
-                                            and len(payload["sample"]) > 0
+                                        if isinstance(payload, dict) and (
+                                            (isinstance(payload.get("sample"), list) and payload["sample"])
+                                            or (isinstance(payload.get("buckets"), list) and payload["buckets"])
                                         ):
                                             yield CohortSampleEvent(payload=payload)
 

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -354,14 +354,16 @@ def _render_event(event: StreamEvent, state: dict[str, Any] | None = None) -> No
 
     if isinstance(event, CohortSampleEvent):
         # Auto-surfaced by runner.stream() right after
-        # search_patients_by_criteria succeeds with a non-empty sample.
-        # Renders as a DataFrame message regardless of whether the LLM
-        # attaches a DataFrameArtifact to the final response.
+        # search_patients_by_criteria succeeds with a non-empty sample OR
+        # breakdown buckets. Renders as a DataFrame message regardless of
+        # whether the LLM attaches a DataFrameArtifact to the final response.
         import pandas as pd
 
+        buckets = event.payload.get("buckets", [])
         sample = event.payload.get("sample", [])
-        if sample:
-            df = pd.DataFrame(sample)
+        rows = buckets or sample
+        if rows:
+            df = pd.DataFrame(rows)
             add_message(
                 Message(
                     RoleType.ASSISTANT,

--- a/agent/state.py
+++ b/agent/state.py
@@ -73,14 +73,15 @@ class PatientChooserEvent(BaseModel):
 
 class CohortSampleEvent(BaseModel):
     """Auto-surfaced after a successful search_patients_by_criteria
-    call so the UI renders the cohort sample as a DataFrame regardless
-    of whether the LLM attaches an artifact to the final response.
+    call (sample rows or breakdown buckets) so the UI renders the cohort
+    result as a DataFrame regardless of whether the LLM attaches an
+    artifact to the final response.
 
     Phase 4 design §3.7.
     """
 
     kind: Literal["cohort_sample"] = "cohort_sample"
-    payload: dict  # CohortResult shape (total_count, sample, data_availability, reliability_note)
+    payload: dict  # CohortResult shape (total_count, sample, buckets, data_availability, reliability_note)
 
 
 class ThinkingDeltaEvent(BaseModel):

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -150,6 +150,14 @@ per-row `sample` array. Do NOT write a COUNT(DISTINCT…) `run_sql` query \
 for cohort counts; the tool already does that, much faster than \
 re-aggregating. \
 \
+BREAKDOWNS ("by month", "broken out by", "per gender", "by age group"): \
+pass `breakdown` with ONE dimension — diagnosis_month / diagnosis_quarter / \
+diagnosis_year (require a diagnosis anchor: codes or a date range), gender, or \
+age_band. Prefer this over a run_sql GROUP BY. Time breakdowns count distinct \
+patients active in each period; buckets OVERLAP and do not sum to the total — \
+surface that note verbatim. For TWO dimensions (e.g. month AND gender), the tool \
+returns a generated_sql template — extend it in run_sql. \
+\
 `condition_text` is a FALLBACK for when codes aren't known. Do NOT pass \
 `condition_text` AND `diagnosis_codes` together — that AND-stacks them \
 and over-constrains the cohort to zero. Pick one. \

--- a/agent/tools/run_sql.py
+++ b/agent/tools/run_sql.py
@@ -111,8 +111,10 @@ def run_sql(ctx: RunContext[AgentDeps], input: RunSqlInput) -> RunSqlResult:
     """Execute a read-only SELECT / WITH against the analytics warehouse.
 
     Use this when the curated clinical tools cannot answer the question
-    (e.g., joining across domains in a non-standard way, ad-hoc aggregations).
-    Prefer get_patient_clinical_data for any per-patient clinical question.
+    (e.g., joining across domains in a non-standard way, multi-dimensional
+    or unsupported breakdowns). Prefer get_patient_clinical_data for any
+    per-patient clinical question, and prefer search_patients_by_criteria
+    with `breakdown` for single-dimension population breakdowns.
 
     Results are capped at 500 rows. If truncated, refine the query for
     a smaller result.

--- a/agent/tools/search_patients_by_criteria.py
+++ b/agent/tools/search_patients_by_criteria.py
@@ -150,6 +150,23 @@ _NON_ADDITIVE_NOTE = (
 )
 
 
+def _reliability_parts(criteria) -> list[str]:
+    """Coverage caveats that apply to a cohort query, given its filters.
+    Shared by the sample path and the breakdown path so the DX/RX/GEO logic
+    lives in one place.
+    """
+    parts: list[str] = []
+    _dr = criteria.diagnosis_date_range
+    _dr_active = _dr is not None and (_dr.start or _dr.end)
+    if criteria.diagnosis_codes or _dr_active:
+        parts.append(_RELIABILITY_DX)
+    elif criteria.medication_rxnorm_codes:
+        parts.append(_RELIABILITY_RX)
+    if criteria.zip_code or criteria.city or criteria.state:
+        parts.append(_RELIABILITY_GEO)
+    return parts
+
+
 def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCriteria) -> CohortResult:
     """Find patients matching demographic and clinical criteria.
 
@@ -222,15 +239,7 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
 
     # Compute reliability_note up front so the no_records path also surfaces it
     # — geo-filter misses are most informative when no rows came back.
-    reliability_parts: list[str] = []
-    _dr = criteria.diagnosis_date_range
-    _dr_active = _dr is not None and (_dr.start or _dr.end)
-    if criteria.diagnosis_codes or _dr_active:
-        reliability_parts.append(_RELIABILITY_DX)
-    elif criteria.medication_rxnorm_codes:
-        reliability_parts.append(_RELIABILITY_RX)
-    if criteria.zip_code or criteria.city or criteria.state:
-        reliability_parts.append(_RELIABILITY_GEO)
+    reliability_parts = _reliability_parts(criteria)
     reliability = " ".join(reliability_parts) if reliability_parts else None
 
     # Count-only fast path: cohort_sql emits a single COUNT(DISTINCT) row
@@ -291,19 +300,11 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
     return result
 
 
-def _run_breakdown(ctx, criteria, adapter, schema_prefix):
+def _run_breakdown(ctx: RunContext[AgentDeps], criteria: CohortCriteria, adapter, schema_prefix: str) -> CohortResult:
     dialect = getattr(adapter, "dialect", "postgres")
 
     # Reuse the existing reliability note logic for coverage caveats.
-    reliability_parts: list[str] = []
-    _dr = criteria.diagnosis_date_range
-    _dr_active = _dr is not None and (_dr.start or _dr.end)
-    if criteria.diagnosis_codes or _dr_active:
-        reliability_parts.append(_RELIABILITY_DX)
-    elif criteria.medication_rxnorm_codes:
-        reliability_parts.append(_RELIABILITY_RX)
-    if criteria.zip_code or criteria.city or criteria.state:
-        reliability_parts.append(_RELIABILITY_GEO)
+    reliability_parts = _reliability_parts(criteria)
 
     primary = criteria.breakdown[0]
 
@@ -313,23 +314,29 @@ def _run_breakdown(ctx, criteria, adapter, schema_prefix):
             criteria, primary, schema_prefix=schema_prefix, dialect=dialect
         )
     except MissingDiagnosisAnchorError as exc:
-        return CohortResult(
+        result = CohortResult(
             total_count=0,
             sample=[],
+            # Nothing was queried on this path; the real signal is in
+            # breakdown_status + notes_to_agent, not a record count.
             data_availability="no_records_found",
             buckets=[],
             breakdown_status="missing_diagnosis_anchor",
             notes_to_agent=str(exc),
             reliability_note=" ".join(reliability_parts) or None,
         )
+        ctx.deps.last_dataframe = cohort_result_to_df(result)
+        return result
 
     handoff_sql = inline_sql_literals(bucket_sql, params)
 
     # 2+ dimensions: do not execute; hand back the primary-dimension template.
     if len(criteria.breakdown) > 1:
-        return CohortResult(
+        result = CohortResult(
             total_count=0,
             sample=[],
+            # Nothing was queried on this path; the real signal is in
+            # breakdown_status + notes_to_agent, not a record count.
             data_availability="no_records_found",
             buckets=[],
             breakdown_status="unsupported_multi_dimension",
@@ -341,6 +348,8 @@ def _run_breakdown(ctx, criteria, adapter, schema_prefix):
             ),
             reliability_note=" ".join(reliability_parts) or None,
         )
+        ctx.deps.last_dataframe = cohort_result_to_df(result)
+        return result
 
     spec = breakdown_bucket(primary, dialect)
     try:

--- a/agent/tools/search_patients_by_criteria.py
+++ b/agent/tools/search_patients_by_criteria.py
@@ -119,6 +119,12 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from agent.dataframe_adapters import cohort_result_to_df
 from agent.db.queries.cohort import cohort_sql
+from agent.db.queries.cohort_breakdown import (
+    MissingDiagnosisAnchorError,
+    breakdown_bucket,
+    cohort_breakdown_sql,
+)
+from agent.db.sql_literals import inline_sql_literals
 from agent.deps import AgentDeps
 
 
@@ -136,6 +142,11 @@ _RELIABILITY_GEO = (
     "in casing and abbreviation; substring matching handles common cases but "
     "may miss heavily abbreviated forms. State filtering matches 'NY'-style "
     "codes; addresses recorded as 'NEW YORK' may be missed."
+)
+_NON_ADDITIVE_NOTE = (
+    "This breakdown counts distinct patients active in each bucket. A patient "
+    "with qualifying diagnoses in multiple periods appears in each — so buckets "
+    "OVERLAP and do not sum to the population total."
 )
 
 
@@ -173,6 +184,12 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
       - city: city name, case-insensitive substring match (city strings vary by source).
       - state: 2-letter USPS code, exact match on uppercased input. May miss long-form 'NEW YORK'.
       - sample_size: 0-100; default 20. Set to 0 for count-only.
+      - breakdown: optional list of ONE dimension to group counts by —
+        diagnosis_month / diagnosis_quarter / diagnosis_year (require a
+        diagnosis anchor: codes or a date range; buckets overlap and don't
+        sum), gender, or age_band. Returns aggregate buckets instead of a
+        patient sample. Pass 2+ dimensions only to escalate: the tool then
+        returns a generated_sql template to extend in run_sql.
 
     Returns CohortResult with total_count + sample. The sample is truncated
     to sample_size; total_count carries the full population. When a code-based
@@ -181,6 +198,9 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
     """
     adapter = ctx.deps.analytics_db
     schema_prefix = getattr(adapter, "schema_prefix", "")
+
+    if criteria.breakdown:
+        return _run_breakdown(ctx, criteria, adapter, schema_prefix)
 
     sql, params = cohort_sql(criteria, schema_prefix=schema_prefix)
     try:
@@ -266,6 +286,89 @@ def search_patients_by_criteria(ctx: RunContext[AgentDeps], criteria: CohortCrit
         data_availability="data_present",
         truncated=truncated,
         reliability_note=reliability,
+    )
+    ctx.deps.last_dataframe = cohort_result_to_df(result)
+    return result
+
+
+def _run_breakdown(ctx, criteria, adapter, schema_prefix):
+    dialect = getattr(adapter, "dialect", "postgres")
+
+    # Reuse the existing reliability note logic for coverage caveats.
+    reliability_parts: list[str] = []
+    _dr = criteria.diagnosis_date_range
+    _dr_active = _dr is not None and (_dr.start or _dr.end)
+    if criteria.diagnosis_codes or _dr_active:
+        reliability_parts.append(_RELIABILITY_DX)
+    elif criteria.medication_rxnorm_codes:
+        reliability_parts.append(_RELIABILITY_RX)
+    if criteria.zip_code or criteria.city or criteria.state:
+        reliability_parts.append(_RELIABILITY_GEO)
+
+    primary = criteria.breakdown[0]
+
+    # Build SQL for the primary dimension (also the escalation template).
+    try:
+        bucket_sql, total_sql, params = cohort_breakdown_sql(
+            criteria, primary, schema_prefix=schema_prefix, dialect=dialect
+        )
+    except MissingDiagnosisAnchorError as exc:
+        return CohortResult(
+            total_count=0,
+            sample=[],
+            data_availability="no_records_found",
+            buckets=[],
+            breakdown_status="missing_diagnosis_anchor",
+            notes_to_agent=str(exc),
+            reliability_note=" ".join(reliability_parts) or None,
+        )
+
+    handoff_sql = inline_sql_literals(bucket_sql, params)
+
+    # 2+ dimensions: do not execute; hand back the primary-dimension template.
+    if len(criteria.breakdown) > 1:
+        return CohortResult(
+            total_count=0,
+            sample=[],
+            data_availability="no_records_found",
+            buckets=[],
+            breakdown_status="unsupported_multi_dimension",
+            generated_sql=handoff_sql,
+            notes_to_agent=(
+                "search_patients_by_criteria supports a single breakdown dimension. "
+                "For a multi-dimensional breakdown, extend the SQL in generated_sql "
+                "using run_sql (add the extra column to SELECT and GROUP BY)."
+            ),
+            reliability_note=" ".join(reliability_parts) or None,
+        )
+
+    spec = breakdown_bucket(primary, dialect)
+    try:
+        rows = adapter.fetch_all(bucket_sql, params)
+        total = adapter.fetch_all(total_sql, params)
+    except SQLAlchemyError as exc:
+        raise ModelRetry(
+            f"Cohort breakdown query failed: {exc}. Try narrowing the criteria or report this limitation to the user."
+        ) from exc
+
+    buckets = [
+        BreakdownBucket(bucket_label=str(r["bucket_label"]), patient_count=int(r["patient_count"])) for r in rows
+    ]
+    total_count = int(total[0]["total_count"]) if total else 0
+    availability = "data_present" if total_count > 0 else "no_records_found"
+
+    if spec.non_additive:
+        reliability_parts.append(_NON_ADDITIVE_NOTE)
+
+    result = CohortResult(
+        total_count=total_count,
+        sample=[],
+        data_availability=availability,
+        buckets=buckets,
+        non_additive=spec.non_additive,
+        generated_sql=handoff_sql,
+        breakdown_status="single_dimension",
+        reliability_note=" ".join(reliability_parts) or None,
     )
     ctx.deps.last_dataframe = cohort_result_to_df(result)
     return result

--- a/agent/tools/search_patients_by_criteria.py
+++ b/agent/tools/search_patients_by_criteria.py
@@ -14,6 +14,7 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from agent.db.queries.cohort_breakdown import BreakdownDimension
 from agent.result_compaction import CompactingListResult
 
 
@@ -44,6 +45,7 @@ class CohortCriteria(BaseModel):
     city: Optional[str] = None  # case-insensitive substring on p.city
     state: Optional[str] = None  # 2-letter USPS code, exact match on uppercased p.state
     sample_size: int = Field(default=20, ge=0, le=100)
+    breakdown: List[BreakdownDimension] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _require_at_least_one_criterion(self) -> "CohortCriteria":
@@ -89,6 +91,11 @@ class PatientMatch(BaseModel):
     practice_name: Optional[str] = None
 
 
+class BreakdownBucket(BaseModel):
+    bucket_label: str
+    patient_count: int
+
+
 class CohortResult(CompactingListResult):
     _list_field = "sample"
 
@@ -98,6 +105,12 @@ class CohortResult(CompactingListResult):
     truncated: bool = False
     reliability_note: Optional[str] = None
     notes_to_agent: Optional[str] = None
+    buckets: List[BreakdownBucket] = Field(default_factory=list)
+    non_additive: bool = False
+    generated_sql: Optional[str] = None
+    breakdown_status: Optional[
+        Literal["single_dimension", "unsupported_multi_dimension", "missing_diagnosis_anchor"]
+    ] = None
 
 
 from pydantic_ai import RunContext

--- a/tests/agent/db/test_cohort_breakdown.py
+++ b/tests/agent/db/test_cohort_breakdown.py
@@ -1,0 +1,45 @@
+"""Tests for agent.db.queries.cohort_breakdown."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.db.queries.cohort_breakdown import (
+    BreakdownDimension,
+    breakdown_bucket,
+)
+
+
+def test_gender_bucket_is_additive_no_anchor():
+    spec = breakdown_bucket(BreakdownDimension.GENDER, dialect="sqlite")
+    assert spec.non_additive is False
+    assert spec.requires_diagnosis_anchor is False
+    assert "p.gender" in spec.group_expr
+    assert "Unknown" in spec.group_expr  # null/U folded to a bucket
+
+
+def test_age_band_bucket_is_additive_no_anchor():
+    spec = breakdown_bucket(BreakdownDimension.AGE_BAND, dialect="sqlite")
+    assert spec.non_additive is False
+    assert spec.requires_diagnosis_anchor is False
+    assert "p.age" in spec.group_expr
+    assert "65" in spec.group_expr
+
+
+def test_diagnosis_month_is_non_additive_needs_anchor_sqlite():
+    spec = breakdown_bucket(BreakdownDimension.DIAGNOSIS_MONTH, dialect="sqlite")
+    assert spec.non_additive is True
+    assert spec.requires_diagnosis_anchor is True
+    assert "strftime" in spec.group_expr
+    assert "dx.start_date" in spec.group_expr
+
+
+def test_diagnosis_month_uses_date_trunc_on_postgres():
+    spec = breakdown_bucket(BreakdownDimension.DIAGNOSIS_MONTH, dialect="postgres")
+    assert "DATE_TRUNC" in spec.group_expr or "TO_CHAR" in spec.group_expr
+    assert "dx.start_date" in spec.group_expr
+
+
+def test_unknown_dialect_rejected():
+    with pytest.raises(ValueError):
+        breakdown_bucket(BreakdownDimension.DIAGNOSIS_YEAR, dialect="oracle")

--- a/tests/agent/db/test_cohort_breakdown.py
+++ b/tests/agent/db/test_cohort_breakdown.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import date
+from types import SimpleNamespace
+
 import pytest
+from sqlalchemy import text
 
 from agent.db.queries.cohort_breakdown import (
     BreakdownDimension,
     breakdown_bucket,
+    cohort_breakdown_sql,
 )
 
 
@@ -43,3 +48,55 @@ def test_diagnosis_month_uses_date_trunc_on_postgres():
 def test_unknown_dialect_rejected():
     with pytest.raises(ValueError):
         breakdown_bucket(BreakdownDimension.DIAGNOSIS_YEAR, dialect="oracle")
+
+
+def _crit(**kw):
+    base = dict(
+        diagnosis_codes=None,
+        diagnosis_date_range=None,
+        medication_rxnorm_codes=None,
+        condition_text=None,
+        age_min=None,
+        age_max=None,
+        gender=None,
+        facility=None,
+        last_visit_after=None,
+        last_visit_before=None,
+        zip_code=None,
+        city=None,
+        state=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_gender_breakdown_buckets_sum_to_total(synthetic_db):
+    crit = _crit(age_min=0)  # permissive: whole population
+    bucket_sql, total_sql, params = cohort_breakdown_sql(
+        crit, BreakdownDimension.GENDER, schema_prefix="", dialect="sqlite"
+    )
+    with synthetic_db.connect() as conn:
+        buckets = conn.execute(text(bucket_sql), params).fetchall()
+        total = conn.execute(text(total_sql), params).scalar()
+    by_count = {r._mapping["bucket_label"]: r._mapping["patient_count"] for r in buckets}
+    assert sum(by_count.values()) == total, "single-valued gender must be additive"
+
+
+def test_diagnosis_month_breakdown_groups_by_month(synthetic_db):
+    crit = _crit(diagnosis_date_range=SimpleNamespace(start=date(2025, 1, 1), end=date(2025, 12, 31)))
+    bucket_sql, total_sql, params = cohort_breakdown_sql(
+        crit, BreakdownDimension.DIAGNOSIS_MONTH, schema_prefix="", dialect="sqlite"
+    )
+    with synthetic_db.connect() as conn:
+        buckets = conn.execute(text(bucket_sql), params).fetchall()
+    labels = {r._mapping["bucket_label"] for r in buckets}
+    # synthetic ICD-10 diagnoses in 2025: 2025-04, 2025-06, 2025-09, 2025-11, 2025-12
+    assert "2025-06" in labels
+    assert "2025-09" in labels
+    assert all(lbl.startswith("2025-") for lbl in labels)
+
+
+def test_time_breakdown_without_anchor_raises():
+    crit = _crit(gender="F")  # demographic only, no diagnosis anchor
+    with pytest.raises(ValueError, match="diagnosis"):
+        cohort_breakdown_sql(crit, BreakdownDimension.DIAGNOSIS_MONTH, schema_prefix="", dialect="sqlite")

--- a/tests/agent/db/test_cohort_geo_filter.py
+++ b/tests/agent/db/test_cohort_geo_filter.py
@@ -151,10 +151,11 @@ def test_sample_size_zero_emits_count_only_fast_path():
     (SELECT source_id, ..., COUNT(*) OVER ()) forces Postgres to compute
     the window over the full result before LIMIT — burned a 30s timeout
     on broad cohorts. The count-only shape is a pure aggregate that's
-    cheap regardless of population size, and counts unique patients
-    instead of inflating by per-source-id fan-out."""
+    cheap regardless of population size, and counts distinct source_id
+    (the EMPI-resolved canonical person identifier) to match the sample
+    path's COUNT(*) OVER () grain and the breakdown path."""
     sql, params = cohort_sql(_make(state="NY", sample_size=0), schema_prefix="dw.")
-    assert "COUNT(DISTINCT p.patient_id) AS total_count" in sql
+    assert "COUNT(DISTINCT isr.source_id) AS total_count" in sql
     assert "COUNT(*) OVER ()" not in sql
     assert "LIMIT" not in sql.upper()
     # No sample_size_plus_one param — that's only for the per-row path.
@@ -167,10 +168,11 @@ def test_sample_size_zero_returns_count_against_synthetic(synthetic_db):
     with synthetic_db.connect() as conn:
         rows = conn.execute(text(sql), params).fetchall()
     assert len(rows) == 1
-    # Synthetic NY patients: John 1962, John 1971 (Buffalo NY, plus several
-    # extras seeded for other tests). Both Johns + the rest are distinct.
+    # Synthetic NY patients (1,2,4,5,6,7,8; Jane is PA). Counted by distinct
+    # source_id: John 1962 (patient 1) has two non-stale source_ids, the rest
+    # one each → 8 distinct source_ids.
     total = rows[0]._mapping["total_count"]
-    assert total >= 2, f"expected ≥2 distinct NY patients, got {total}"
+    assert total >= 2, f"expected ≥2 distinct NY source_ids, got {total}"
 
 
 def test_sample_size_nonzero_keeps_per_row_pivot():

--- a/tests/agent/db/test_sql_literals.py
+++ b/tests/agent/db/test_sql_literals.py
@@ -25,3 +25,14 @@ def test_longer_keys_not_clobbered_by_prefixes():
 def test_leaves_unknown_placeholders_untouched():
     out = inline_sql_literals("WHERE x = :known AND y = :other", {"known": 1})
     assert out == "WHERE x = 1 AND y = :other"
+
+
+def test_bool_replaced_as_true_false():
+    assert inline_sql_literals("WHERE active = :a", {"a": True}) == "WHERE active = TRUE"
+    assert inline_sql_literals("WHERE active = :a", {"a": False}) == "WHERE active = FALSE"
+
+
+def test_value_containing_placeholder_substring_is_not_re_substituted():
+    # foo's value contains ":bar"; single-pass must not re-substitute it
+    out = inline_sql_literals("WHERE a = :foo AND b = :bar", {"foo": ":bar", "bar": "safe"})
+    assert out == "WHERE a = ':bar' AND b = 'safe'"

--- a/tests/agent/db/test_sql_literals.py
+++ b/tests/agent/db/test_sql_literals.py
@@ -1,0 +1,27 @@
+"""Tests for agent.db.sql_literals.inline_sql_literals."""
+
+from __future__ import annotations
+
+from agent.db.sql_literals import inline_sql_literals
+
+
+def test_inlines_string_with_quotes_escaped():
+    out = inline_sql_literals("WHERE name = :n", {"n": "O'Brien"})
+    assert out == "WHERE name = 'O''Brien'"
+
+
+def test_inlines_int_unquoted():
+    out = inline_sql_literals("WHERE age >= :age_min", {"age_min": 65})
+    assert out == "WHERE age >= 65"
+
+
+def test_longer_keys_not_clobbered_by_prefixes():
+    # :dx_1 must not match inside :dx_10
+    sql = "WHERE a = :dx_1 AND b = :dx_10"
+    out = inline_sql_literals(sql, {"dx_1": "A", "dx_10": "B"})
+    assert out == "WHERE a = 'A' AND b = 'B'"
+
+
+def test_leaves_unknown_placeholders_untouched():
+    out = inline_sql_literals("WHERE x = :known AND y = :other", {"known": 1})
+    assert out == "WHERE x = 1 AND y = :other"

--- a/tests/agent/flows/test_cohort_breakdown_sample_db.py
+++ b/tests/agent/flows/test_cohort_breakdown_sample_db.py
@@ -1,0 +1,113 @@
+"""sample_db integration: monthly diagnosis breakdown over the loaded
+synthetic ~200-patient database.
+
+Requires:
+- Docker Postgres running (docker compose up -d)
+- Sample dump loaded (uv run python scripts/load_sample_db.py)
+- [postgres] in .streamlit/secrets.toml pointing at it
+
+Run: uv run pytest -m sample_db
+
+Without a reachable / loaded Postgres these tests SKIP rather than fail.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+
+from agent.db.queries.cohort_breakdown import BreakdownDimension, cohort_breakdown_sql
+
+pytestmark = pytest.mark.sample_db
+
+# The sample dump loads its views into the "dw" schema (see scripts/load_sample_db.py
+# and data/sample/thrive_sample.sql.zst), and Postgres is the loaded dialect.
+SCHEMA_PREFIX = "dw."
+DIALECT = "postgres"
+
+
+def _engine_or_skip() -> sa.Engine:
+    """Build a Postgres engine and probe it; skip the test if unreachable.
+
+    Mirrors tests/sample_db/test_agent_on_sample_db.py — the established
+    sample_db connection mechanism in this repo (no shared fixture exists).
+    """
+    import tomllib
+
+    try:
+        pg = tomllib.loads(open(".streamlit/secrets.toml").read())["postgres"]
+    except (FileNotFoundError, KeyError) as e:
+        pytest.skip(f"Postgres config not found: {e}")
+
+    url = f"postgresql+psycopg2://{pg['user']}:{pg['password']}@{pg['host']}:{pg['port']}/{pg['database']}"
+    eng = sa.create_engine(url)
+    try:
+        with eng.connect() as conn:
+            conn.execute(sa.text("SELECT 1"))
+            # internal_source_reference_v is created exclusively by
+            # load_sample_db.py, so its absence means the dump isn't loaded.
+            table_exists = conn.execute(
+                sa.text(
+                    """
+                    SELECT 1
+                    FROM information_schema.tables
+                    WHERE table_schema = 'dw'
+                      AND table_name = 'internal_source_reference_v'
+                    """
+                )
+            ).scalar()
+            if not table_exists:
+                pytest.skip("Sample DB tables not found — run 'uv run python scripts/load_sample_db.py' first")
+    except pytest.skip.Exception:
+        raise
+    except Exception as e:  # noqa: BLE001
+        pytest.skip(f"Postgres sample DB not reachable: {e}")
+    return eng
+
+
+def _crit(**kw):
+    base = dict(
+        diagnosis_codes=None,
+        diagnosis_date_range=None,
+        medication_rxnorm_codes=None,
+        condition_text=None,
+        age_min=None,
+        age_max=None,
+        gender=None,
+        facility=None,
+        last_visit_after=None,
+        last_visit_before=None,
+        zip_code=None,
+        city=None,
+        state=None,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_monthly_breakdown_runs_on_sample_db():
+    """The diagnosis-month breakdown SQL executes end-to-end against the
+    loaded sample DB and returns sane monthly buckets."""
+    eng = _engine_or_skip()
+
+    # A wide window that the sample diagnosis data populates densely.
+    crit = _crit(diagnosis_date_range=SimpleNamespace(start=date(2020, 1, 1), end=date(2026, 12, 31)))
+
+    bucket_sql, total_sql, params = cohort_breakdown_sql(
+        crit,
+        BreakdownDimension.DIAGNOSIS_MONTH,
+        schema_prefix=SCHEMA_PREFIX,
+        dialect=DIALECT,
+    )
+
+    with eng.connect() as conn:
+        buckets = conn.execute(sa.text(bucket_sql), params).mappings().all()
+        total = conn.execute(sa.text(total_sql), params).scalar()
+
+    assert buckets, "expected at least one monthly bucket from the sample DB"
+    for row in buckets:
+        assert row["patient_count"] >= 1, f"bucket {row['bucket_label']!r} has count {row['patient_count']}"
+    assert total is not None and total >= 1, f"expected total_count >= 1, got {total}"

--- a/tests/agent/flows/test_cohort_flow.py
+++ b/tests/agent/flows/test_cohort_flow.py
@@ -128,6 +128,45 @@ async def test_cohort_tool_completion_emits_cohort_sample_event():
 
 
 @pytest.mark.asyncio
+async def test_cohort_breakdown_buckets_emit_cohort_sample_event():
+    """End-to-end via the streaming runner, exercising the BREAKDOWN path.
+
+    A single-dimension breakdown returns an empty patient sample but a
+    non-empty buckets list. This drives the runner.py gate (runner.py
+    ~line 539) that also fires CohortSampleEvent when buckets are present,
+    not just when a sample is. Mirrors the SAMPLE-path test above exactly,
+    only differing in the scripted criteria args (adds breakdown=["gender"]).
+    """
+    engine = _make_threadsafe_db()
+    runner = AgenticRunner(
+        model=_scripted_llm_cohort({"diagnosis_codes": ["E11.9"], "sample_size": 0, "breakdown": ["gender"]})
+    )
+
+    events = []
+    async for ev in runner.stream("break down diabetics by gender", deps=_deps(engine)):
+        events.append(ev)
+
+    cohort_events = [e for e in events if isinstance(e, CohortSampleEvent)]
+    assert len(cohort_events) == 1, f"expected 1 CohortSampleEvent, got {len(cohort_events)}"
+    payload = cohort_events[0].payload
+    assert payload["data_availability"] == "data_present"
+    assert payload["breakdown_status"] == "single_dimension"
+    assert payload["non_additive"] is False
+    # The buckets branch of the gate is what we're covering: buckets present,
+    # sample empty.
+    assert len(payload["buckets"]) >= 1
+    assert payload["sample"] == []
+    # Must come AFTER ToolCallCompleted for the cohort tool.
+    tcc_index = next(
+        i
+        for i, e in enumerate(events)
+        if isinstance(e, ToolCallCompleted) and e.tool_name == "search_patients_by_criteria"
+    )
+    cse_index = events.index(cohort_events[0])
+    assert cse_index > tcc_index
+
+
+@pytest.mark.asyncio
 async def test_cohort_tool_no_event_when_sample_empty():
     """sample_size=0 → no CohortSampleEvent emitted (count-only mode)."""
     engine = _make_threadsafe_db()

--- a/tests/agent/rag/test_seed.py
+++ b/tests/agent/rag/test_seed.py
@@ -6,9 +6,13 @@ def test_examples_include_breakdown_routing():
     assert "breakdown" in texts and "by month" in texts
 
 
-def test_run_sql_examples_include_breakdown_idiom():
+def test_run_sql_examples_excludes_breakdown_idiom_for_budget():
+    # The breakdown SQL idiom is intentionally NOT a static run_sql example:
+    # the tool's generated_sql handoff supplies a tailored template at runtime,
+    # and the run_sql tool description must stay within its char budget
+    # (see tests/agent/db/test_sql_context.py::test_output_under_budget).
     texts = " ".join(d["text"] for d in RUN_SQL_EXAMPLES)
-    assert "DATE_TRUNC" in texts and "GROUP BY" in texts
+    assert "DATE_TRUNC('month', dx.start_date)" not in texts
 
 
 def test_all_seed_docs_includes_examples_and_run_sql():

--- a/tests/agent/rag/test_seed.py
+++ b/tests/agent/rag/test_seed.py
@@ -1,0 +1,19 @@
+from agent.rag.seed import EXAMPLES_DOCS, RUN_SQL_EXAMPLES, all_seed_docs
+
+
+def test_examples_include_breakdown_routing():
+    texts = " ".join(d["text"].lower() for d in EXAMPLES_DOCS)
+    assert "breakdown" in texts and "by month" in texts
+
+
+def test_run_sql_examples_include_breakdown_idiom():
+    texts = " ".join(d["text"] for d in RUN_SQL_EXAMPLES)
+    assert "DATE_TRUNC" in texts and "GROUP BY" in texts
+
+
+def test_all_seed_docs_includes_examples_and_run_sql():
+    docs = all_seed_docs()
+    for d in EXAMPLES_DOCS:
+        assert d in docs
+    for d in RUN_SQL_EXAMPLES:
+        assert d in docs

--- a/tests/agent/test_dataframe_adapters.py
+++ b/tests/agent/test_dataframe_adapters.py
@@ -14,7 +14,6 @@ shape rules:
 from __future__ import annotations
 from datetime import date
 import pandas as pd
-import pytest
 
 from agent.dataframe_adapters import (
     clinical_result_to_df,
@@ -203,3 +202,29 @@ def test_cohort_result_to_df_empty_sample():
     df = cohort_result_to_df(result)
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 0
+
+
+def test_cohort_df_uses_buckets_when_present():
+    from agent.dataframe_adapters import cohort_result_to_df
+    from agent.tools.search_patients_by_criteria import BreakdownBucket, CohortResult
+
+    r = CohortResult(
+        total_count=5,
+        sample=[],
+        data_availability="data_present",
+        buckets=[
+            BreakdownBucket(bucket_label="F", patient_count=3),
+            BreakdownBucket(bucket_label="M", patient_count=2),
+        ],
+    )
+    df = cohort_result_to_df(r)
+    assert list(df.columns) == ["bucket_label", "patient_count"]
+    assert len(df) == 2
+
+
+def test_cohort_df_empty_when_no_sample_no_buckets():
+    from agent.dataframe_adapters import cohort_result_to_df
+    from agent.tools.search_patients_by_criteria import CohortResult
+
+    r = CohortResult(total_count=0, sample=[], data_availability="no_records_found")
+    assert cohort_result_to_df(r).empty

--- a/tests/agent/test_runtime_cohort_event.py
+++ b/tests/agent/test_runtime_cohort_event.py
@@ -1,0 +1,17 @@
+"""The runtime renders a DataFrame message for breakdown buckets too,
+not only per-patient samples."""
+
+from __future__ import annotations
+
+
+def _payload_has_renderable(payload: dict) -> bool:
+    # Mirrors the runner gate we are about to implement.
+    return bool(payload.get("sample")) or bool(payload.get("buckets"))
+
+
+def test_gate_accepts_buckets_only_payload():
+    assert _payload_has_renderable({"sample": [], "buckets": [{"bucket_label": "F", "patient_count": 3}]})
+
+
+def test_gate_rejects_empty_payload():
+    assert not _payload_has_renderable({"sample": [], "buckets": []})

--- a/tests/agent/test_system_prompt_routing.py
+++ b/tests/agent/test_system_prompt_routing.py
@@ -1,0 +1,10 @@
+from agent.system_prompt import SYSTEM_PROMPT
+from agent.tools.run_sql import _RUN_SQL_BASE_DESCRIPTION
+
+
+def test_prompt_mentions_breakdown_routing():
+    assert "breakdown" in SYSTEM_PROMPT.lower()
+
+
+def test_run_sql_description_defers_single_dimension_breakdowns():
+    assert "single-dimension" in _RUN_SQL_BASE_DESCRIPTION.lower()

--- a/tests/agent/tools/test_search_patients_by_criteria.py
+++ b/tests/agent/tools/test_search_patients_by_criteria.py
@@ -399,3 +399,35 @@ def test_dx_plus_geo_concatenates_both_notes(synthetic_db):
     )
     assert _RELIABILITY_DX in (out.reliability_note or "")
     assert _RELIABILITY_GEO in (out.reliability_note or "")
+
+
+def test_criteria_accepts_breakdown_list():
+    from agent.db.queries.cohort_breakdown import BreakdownDimension
+    from agent.tools.search_patients_by_criteria import CohortCriteria
+
+    c = CohortCriteria(gender="F", breakdown=[BreakdownDimension.GENDER])
+    assert c.breakdown == [BreakdownDimension.GENDER]
+
+
+def test_criteria_breakdown_defaults_empty():
+    from agent.tools.search_patients_by_criteria import CohortCriteria
+
+    c = CohortCriteria(gender="F")
+    assert c.breakdown == []
+
+
+def test_cohort_result_carries_breakdown_fields():
+    from agent.tools.search_patients_by_criteria import BreakdownBucket, CohortResult
+
+    r = CohortResult(
+        total_count=3,
+        sample=[],
+        data_availability="data_present",
+        buckets=[BreakdownBucket(bucket_label="F", patient_count=3)],
+        non_additive=False,
+        generated_sql="SELECT 1",
+        breakdown_status="single_dimension",
+    )
+    assert r.buckets[0].patient_count == 3
+    assert r.non_additive is False
+    assert r.breakdown_status == "single_dimension"

--- a/tests/agent/tools/test_search_patients_by_criteria.py
+++ b/tests/agent/tools/test_search_patients_by_criteria.py
@@ -431,3 +431,63 @@ def test_cohort_result_carries_breakdown_fields():
     assert r.buckets[0].patient_count == 3
     assert r.non_additive is False
     assert r.breakdown_status == "single_dimension"
+
+
+def _ctx(synthetic_db):
+    ctx = MagicMock()
+    ctx.deps = _deps(synthetic_db, selected=None)
+    return ctx
+
+
+def test_single_gender_breakdown_returns_buckets(synthetic_db):
+    from agent.tools.search_patients_by_criteria import CohortCriteria, search_patients_by_criteria
+    from agent.db.queries.cohort_breakdown import BreakdownDimension
+
+    crit = CohortCriteria(age_min=0, breakdown=[BreakdownDimension.GENDER])
+    result = search_patients_by_criteria(_ctx(synthetic_db), crit)
+    assert result.breakdown_status == "single_dimension"
+    assert result.buckets, "expected gender buckets"
+    assert result.sample == [], "sample suppressed in breakdown mode"
+    assert result.non_additive is False
+    assert result.generated_sql and ":age_min" not in result.generated_sql
+
+
+def test_diagnosis_month_breakdown_is_non_additive(synthetic_db):
+    from datetime import date
+    from agent.tools.search_patients_by_criteria import CohortCriteria, search_patients_by_criteria
+    from agent.db.queries.cohort_breakdown import BreakdownDimension
+
+    crit = CohortCriteria(
+        diagnosis_date_range={"start": date(2025, 1, 1), "end": date(2025, 12, 31)},
+        breakdown=[BreakdownDimension.DIAGNOSIS_MONTH],
+    )
+    result = search_patients_by_criteria(_ctx(synthetic_db), crit)
+    assert result.non_additive is True
+    assert result.reliability_note and "do not sum" in result.reliability_note.lower()
+
+
+def test_two_dimensions_escalates_without_executing(synthetic_db):
+    from datetime import date
+    from agent.tools.search_patients_by_criteria import CohortCriteria, search_patients_by_criteria
+    from agent.db.queries.cohort_breakdown import BreakdownDimension
+
+    crit = CohortCriteria(
+        diagnosis_date_range={"start": date(2025, 1, 1), "end": date(2025, 12, 31)},
+        breakdown=[BreakdownDimension.DIAGNOSIS_MONTH, BreakdownDimension.GENDER],
+    )
+    result = search_patients_by_criteria(_ctx(synthetic_db), crit)
+    assert result.breakdown_status == "unsupported_multi_dimension"
+    assert result.buckets == []
+    assert result.generated_sql, "must hand back a template for the first dimension"
+    assert result.notes_to_agent and "run_sql" in result.notes_to_agent
+
+
+def test_time_breakdown_missing_anchor_signals(synthetic_db):
+    from agent.tools.search_patients_by_criteria import CohortCriteria, search_patients_by_criteria
+    from agent.db.queries.cohort_breakdown import BreakdownDimension
+
+    crit = CohortCriteria(gender="F", breakdown=[BreakdownDimension.DIAGNOSIS_MONTH])
+    result = search_patients_by_criteria(_ctx(synthetic_db), crit)
+    assert result.breakdown_status == "missing_diagnosis_anchor"
+    assert result.buckets == []
+    assert result.notes_to_agent and "diagnosis" in result.notes_to_agent.lower()


### PR DESCRIPTION
## Summary

Adds single-dimension population breakdowns to the agent's `search_patients_by_criteria` tool. A user asking *"How many people had any diagnosis in 2024? Break it out by month."* now routes to the curated tool (instead of the LLM hand-writing `run_sql`).

Supports breakdown by `diagnosis_month` / `diagnosis_quarter` / `diagnosis_year`, `gender`, `age_band`. One dimension executes; 2+ returns a copy-pasteable `generated_sql` template to extend in `run_sql`.

## ⚠️ Counting-grain correction (resolved during review — read this)

While validating the live output, we found a **pre-existing, warehouse-wide counting bug** that this PR initially inherited and now fixes:

- HEALTHeLINK patients accumulate **multiple CIDs (`source_id`) over time** via record merges. `internal_source_reference_v.empi_rank` ranks them: **`empi_rank = 1` = the current primary CID (one per person)**; ranks 2–10 are legacy/merged CIDs; 99 is inactive.
- The established `empi_rank != 99` + `COUNT(DISTINCT source_id)` pattern counts **every historical CID**, over-counting people **~2×**. Prod validation, "any diagnosis in 2024": **2,801,890** with `!= 99` vs **1,415,171** with `= 1` — the latter matches the ~1.4–1.5M WNY population.
- **Fix:** count `COUNT(DISTINCT source_id)` at **`empi_rank = 1`** across the count-only path, sample path, and breakdown. `source_id`/CID stays the patient key (`patient_id` is not used for aggregation, per the team's DW guidance). `!= 99` is retained only where we *gather* a person's facts across their CIDs (`patient.py`, `procedures.py`), not for counting.
- Also corrected the **system prompt + RAG seed examples**, which taught the `!= 99` pattern, and added a best-effort caveat (CID merges don't back-propagate).

User-facing counts drop ~2× as a result — they were wrong before.

## Behavior
- `breakdown=[]` → unchanged.
- `breakdown=[one dim]` → aggregate buckets (`COUNT(DISTINCT source_id)` at `empi_rank = 1`) + population total at the same grain; per-patient sample suppressed.
- `breakdown=[2+]` → no execution; structured escalation with `generated_sql`.
- Diagnosis-time breakdowns require a diagnosis anchor; time buckets are non-additive (a patient active in multiple months appears in each — surfaced verbatim).

## Test Plan
- [x] Full agent suite: `uv run pytest tests/agent -m "not milvus and not sample_db"` → **542 passed**
- [x] Dedup proof: tests assert a person with multiple active CIDs (ranks 1 + 2) counts **once**
- [x] Breakdown unit + additivity/non-additivity, `inline_sql_literals`, arity 0/1/2+, missing-anchor
- [x] End-to-end runner gate driven with a real buckets payload
- [x] `run_sql` description within char budget (5989/6000)
- [x] sample_db integration: monthly breakdown passes against the loaded ~200-patient Postgres DB
- [ ] Reviewer: confirm `empi_rank = 1` (primary CID) is the correct people-count grain warehouse-wide
- [ ] Deploy: re-run `uv run python scripts/seed_agent_rag.py` so updated RAG guidance is retrievable

🤖 Generated with [Claude Code](https://claude.com/claude-code)