### PR TITLE
fix: enforce row LIMIT at SQL execution time

### DIFF
--- a/tests/utils/test_database_execution_retry.py
+++ b/tests/utils/test_database_execution_retry.py
@@ -479,7 +479,8 @@ class TestVannaServiceRunSql:
         # Verify error was stored
         assert result is None
         assert mock_session.get("last_run_sql_error") == "Connection refused"
-        assert mock_session.get("last_failed_sql") == "SELECT 1"
+        # run_sql now enforces a LIMIT before execution
+        assert mock_session.get("last_failed_sql") == "SELECT 1 LIMIT 1000"
 
     def test_run_sql_clears_error_on_success(self, monkeypatch):
         """Test that run_sql clears previous error context on success."""

--- a/tests/utils/test_vanna_service_functions.py
+++ b/tests/utils/test_vanna_service_functions.py
@@ -93,7 +93,8 @@ class TestVannaServiceAdditional:
         result = service.run_sql("SELECT * FROM test_table")
 
         assert result.equals(mock_df)
-        service.vn.run_sql.assert_called_once_with(sql="SELECT * FROM test_table")
+        # run_sql enforces a LIMIT clause before execution
+        service.vn.run_sql.assert_called_once_with(sql="SELECT * FROM test_table LIMIT 1000")
 
     def test_should_generate_chart(self, mock_vanna_service):
         service = mock_vanna_service

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -1075,6 +1075,10 @@ class VannaService:
 
         For backwards compatibility, some callers may only expect a DataFrame.
         """
+        from utils.config_helper import ensure_query_has_limit
+
+        sql = ensure_query_has_limit(sql)
+
         try:
             # Clear any previous error context before executing a new query
             try:

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -167,7 +167,7 @@ if "_messages_loaded" not in st.session_state:
 from utils.config_helper import get_max_session_messages
 
 max_messages = get_max_session_messages()
-if len(st.session_state.messages) > max_messages:
+if st.session_state.messages and len(st.session_state.messages) > max_messages:
     messages_to_remove = len(st.session_state.messages) - max_messages
     st.session_state.messages = st.session_state.messages[messages_to_remove:]
     logger.info(


### PR DESCRIPTION
## Summary
- Adds `ensure_query_has_limit()` call inside `VannaService.run_sql()` so every query is capped (default 1000 rows) **before** hitting the database
- Previously the limit was only applied after SQL generation, leaving manually edited queries, retries, and other `run_sql` callers unbounded
- Updates two test assertions to reflect that `last_failed_sql` now stores the limit-enforced query

## Test plan
- [x] All 347 utils/orm tests pass
- [ ] Verify in the UI that queries returning large result sets are properly capped

🤖 Generated with [Claude Code](https://claude.com/claude-code)