### PR TITLE
feat(chat): friendly collapsible error cards + non-blocking flow

### DIFF
--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -339,6 +339,49 @@ def test_handle_sql_retry_click_sets_retry_context(monkeypatch):
     assert fake_st.session_state.get("pending_sql_error") is False
 
 
+def test_retry_feedback_from_dynamic_textbox_key_reaches_handler(monkeypatch):
+    """End-to-end: feedback typed into the active error's dynamic widget key
+    flows through render_friendly_error → handle_sql_retry_click → retry_user_feedback.
+
+    Regression test: before the fix, render_friendly_error wrote the textbox to
+    `retry_feedback_msg_<id>` while handle_sql_retry_click only read
+    `retry_feedback_active`, so feedback was silently dropped.
+    """
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    # Simulate that Streamlit's text_input has stored the user's typed value
+    # under the dynamic widget key (this is what real Streamlit does).
+    fake_st.session_state.update(
+        {
+            "pending_sql_error": True,
+            "pending_question": "Show me data",
+            "last_failed_sql": "SELECT 1",
+            "last_run_sql_error": "syntax error",
+            "retry_feedback_msg_42": "use a JOIN",
+        }
+    )
+
+    # Render the active error card — this is where the canonical key gets mirrored.
+    cbh.render_friendly_error(
+        "syntax error",
+        failed_sql="SELECT 1",
+        show_retry=True,
+        retry_key_suffix="msg_42",
+    )
+
+    # After rendering, the canonical key should mirror the dynamic one.
+    assert fake_st.session_state.get("retry_feedback_active") == "use a JOIN"
+
+    # Now click Retry.
+    cbh.handle_sql_retry_click()
+
+    assert fake_st.session_state.get("retry_user_feedback") == "use a JOIN"
+    assert fake_st.session_state.get("use_retry_context") is True
+
+
 def test_chart_failure_includes_stashed_error_detail(monkeypatch):
     """When a chart fails, the friendly ERROR message includes the actual error from session state."""
     import utils.chat_bot_helper as cbh

--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -1,0 +1,391 @@
+"""Tests for the friendly collapsible error UX in the chat UI.
+
+Covers:
+- render_friendly_error uses an expander, never st.error (no red wall).
+- The active SQL error message renders an in-card Retry button; older error
+  messages in history do not.
+- A SQL failure no longer calls st.stop() — control returns cleanly so the
+  chat input keeps working for new questions.
+- A surprise exception in the chat flow is caught by the top-level safety
+  net and persisted as a friendly ERROR Message.
+"""
+
+from __future__ import annotations
+
+import types
+from contextlib import nullcontext
+
+import pandas as pd
+
+
+def _fake_st():
+    """Recording fake-Streamlit used to assert what the UI rendered."""
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    st.session_state.update(
+        {
+            "messages": [],
+            "show_sql": True,
+            "show_table": True,
+            "show_chart": False,
+            "show_summary": False,
+            "speak_summary": False,
+        }
+    )
+
+    st.chat_message = lambda *_a, **_k: nullcontext()
+
+    class _Placeholder:
+        def markdown(self, *a, **k):
+            pass
+
+        def empty(self):
+            pass
+
+    st.empty = lambda: _Placeholder()
+
+    class _Ctx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    st.columns = lambda sizes: [_Ctx() for _ in sizes]
+
+    # Recorders: capture each UI element the renderer emits.
+    st._expander_calls = []
+    st._error_calls = []
+    st._warning_calls = []
+    st._button_calls = []
+    st._code_calls = []
+    st._markdown_calls = []
+
+    def _expander(label, *_a, **_k):
+        st._expander_calls.append(label)
+        return _Ctx()
+
+    st.expander = _expander
+    st.error = lambda *a, **k: st._error_calls.append(a[0] if a else None)
+    st.warning = lambda *a, **k: st._warning_calls.append(a[0] if a else None)
+
+    def _button(label, *_a, **_k):
+        st._button_calls.append(label)
+        return False
+
+    st.button = _button
+    st.code = lambda *a, **k: st._code_calls.append(a[0] if a else None)
+    st.markdown = lambda *a, **k: st._markdown_calls.append(a[0] if a else None)
+    st.write = lambda *a, **k: None
+    st.caption = lambda *a, **k: None
+    st.info = lambda *a, **k: None
+    st.text = lambda *a, **k: None
+    st.text_input = lambda *a, **k: ""
+
+    class StopException(Exception):
+        pass
+
+    st.StopException = StopException
+
+    def _stop():
+        raise StopException()
+
+    st.stop = _stop
+    st.dataframe = lambda *a, **k: None
+    st.plotly_chart = lambda *a, **k: None
+    st.popover = lambda *a, **k: nullcontext()
+    st.rerun = lambda: None
+    return st
+
+
+def test_render_friendly_error_uses_expander_not_red_wall(monkeypatch):
+    """The helper should never call st.error — that's what produces the red wall."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    cbh.render_friendly_error("syntax error near LIMIT")
+
+    assert fake_st._error_calls == [], "render_friendly_error must not call st.error"
+    assert fake_st._expander_calls, "render_friendly_error must wrap content in an expander"
+    assert "Well this is awkward" in fake_st._expander_calls[0]
+    assert any("syntax error near LIMIT" in (c or "") for c in fake_st._code_calls)
+
+
+def test_render_friendly_error_omits_retry_by_default(monkeypatch):
+    """Default rendering has no Retry button — only SQL errors opt in."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    cbh.render_friendly_error("something broke")
+
+    assert "Retry" not in fake_st._button_calls
+
+
+def test_render_friendly_error_with_retry_button(monkeypatch):
+    """When show_retry=True, the helper renders a Retry button + failed SQL."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    cbh.render_friendly_error(
+        "permission denied",
+        failed_sql="SELECT * FROM secret",
+        show_retry=True,
+    )
+
+    assert "Retry" in fake_st._button_calls
+    assert any("SELECT * FROM secret" in (c or "") for c in fake_st._code_calls)
+
+
+def test_render_error_shows_retry_only_for_active_error(monkeypatch):
+    """A historical ERROR whose SQL doesn't match last_failed_sql shouldn't get a Retry button."""
+    import utils.chat_bot_helper as cbh
+    from orm.models import Message
+    from utils.enums import MessageType, RoleType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    fake_st.session_state["pending_sql_error"] = True
+    fake_st.session_state["last_failed_sql"] = "SELECT current_failed"
+    fake_st.session_state["last_run_sql_error"] = "boom"
+
+    active = Message(RoleType.ASSISTANT, "boom", MessageType.ERROR, "SELECT current_failed", "Q", None, None)
+    stale = Message(RoleType.ASSISTANT, "old", MessageType.ERROR, "SELECT old_failed", "Q-old", None, None)
+
+    cbh._render_error(active, 0)
+    cbh._render_error(stale, 1)
+
+    # Active error: Retry button present.
+    # Stale error: rendered, but its retry button was suppressed.
+    assert fake_st._button_calls.count("Retry") == 1
+
+
+def test_render_error_no_retry_when_no_pending_error(monkeypatch):
+    """Even if message.query is set, no Retry button without an active session error."""
+    import utils.chat_bot_helper as cbh
+    from orm.models import Message
+    from utils.enums import MessageType, RoleType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    fake_st.session_state["pending_sql_error"] = False
+    msg = Message(RoleType.ASSISTANT, "old error", MessageType.ERROR, "SELECT 1", "Q", None, None)
+
+    cbh._render_error(msg, 0)
+
+    assert "Retry" not in fake_st._button_calls
+
+
+class _SqlFailsForever:
+    """Mock VannaService whose run_sql never returns a DataFrame."""
+
+    def is_sql_valid(self, sql):
+        return True
+
+    def generate_sql(self, question):
+        return ("SELECT 1", 0.01)
+
+    def generate_sql_retry(self, question, failed_sql=None, error_message=None, attempt_number=2, user_feedback=None):
+        return ("SELECT 1 /* retry */", 0.01)
+
+    def run_sql(self, sql):
+        return ("not-a-df", 0.01)
+
+
+def test_sql_failure_no_longer_calls_st_stop(monkeypatch):
+    """The whole point of the fix: a SQL failure must NOT halt the script."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "get_ethical_guideline", lambda q: ("", 1))
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    monkeypatch.setattr(cbh, "get_vn", lambda: _SqlFailsForever())
+
+    cbh.set_question("Q that fails", render=False)
+
+    # Should NOT raise StopException.
+    cbh.normal_message_flow("Q that fails")
+
+    # A friendly ERROR message landed in history…
+    assert any(getattr(m, "type", None) == "error" for m in fake_st.session_state["messages"])
+    # …and pending_sql_error was set so the in-history card shows Retry on its next render.
+    assert fake_st.session_state.get("pending_sql_error") is True
+
+
+class _RaisesRuntimeError:
+    """Mock VannaService that raises a surprise exception."""
+
+    def is_sql_valid(self, sql):
+        return True
+
+    def generate_sql(self, question):
+        raise RuntimeError("kaboom from generate_sql")
+
+
+def test_top_level_safety_net_catches_unexpected_exception(monkeypatch):
+    """A surprise RuntimeError must surface as a friendly ERROR message, not propagate."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "get_ethical_guideline", lambda q: ("", 1))
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    monkeypatch.setattr(cbh, "get_vn", lambda: _RaisesRuntimeError())
+
+    cbh.set_question("Q that explodes", render=False)
+    cbh.normal_message_flow("Q that explodes")  # must not raise
+
+    error_msgs = [m for m in fake_st.session_state["messages"] if getattr(m, "type", None) == "error"]
+    assert error_msgs, "Expected a friendly ERROR message to be persisted"
+    assert "kaboom from generate_sql" in error_msgs[-1].content
+    # my_question gets cleared so the same failing question doesn't re-fire on rerun.
+    assert fake_st.session_state.get("my_question") is None
+
+
+def test_top_level_safety_net_reraises_streamlit_control_exceptions(monkeypatch):
+    """Streamlit's RerunException / StopException must still propagate so the runtime can act."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "get_ethical_guideline", lambda q: ("", 1))
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    class StopException(Exception):
+        pass
+
+    StopException.__name__ = "StopException"
+
+    class _StopVn:
+        def is_sql_valid(self, sql):
+            return True
+
+        def generate_sql(self, question):
+            raise StopException()
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _StopVn())
+    cbh.set_question("Q", render=False)
+
+    raised = False
+    try:
+        cbh.normal_message_flow("Q")
+    except StopException:
+        raised = True
+    assert raised, "StopException must propagate, not be swallowed by the safety net"
+
+
+def test_render_error_short_content_still_uses_expander(monkeypatch):
+    """The legacy short/long branching is gone — every error uses the friendly expander."""
+    import utils.chat_bot_helper as cbh
+    from orm.models import Message
+    from utils.enums import MessageType, RoleType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    short = Message(RoleType.ASSISTANT, "oops", MessageType.ERROR, "", "Q", None, None)
+    cbh._render_error(short, 0)
+
+    assert fake_st._warning_calls == [], "We removed the st.warning fallback for short messages"
+    assert fake_st._expander_calls, "Short ERRORs should still be wrapped in the friendly expander"
+
+
+def test_handle_sql_retry_click_sets_retry_context(monkeypatch):
+    """Clicking Retry must arm use_retry_context with the pending error info."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    fake_st.session_state.update(
+        {
+            "pending_sql_error": True,
+            "pending_question": "Show me data",
+            "last_failed_sql": "SELECT 1",
+            "last_run_sql_error": "syntax error",
+            "retry_feedback_active": "try a JOIN",
+        }
+    )
+
+    cbh.handle_sql_retry_click()
+
+    assert fake_st.session_state.get("use_retry_context") is True
+    assert fake_st.session_state.get("retry_failed_sql") == "SELECT 1"
+    assert fake_st.session_state.get("retry_error_msg") == "syntax error"
+    assert fake_st.session_state.get("retry_user_feedback") == "try a JOIN"
+    assert fake_st.session_state.get("my_question") == "Show me data"
+    assert fake_st.session_state.get("pending_sql_error") is False
+
+
+def test_new_question_after_error_clears_pending_state(monkeypatch):
+    """After a SQL error, typing a new question proceeds without needing to click Retry."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "get_ethical_guideline", lambda q: ("", 1))
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    class _FailThenSucceed:
+        def __init__(self):
+            self.failed_once = False
+
+        def is_sql_valid(self, sql):
+            return True
+
+        def generate_sql(self, question):
+            return ("SELECT 1", 0.01)
+
+        def generate_sql_retry(
+            self, question, failed_sql=None, error_message=None, attempt_number=2, user_feedback=None
+        ):
+            return ("SELECT 1 /* retry */", 0.01)
+
+        def run_sql(self, sql):
+            if not self.failed_once:
+                self.failed_once = True
+                return ("not-a-df", 0.01)
+            return (pd.DataFrame({"c": [1]}), 0.02)
+
+        def should_generate_chart(self, question, sql, df):
+            return False
+
+        def generate_summary(self, question, df):
+            return ("ok", 0.01)
+
+        def generate_followup_questions(self, question, sql, df):
+            return []
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _FailThenSucceed())
+
+    cbh.set_question("Q1 fails", render=False)
+    cbh.normal_message_flow("Q1 fails")  # must not raise
+    assert fake_st.session_state.get("pending_sql_error") is True
+
+    cbh.set_question("Q2 works", render=False)
+    # set_question alone is supposed to clear the lingering error state.
+    assert fake_st.session_state.get("pending_sql_error") is False
+    assert fake_st.session_state.get("last_failed_sql") in (None, "")
+    assert fake_st.session_state.get("last_run_sql_error") in (None, "")

--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -339,6 +339,148 @@ def test_handle_sql_retry_click_sets_retry_context(monkeypatch):
     assert fake_st.session_state.get("pending_sql_error") is False
 
 
+def test_chart_failure_includes_stashed_error_detail(monkeypatch):
+    """When a chart fails, the friendly ERROR message includes the actual error from session state."""
+    import utils.chat_bot_helper as cbh
+    from utils.enums import MessageType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    # get_chart prefers the module-level cbh.vn over get_vn() — null it so other tests
+    # that populated it can't leak in.
+    monkeypatch.setattr(cbh, "vn", None)
+
+    class _ChartFailsVN:
+        def should_generate_chart(self, question, sql, df):
+            return True
+
+        def generate_plotly_code(self, question, sql, df):
+            return None, 0  # simulates the swallowed-exception path; detail is in session state
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _ChartFailsVN())
+
+    fake_st.session_state["last_chart_error"] = "boom: chart code blew up"
+
+    cbh.get_chart("Q", "SELECT 1", pd.DataFrame({"a": [1, 2]}))
+
+    errors = [m for m in fake_st.session_state["messages"] if getattr(m, "type", None) == MessageType.ERROR.value]
+    assert errors, "expected a friendly chart ERROR message"
+    assert "boom: chart code blew up" in errors[-1].content
+    # And the key is consumed so it doesn't leak into the next flow.
+    assert fake_st.session_state.get("last_chart_error") is None
+
+
+def test_chart_failure_without_stashed_error_uses_generic_text(monkeypatch):
+    """No detail stashed → keep the existing generic message rather than dangling a stray separator."""
+    import utils.chat_bot_helper as cbh
+    from utils.enums import MessageType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    monkeypatch.setattr(cbh, "vn", None)
+
+    class _ChartSilentNoneVN:
+        def should_generate_chart(self, question, sql, df):
+            return False
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _ChartSilentNoneVN())
+
+    cbh.get_chart("Q", "SELECT 1", pd.DataFrame({"a": [1, 2]}))
+
+    errors = [m for m in fake_st.session_state["messages"] if getattr(m, "type", None) == MessageType.ERROR.value]
+    assert errors
+    assert errors[-1].content == "I was unable to generate a chart for this question."
+
+
+def test_followup_failure_emits_friendly_error(monkeypatch):
+    """A followup-generation failure surfaces as an ERROR message, not a silent empty list."""
+    import utils.chat_bot_helper as cbh
+    from utils.enums import MessageType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    class _FollowupFailsVN:
+        def generate_followup_questions(self, question, sql, df):
+            return []  # vanna_calls swallowed; detail in session state
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _FollowupFailsVN())
+
+    fake_st.session_state["last_followup_error"] = "kaboom: followup model timeout"
+
+    cbh.get_followup_questions("Q", "SELECT 1", pd.DataFrame({"a": [1, 2]}))
+
+    # Should be an ERROR message, NOT a FOLLOWUP message.
+    types_seen = [getattr(m, "type", None) for m in fake_st.session_state["messages"]]
+    assert MessageType.ERROR.value in types_seen
+    assert MessageType.FOLLOWUP.value not in types_seen
+    err_msg = next(m for m in fake_st.session_state["messages"] if m.type == MessageType.ERROR.value)
+    assert "kaboom: followup model timeout" in err_msg.content
+
+
+def test_followup_success_still_emits_followup(monkeypatch):
+    """No stashed error → the existing FOLLOWUP message path is preserved."""
+    import utils.chat_bot_helper as cbh
+    from utils.enums import MessageType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    class _FollowupOkVN:
+        def generate_followup_questions(self, question, sql, df):
+            return ["Question A?", "Question B?"]
+
+    monkeypatch.setattr(cbh, "get_vn", lambda: _FollowupOkVN())
+    cbh.get_followup_questions("Q", "SELECT 1", pd.DataFrame({"a": [1, 2]}))
+
+    types_seen = [getattr(m, "type", None) for m in fake_st.session_state["messages"]]
+    assert MessageType.FOLLOWUP.value in types_seen
+    assert MessageType.ERROR.value not in types_seen
+
+
+def test_set_question_clears_optional_step_error_keys(monkeypatch):
+    """Stale chart/summary/followup error stashes don't leak into the next question."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+
+    fake_st.session_state["last_chart_error"] = "stale chart error"
+    fake_st.session_state["last_summary_error"] = "stale summary error"
+    fake_st.session_state["last_followup_error"] = "stale followup error"
+
+    cbh.set_question("a fresh question", render=False)
+
+    assert fake_st.session_state.get("last_chart_error") is None
+    assert fake_st.session_state.get("last_summary_error") is None
+    assert fake_st.session_state.get("last_followup_error") is None
+
+
+def test_vanna_calls_stashes_chart_error(monkeypatch):
+    """The helper in vanna_calls actually writes the error into session state on failure."""
+    import streamlit as st_real
+
+    import utils.vanna_calls as vc
+
+    captured = {}
+
+    class _FakeState(dict):
+        def __setitem__(self, k, v):
+            captured[k] = v
+            super().__setitem__(k, v)
+
+    monkeypatch.setattr(st_real, "session_state", _FakeState())
+
+    vc._stash_optional_step_error("last_chart_error", RuntimeError("plot crashed"))
+
+    assert captured.get("last_chart_error") == "plot crashed"
+
+
 def test_new_question_after_error_clears_pending_state(monkeypatch):
     """After a SQL error, typing a new question proceeds without needing to click Retry."""
     import utils.chat_bot_helper as cbh

--- a/tests/utils/test_vanna_exception_handling.py
+++ b/tests/utils/test_vanna_exception_handling.py
@@ -159,71 +159,64 @@ class TestVannaServiceExceptions:
 
     @patch("streamlit.error")
     def test_generate_sql_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in generate_sql are handled properly."""
+        """generate_sql swallows the exception silently; the friendly error card is rendered
+        by the chat-flow layer when no SQL is produced."""
         service = mock_vanna_service
         service.vn.generate_sql.side_effect = Exception("Failed to generate SQL")
 
         with patch.dict("streamlit.secrets", {"security": {"allow_llm_to_see_data": False}}):
             result, elapsed_time = service.generate_sql("Show me the data")
 
-            # Should return None and display error
             assert result is None
             assert elapsed_time == 0
-            mock_st_error.assert_called_once()
-            assert "Error generating SQL" in mock_st_error.call_args[0][0]
+            mock_st_error.assert_not_called()
 
     @patch("streamlit.error")
     def test_is_sql_valid_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in is_sql_valid are handled properly."""
+        """is_sql_valid returns False on exception without surfacing a red-wall st.error."""
         service = mock_vanna_service
         service.vn.is_sql_valid.side_effect = Exception("SQL validation error")
 
         result = service.is_sql_valid("SELECT * FROM table")
 
-        # Should return False and display error
         assert result is False
-        mock_st_error.assert_called_once()
-        assert "Error checking SQL validity" in mock_st_error.call_args[0][0]
+        mock_st_error.assert_not_called()
 
     @patch("streamlit.error")
     def test_run_sql_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in run_sql are handled properly."""
+        """run_sql stores error context in session state but does not render st.error;
+        normal_message_flow renders the friendly ERROR card after retries are exhausted."""
         service = mock_vanna_service
         service.vn.run_sql.side_effect = Exception("Failed to run SQL")
 
         result = service.run_sql("SELECT * FROM table")
 
-        # Should return None and display error
         assert result is None
-        mock_st_error.assert_called_once()
-        assert "Error running SQL" in mock_st_error.call_args[0][0]
+        mock_st_error.assert_not_called()
 
     @patch("streamlit.error")
     def test_should_generate_chart_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in should_generate_chart are handled properly."""
+        """should_generate_chart returns False on exception without an st.error red wall."""
         service = mock_vanna_service
         service.vn.should_generate_chart.side_effect = Exception("Chart generation decision error")
 
         result = service.should_generate_chart("question", "sql", DataFrame())
 
-        # Should return False and display error
         assert result is False
-        mock_st_error.assert_called_once()
-        assert "Error checking if we should generate a chart" in mock_st_error.call_args[0][0]
+        mock_st_error.assert_not_called()
 
     @patch("streamlit.error")
     def test_generate_plotly_code_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in generate_plotly_code are handled properly."""
+        """generate_plotly_code returns (None, 0) on exception. The caller (get_chart) emits a
+        friendly ERROR message via the existing fallback path."""
         service = mock_vanna_service
         service.vn.generate_plotly_code.side_effect = Exception("Plotly code generation error")
 
         result, elapsed_time = service.generate_plotly_code("question", "sql", DataFrame())
 
-        # Should return None and display error
         assert result is None
         assert elapsed_time == 0
-        mock_st_error.assert_called_once()
-        assert "Error generating Plotly code" in mock_st_error.call_args[0][0]
+        mock_st_error.assert_not_called()
 
     @pytest.mark.skip(reason="Streamlit caching interferes with MagicMock serialization")
     @patch("streamlit.error")
@@ -246,16 +239,15 @@ class TestVannaServiceExceptions:
 
     @patch("streamlit.error")
     def test_generate_followup_questions_exception(self, mock_st_error, mock_vanna_service):
-        """Test that exceptions in generate_followup_questions are handled properly."""
+        """generate_followup_questions returns [] on exception without an st.error red wall.
+        Follow-ups are optional, so silent failure is the right behavior."""
         service = mock_vanna_service
         service.vn.generate_followup_questions.side_effect = Exception("Followup questions error")
 
         result = service.generate_followup_questions("question", "sql", DataFrame())
 
-        # Should return empty list and display error
         assert result == []
-        mock_st_error.assert_called_once()
-        assert "Error generating followup questions" in mock_st_error.call_args[0][0]
+        mock_st_error.assert_not_called()
 
     @pytest.mark.skip(reason="Streamlit caching interferes with this test")
     def test_generate_summary_exception(self, mock_vanna_service):

--- a/tests/views/test_chat_bot.py
+++ b/tests/views/test_chat_bot.py
@@ -341,20 +341,23 @@ class TestRenderMessage:
 
     @patch("utils.chat_bot_helper.st")
     def test_render_short_error_message(self, mock_st):
-        """Short error messages are displayed directly in warning without collapsible."""
+        """All errors render inside the friendly collapsible card — no st.warning or st.error."""
+        mock_st.session_state = {}
         msg = Message(role=RoleType.ASSISTANT, content="An error occurred", type=MessageType.ERROR)
 
         render_message(msg, 4)
 
         self.common_asserts(mock_st, RoleType.ASSISTANT.value)
-        # Short errors display directly in warning
-        mock_st.warning.assert_called_once_with("An error occurred")
-        mock_st.expander.assert_not_called()
+        mock_st.warning.assert_not_called()
+        mock_st.error.assert_not_called()
+        mock_st.expander.assert_called_once()
+        title_arg = mock_st.expander.call_args.args[0]
+        assert "Well this is awkward" in title_arg
 
     @patch("utils.chat_bot_helper.st")
     def test_render_long_error_message(self, mock_st):
-        """Long error messages (stack traces) use collapsible details."""
-        # Create a long error message (over 300 chars) to trigger collapsible
+        """Long error messages also use the friendly collapsible card (no separate branching)."""
+        mock_st.session_state = {}
         long_error = "x" * 350
 
         msg = Message(role=RoleType.ASSISTANT, content=long_error, type=MessageType.ERROR)
@@ -362,9 +365,11 @@ class TestRenderMessage:
         render_message(msg, 4)
 
         self.common_asserts(mock_st, RoleType.ASSISTANT.value)
-        # Long errors use warning with collapsible details
-        mock_st.warning.assert_called_once_with("An error occurred while processing your request.")
-        mock_st.expander.assert_called_once_with("View error details", expanded=False)
+        mock_st.warning.assert_not_called()
+        mock_st.error.assert_not_called()
+        mock_st.expander.assert_called_once()
+        title_arg = mock_st.expander.call_args.args[0]
+        assert "Well this is awkward" in title_arg
 
     @patch("utils.chat_bot_helper.st")
     def test_render_dataframe_message(self, mock_st):

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -785,20 +785,28 @@ def get_followup_questions(my_question, sql, df):
     followup_questions = vn_instance.generate_followup_questions(question=my_question, sql=sql, df=df)
 
     # Surface a friendly ERROR card when generation failed instead of silently
-    # dropping a FOLLOWUP message that would render as nothing.
-    detail = _consume_optional_step_error("last_followup_error")
-    if detail:
-        add_message(
-            Message(
-                RoleType.ASSISTANT,
-                f"I couldn't generate follow-up questions.\n\n{detail}",
-                MessageType.ERROR,
-                sql,
-                my_question,
-                group_id=get_current_group_id(),
+    # dropping a FOLLOWUP message that would render as nothing. Only consult the
+    # error stash when the call did NOT produce results — otherwise a stale
+    # stash from a prior turn could suppress a current-turn success.
+    if not followup_questions:
+        detail = _consume_optional_step_error("last_followup_error")
+        if detail:
+            add_message(
+                Message(
+                    RoleType.ASSISTANT,
+                    f"I couldn't generate follow-up questions.\n\n{detail}",
+                    MessageType.ERROR,
+                    sql,
+                    my_question,
+                    group_id=get_current_group_id(),
+                )
             )
-        )
-        return
+            return
+    else:
+        try:
+            st.session_state.pop("last_followup_error", None)
+        except Exception:
+            pass
 
     add_message(
         Message(
@@ -919,6 +927,12 @@ def render_friendly_error(
                 key=f"retry_feedback_{retry_key_suffix}",
                 placeholder="e.g., 'try using patient_id instead of id' or 'use a LEFT JOIN'",
             )
+            try:
+                st.session_state["retry_feedback_active"] = st.session_state.get(
+                    f"retry_feedback_{retry_key_suffix}", ""
+                )
+            except Exception:
+                pass
             st.button(
                 "Retry",
                 type="primary",
@@ -1277,6 +1291,11 @@ def normal_message_flow(my_question: str):
             )
         except Exception:
             logger.exception("Failed to persist friendly error message")
+            try:
+                with st.chat_message(RoleType.ASSISTANT.value):
+                    render_friendly_error(str(e))
+            except Exception:
+                logger.exception("Failed to render fallback friendly error")
         try:
             st.session_state["my_question"] = None
         except Exception:

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -339,6 +339,33 @@ def create_summary_cache_key(question: str, df: pd.DataFrame) -> str:
         return hashlib.sha1((question or "").encode("utf-8")).hexdigest()
 
 
+def _consume_optional_step_error(key: str) -> str | None:
+    """Pop a stashed optional-step error (chart/summary/followup) from session state."""
+    try:
+        err = st.session_state.pop(key, None)
+    except Exception:
+        err = None
+    if isinstance(err, str) and err.strip():
+        return err
+    return None
+
+
+def _chart_failure_message(default_text: str, sql: str, my_question: str, elapsed: float) -> Message:
+    """Build a friendly chart-failure ERROR message, including the stashed detail when present."""
+    detail = _consume_optional_step_error("last_chart_error")
+    content = f"{default_text}\n\n{detail}" if detail else default_text
+    return Message(
+        RoleType.ASSISTANT,
+        content,
+        MessageType.ERROR,
+        sql,
+        my_question,
+        None,
+        elapsed,
+        group_id=get_current_group_id(),
+    )
+
+
 def get_chart(my_question, sql, df):
     vn_instance = vn if vn is not None else get_vn()
     elapsed_sum = 0
@@ -387,44 +414,11 @@ def get_chart(my_question, sql, df):
                     )
                 )
             else:
-                add_message(
-                    Message(
-                        RoleType.ASSISTANT,
-                        "I couldn't generate a chart",
-                        MessageType.ERROR,
-                        sql,
-                        my_question,
-                        None,
-                        elapsed_sum,
-                        group_id=get_current_group_id(),
-                    )
-                )
+                add_message(_chart_failure_message("I couldn't generate a chart", sql, my_question, elapsed_sum))
         else:
-            add_message(
-                Message(
-                    RoleType.ASSISTANT,
-                    "I couldn't generate a chart",
-                    MessageType.ERROR,
-                    sql,
-                    my_question,
-                    None,
-                    elapsed_sum,
-                    group_id=get_current_group_id(),
-                )
-            )
+            add_message(_chart_failure_message("I couldn't generate a chart", sql, my_question, elapsed_sum))
     else:
-        add_message(
-            Message(
-                RoleType.ASSISTANT,
-                "I was unable to generate a chart for this question.",
-                MessageType.ERROR,
-                sql,
-                my_question,
-                None,
-                0,
-                group_id=get_current_group_id(),
-            )
-        )
+        add_message(_chart_failure_message("I was unable to generate a chart for this question.", sql, my_question, 0))
 
 
 def set_question(question: str, render=True):
@@ -452,6 +446,9 @@ def set_question(question: str, render=True):
             st.session_state["last_run_sql_error"] = None
             st.session_state["last_failed_sql"] = None
             st.session_state["show_failed_sql_open"] = False
+            st.session_state["last_chart_error"] = None
+            st.session_state["last_summary_error"] = None
+            st.session_state["last_followup_error"] = None
         except Exception:
             pass
         add_message(Message(RoleType.USER, question, MessageType.TEXT, group_id=group_id), render)
@@ -786,6 +783,22 @@ def render_message_group(messages: list, group_index: int, start_index: int, is_
 def get_followup_questions(my_question, sql, df):
     vn_instance = get_vn()
     followup_questions = vn_instance.generate_followup_questions(question=my_question, sql=sql, df=df)
+
+    # Surface a friendly ERROR card when generation failed instead of silently
+    # dropping a FOLLOWUP message that would render as nothing.
+    detail = _consume_optional_step_error("last_followup_error")
+    if detail:
+        add_message(
+            Message(
+                RoleType.ASSISTANT,
+                f"I couldn't generate follow-up questions.\n\n{detail}",
+                MessageType.ERROR,
+                sql,
+                my_question,
+                group_id=get_current_group_id(),
+            )
+        )
+        return
 
     add_message(
         Message(
@@ -1662,7 +1675,23 @@ def _run_message_flow(my_question: str):
                 if st.session_state.get("speak_summary", True):
                     speak(summary)
             else:
-                # Do not add a blank/failed summary message per guidance; optionally speak a brief notice
+                # When generation failed (an error was stashed by vanna_calls),
+                # surface a friendly ERROR card so the user knows what happened
+                # instead of silently dropping the summary.
+                detail = _consume_optional_step_error("last_summary_error")
+                if detail and st.session_state.get("show_summary", True):
+                    add_message(
+                        Message(
+                            RoleType.ASSISTANT,
+                            f"I couldn't generate a summary.\n\n{detail}",
+                            MessageType.ERROR,
+                            final_sql,
+                            my_question,
+                            None,
+                            elapsed_time,
+                            group_id=get_current_group_id(),
+                        )
+                    )
                 if st.session_state.get("speak_summary", True):
                     speak("Summary is unavailable for this result")
 

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -858,19 +858,83 @@ def _render_plotly_chart(message: Message, index: int):
     st.plotly_chart(chart, key=f"message_{message.id}")
 
 
+FRIENDLY_ERROR_TITLE = "🤔 Well this is awkward, we seem to have run into an error"
+
+
+def handle_sql_retry_click() -> None:
+    """Shared callback for the in-card SQL Retry button.
+
+    Reads error context from session state and arms the retry path in
+    normal_message_flow. Re-asks the original question with the previous failed
+    SQL + error message fed back to the LLM so it can try a different approach.
+    """
+    user_feedback = st.session_state.get("retry_feedback_active", "")
+    st.session_state["use_retry_context"] = True
+    st.session_state["retry_failed_sql"] = st.session_state.get("last_failed_sql")
+    st.session_state["retry_error_msg"] = st.session_state.get("last_run_sql_error")
+    st.session_state["retry_user_feedback"] = user_feedback if user_feedback else None
+    st.session_state["my_question"] = st.session_state.get("pending_question")
+    st.session_state["pending_sql_error"] = False
+
+
+def render_friendly_error(
+    error_message: str,
+    *,
+    failed_sql: str | None = None,
+    show_retry: bool = False,
+    retry_key_suffix: str = "active",
+    title: str = FRIENDLY_ERROR_TITLE,
+) -> None:
+    """Render a collapsible, friendly error card.
+
+    Replaces Streamlit's red wall for any chat-screen error. The expander is
+    collapsed by default so the surface stays calm; the raw error and failed
+    SQL (if any) live inside it. When ``show_retry`` is True, an in-card Retry
+    button + optional feedback box re-runs the SQL with the error context fed
+    back to the LLM.
+    """
+    with st.expander(title, expanded=False):
+        st.markdown("Sorry about that — here's what happened:")
+        if error_message:
+            st.code(error_message, language="text")
+        if failed_sql:
+            st.markdown("**The SQL we tried:**")
+            st.code(failed_sql, language="sql", line_numbers=True)
+        if show_retry:
+            st.text_input(
+                "Optional feedback to help improve the query",
+                key=f"retry_feedback_{retry_key_suffix}",
+                placeholder="e.g., 'try using patient_id instead of id' or 'use a LEFT JOIN'",
+            )
+            st.button(
+                "Retry",
+                type="primary",
+                key=f"retry_button_{retry_key_suffix}",
+                on_click=handle_sql_retry_click,
+            )
+
+
+def _is_active_sql_error(message: Message) -> bool:
+    """True if this ERROR message represents the currently-pending SQL failure."""
+    if not st.session_state.get("pending_sql_error"):
+        return False
+    last_failed = st.session_state.get("last_failed_sql")
+    if not last_failed:
+        return False
+    return bool(getattr(message, "query", None)) and message.query == last_failed
+
+
 def _render_error(message: Message, index: int):
     if st.session_state.get("show_elapsed_time", True) and message.elapsed_time is not None:
         st.write(f"Elapsed Time: {message.elapsed_time}")
-    # Short error messages are displayed directly; long ones (stack traces) use collapsible
-    error_length_threshold = 300
-    if len(message.content) <= error_length_threshold:
-        # Short, user-friendly error - display directly in warning
-        st.warning(message.content)
-    else:
-        # Long error (likely stack trace) - use collapsible to reduce visual clutter
-        st.warning("An error occurred while processing your request.")
-        with st.expander("View error details", expanded=False):
-            st.code(message.content, language="text")
+    show_retry = _is_active_sql_error(message)
+    failed_sql = getattr(message, "query", None) if show_retry else None
+    render_friendly_error(
+        message.content,
+        failed_sql=failed_sql,
+        show_retry=show_retry,
+        retry_key_suffix=f"msg_{getattr(message, 'id', index)}",
+    )
 
 
 def _render_dataframe(message: Message, index: int):
@@ -1170,6 +1234,43 @@ def add_acknowledgement():
 
 
 def normal_message_flow(my_question: str):
+    """Top-level entry point — wraps the flow in a safety net so that any
+    unexpected exception surfaces as a friendly ERROR card instead of
+    Streamlit's default red traceback wall."""
+    try:
+        return _run_message_flow(my_question)
+    except BaseException as e:
+        # Re-raise Streamlit's own control-flow exceptions (RerunException,
+        # StopException) so the script runner can act on them. Identifying
+        # them by class name keeps us version-independent across Streamlit
+        # internals.
+        if type(e).__name__ in ("RerunException", "StopException"):
+            raise
+        if not isinstance(e, Exception):
+            raise
+        logger.exception("Unexpected error in chat flow")
+        try:
+            add_message(
+                Message(
+                    RoleType.ASSISTANT,
+                    f"Something went wrong while processing your question.\n\n{e}",
+                    MessageType.ERROR,
+                    "",
+                    my_question,
+                    None,
+                    None,
+                    group_id=get_current_group_id(),
+                )
+            )
+        except Exception:
+            logger.exception("Failed to persist friendly error message")
+        try:
+            st.session_state["my_question"] = None
+        except Exception:
+            pass
+
+
+def _run_message_flow(my_question: str):
     # Live source of truth for the toggle is st.session_state.agentic_mode —
     # see views/chat_bot.py where the sidebar checkbox writes to it. The
     # User ORM object is the persistence layer; reading user.agentic_mode
@@ -1574,15 +1675,35 @@ def normal_message_flow(my_question: str):
         # Trigger a rerun to properly refresh the UI
         st.rerun()
     elif final_sql:
-        # SQL was generated but execution/validation failed after all retries
+        # SQL was generated but execution/validation failed after all retries.
+        # We surface the failure as a persisted ERROR message that renders via
+        # _render_error as a friendly collapsible card with an in-card Retry
+        # button. No st.stop() — the user can also just type a new question.
         error_msg = last_error_msg or st.session_state.get("last_run_sql_error")
         failed_sql = last_failed_sql or st.session_state.get("last_failed_sql")
 
-        # Add error message to messages for test verification and history
+        # Set the active-error session keys BEFORE adding the message so that
+        # _render_error sees pending_sql_error=True during the immediate render.
+        # We populate both the canonical (last_*) and retry-context (retry_*)
+        # keys so the in-card Retry button can pick them up later.
+        st.session_state["pending_sql_error"] = True
+        st.session_state["pending_question"] = my_question
+        st.session_state["last_run_sql_error"] = error_msg
+        st.session_state["last_failed_sql"] = failed_sql
+        st.session_state["retry_error_msg"] = error_msg
+        st.session_state["retry_failed_sql"] = failed_sql
+
+        if attempt > 1:
+            display_msg = f"I couldn't execute the SQL after {attempt - 1} automatic retries."
+        else:
+            display_msg = "I couldn't execute the generated SQL."
+        if error_msg:
+            display_msg = f"{display_msg}\n\n{error_msg}"
+
         add_message(
             Message(
                 RoleType.ASSISTANT,
-                f"SQL failed: {error_msg}" if error_msg else "SQL failed after retries",
+                display_msg,
                 MessageType.ERROR,
                 failed_sql,
                 my_question,
@@ -1607,46 +1728,6 @@ def normal_message_flow(my_question: str):
                         group_id=get_current_group_id(),
                     )
                 )
-
-        # Store context in session state for use after page rerun
-        st.session_state["pending_sql_error"] = True
-        st.session_state["pending_question"] = my_question
-        st.session_state["retry_failed_sql"] = failed_sql
-        st.session_state["retry_error_msg"] = error_msg
-
-        def handle_inline_retry_click():
-            """Callback to handle inline retry button click - sets up retry context."""
-            user_feedback = st.session_state.get("retry_feedback_inline", "")
-            st.session_state["use_retry_context"] = True
-            st.session_state["retry_user_feedback"] = user_feedback if user_feedback else None
-            st.session_state["my_question"] = st.session_state.get("pending_question")
-            st.session_state["pending_sql_error"] = False
-
-        with st.chat_message(RoleType.ASSISTANT.value):
-            # Use warning with collapsible details for less intrusive error display
-            if attempt > 1:
-                st.warning(f"I couldn't execute the SQL after {attempt - 1} automatic retries.")
-            else:
-                st.warning("I couldn't execute the generated SQL.")
-            # Collapsible error details section
-            with st.expander("View error details", expanded=False):
-                if error_msg:
-                    st.markdown(f"**Database error:** {error_msg}")
-                if failed_sql:
-                    st.markdown("**Failed SQL:**")
-                    st.code(failed_sql, language="sql", line_numbers=True)
-            # Feedback input for user hints
-            st.text_input(
-                "Optional feedback to help improve the query",
-                key="retry_feedback_inline",
-                placeholder="e.g., 'try using patient_id instead of id' or 'use a LEFT JOIN'",
-            )
-            # Action button with on_click callback - more reliable than checking return value
-            cols = st.columns([0.2, 0.8])
-            with cols[0]:
-                st.button("Retry", type="primary", key="retry_inline", on_click=handle_inline_retry_click)
-
-        st.stop()
     else:
         # Show the LLM's actual response if it gave one, otherwise use generic message
         llm_response = st.session_state.pop("last_llm_non_sql_response", None)

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -40,6 +40,20 @@ def _get_user_id_from_session() -> int | None:
     return None
 
 
+def _stash_optional_step_error(key: str, e: Exception) -> None:
+    """Stash an error string on the session for chart/summary/followup callers to surface.
+
+    These optional-step methods deliberately swallow exceptions and return a
+    fallback value so the chat flow keeps moving. The caller in
+    ``utils.chat_bot_helper`` reads this session-state key after invoking the
+    step and emits a friendly MessageType.ERROR card when set, then clears it.
+    """
+    try:
+        st.session_state[key] = str(e)
+    except Exception:
+        pass
+
+
 @dataclass
 class UserContext:
     """User context containing authentication and authorization information."""
@@ -1138,6 +1152,7 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Chart generation check elapsed time is %s", elapsed_time)
         except Exception as e:
+            _stash_optional_step_error("last_chart_error", e)
             logger.exception("%s", e)
             return False
         else:
@@ -1155,6 +1170,7 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Plotly code generation elapsed time is %s", elapsed_time)
         except Exception as e:
+            _stash_optional_step_error("last_chart_error", e)
             logger.exception("%s", e)
             # Log chart generation error
             try:
@@ -1181,6 +1197,7 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Plotly figure generation elapsed time is %s", elapsed_time)
         except Exception as e:
+            _stash_optional_step_error("last_chart_error", e)
             logger.exception("%s", e)
             # Log chart generation error
             try:
@@ -1203,6 +1220,7 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Followup questions generation elapsed time is %s", elapsed_time)
         except Exception as e:
+            _stash_optional_step_error("last_followup_error", e)
             logger.exception("%s", e)
             return []
         else:
@@ -1218,6 +1236,7 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Summary generation elapsed time is %s", elapsed_time)
         except Exception as e:
+            _stash_optional_step_error("last_summary_error", e)
             logger.exception("%s", e)
             return None, 0
         else:

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -981,7 +981,6 @@ class VannaService:
             except Exception as log_err:
                 logger.warning("Failed to log LLM context: %s", log_err)
         except Exception as e:
-            st.error(f"Error generating SQL: {e}")
             logger.exception("%s", e)
             # Log error to database
             try:
@@ -1049,7 +1048,6 @@ class VannaService:
 
             return _self.generate_sql(augmented_question)
         except Exception as e:
-            st.error(f"Error regenerating SQL: {e}")
             logger.exception("%s", e)
             return None, 0
 
@@ -1063,7 +1061,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("SQL validation elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error checking SQL validity: {e}")
             logger.exception("%s", e)
             return False
         else:
@@ -1104,13 +1101,15 @@ class VannaService:
             except Exception:
                 pass
         except Exception as e:
-            # Persist error context for downstream UI/logic (e.g., retry flow)
+            # Persist error context for downstream UI/logic (e.g., retry flow).
+            # We deliberately do NOT render st.error here — the failure surfaces
+            # to the user via the friendly MessageType.ERROR card emitted by
+            # normal_message_flow once all retries are exhausted.
             try:
                 st.session_state["last_run_sql_error"] = str(e)
                 st.session_state["last_failed_sql"] = sql
             except Exception:
                 pass
-            st.error(f"Error running SQL: {e}")
             logger.exception("%s", e)
             # Log SQL execution error to database
             try:
@@ -1139,7 +1138,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Chart generation check elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error checking if we should generate a chart: {e}")
             logger.exception("%s", e)
             return False
         else:
@@ -1157,7 +1155,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Plotly code generation elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error generating Plotly code: {e}")
             logger.exception("%s", e)
             # Log chart generation error
             try:
@@ -1184,7 +1181,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Plotly figure generation elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error generating plot: {e}")
             logger.exception("%s", e)
             # Log chart generation error
             try:
@@ -1207,7 +1203,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Followup questions generation elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error generating followup questions: {e}")
             logger.exception("%s", e)
             return []
         else:
@@ -1223,7 +1218,6 @@ class VannaService:
             elapsed_time = end_time - start_time
             logger.info("Summary generation elapsed time is %s", elapsed_time)
         except Exception as e:
-            st.error(f"Error generating summary: {e}")
             logger.exception("%s", e)
             return None, 0
         else:

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -1445,6 +1445,7 @@ class VannaService:
                             yield summary_result
                     except Exception as e:
                         logger.warning(f"Failed to generate summary for streaming fallback: {e}")
+                        _stash_optional_step_error("last_summary_error", e)
                         # Return empty string to avoid breaking the UI
                         yield ""
             finally:
@@ -1505,6 +1506,7 @@ class VannaService:
                         elapsed = time.perf_counter() - start
                 except Exception as e:
                     logger.warning("Failed to generate non-streaming summary: %s", e)
+                    _stash_optional_step_error("last_summary_error", e)
                     summary_text = ""
                     elapsed = 0
                 # Persist final content to session_state for downstream helpers/cache
@@ -3932,7 +3934,9 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
             prompt_parts = [f"Database Schema (DDL):\n{ddl_context}"]
 
             if example_pairs_text:
-                prompt_parts.append(f"Working Example Question/SQL Pairs (use these as reference for table names, JOINs, and filters):\n{example_pairs_text}")
+                prompt_parts.append(
+                    f"Working Example Question/SQL Pairs (use these as reference for table names, JOINs, and filters):\n{example_pairs_text}"
+                )
 
             if doc_context:
                 prompt_parts.append(f"Documentation:\n{doc_context}")
@@ -3974,7 +3978,9 @@ def auto_generate_sql_pairs(count: int = 5) -> dict:
             # Also check via VannaService.check_references
             checked_sql = vanna_service.check_references(sql)
             if checked_sql is None:
-                _reject_pair(pair_detail, results, "Forbidden reference or configuration error detected by check_references")
+                _reject_pair(
+                    pair_detail, results, "Forbidden reference or configuration error detected by check_references"
+                )
                 continue
 
             # Step 3: Execute SQL against database
@@ -4041,7 +4047,9 @@ def _parse_question_sql_response(response_text: str) -> tuple[str | None, str | 
     sql = None
 
     # Try structured QUESTION:/SQL: format (tolerates markdown bold in various positions)
-    q_match = re.search(r"\*{0,2}QUESTION\*{0,2}:\s*(.+?)(?=\n\*{0,2}SQL\*{0,2}:)", response_text, re.DOTALL | re.IGNORECASE)
+    q_match = re.search(
+        r"\*{0,2}QUESTION\*{0,2}:\s*(.+?)(?=\n\*{0,2}SQL\*{0,2}:)", response_text, re.DOTALL | re.IGNORECASE
+    )
     s_match = re.search(r"(?:^|\n)\*{0,2}SQL\*{0,2}:\s*(.+)", response_text, re.DOTALL | re.IGNORECASE)
 
     if q_match and s_match:

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -16,6 +16,7 @@ from utils.chat_bot_helper import (
     get_vn,
     group_messages_by_id,
     normal_message_flow,
+    render_friendly_error,
     render_message_group,
     set_question,
 )
@@ -37,14 +38,14 @@ def load_community_questions(csv_file):
 
         # Validate the CSV has a 'question' column
         if "question" not in df.columns:
-            st.error("CSV must have a 'question' column")
+            render_friendly_error("CSV must have a 'question' column")
             return
 
         # Get the list of questions
         questions = df["question"].dropna().tolist()
 
         if not questions:
-            st.error("No questions found in CSV")
+            render_friendly_error("No questions found in CSV")
             return
 
         # Store questions in session state
@@ -52,7 +53,7 @@ def load_community_questions(csv_file):
         st.success(f"✅ Loaded {len(questions)} community questions")
 
     except Exception as e:
-        st.error(f"Error loading CSV: {str(e)}")
+        render_friendly_error(f"Error loading CSV: {str(e)}")
 
 
 from utils.quick_logger import get_logger
@@ -522,44 +523,9 @@ if chat_input:
 # Get question from session state
 my_question = st.session_state.get("my_question", None)
 
-# If we have a pending SQL error from a prior run, render a persistent retry panel
-# Gate on an actual stored error message to avoid showing stale panels
-if not my_question and st.session_state.get("pending_sql_error", False) and st.session_state.get("last_run_sql_error"):
-    pending_question = st.session_state.get("pending_question")
-    error_msg = st.session_state.get("last_run_sql_error")
-    failed_sql = st.session_state.get("last_failed_sql")
-
-    def handle_retry_click():
-        """Callback to handle retry button click - sets up retry context."""
-        user_feedback = st.session_state.get("retry_feedback_persist", "")
-        st.session_state["use_retry_context"] = True
-        st.session_state["retry_failed_sql"] = failed_sql
-        st.session_state["retry_error_msg"] = error_msg
-        st.session_state["retry_user_feedback"] = user_feedback if user_feedback else None
-        st.session_state["my_question"] = pending_question
-        st.session_state["pending_sql_error"] = False
-        st.session_state["show_failed_sql_open"] = False
-
-    with st.chat_message(RoleType.ASSISTANT.value):
-        # Use warning with collapsible details for less intrusive error display
-        st.warning("I couldn't execute the generated SQL.")
-        # Collapsible error details section
-        with st.expander("View error details", expanded=False):
-            if error_msg:
-                st.markdown(f"**Database error:** {error_msg}")
-            if failed_sql:
-                st.markdown("**Failed SQL:**")
-                st.code(failed_sql, language="sql", line_numbers=True)
-        # Feedback input for user hints
-        st.text_input(
-            "Optional feedback to help improve the query",
-            key="retry_feedback_persist",
-            placeholder="e.g., 'try using patient_id instead of id' or 'use a LEFT JOIN'",
-        )
-        # Action button with on_click callback - more reliable than checking return value
-        st.button("Retry", type="primary", key="retry_persist", on_click=handle_retry_click)
-
-    st.stop()
+# Note: pending SQL errors render in-line as MessageType.ERROR via _render_error,
+# which embeds the Retry button when the message matches the active failed SQL.
+# No persistent panel / st.stop() needed — users can also just type a new question.
 
 if my_question:
     if st.session_state.get("agentic_mode", False):


### PR DESCRIPTION
## Summary

- Replace Streamlit's red "wall of error" with a single collapsible **"Well this is awkward, we seem to have run into an error"** card across every chat-screen error path. The raw exception is one click away inside the expander instead of dominating the page.
- Stop blocking the app after a SQL failure. The previous `st.stop()` calls (`utils/chat_bot_helper.py` post-retry and `views/chat_bot.py` persistent panel) froze the script and made new questions feel like nothing was happening. Both are gone — users can click Retry **or** just type a new question.
- Wrap `normal_message_flow` in a top-level safety net so any surprise exception (chart code, agent, slash commands) becomes a friendly ERROR message rather than Streamlit's default traceback. Streamlit's own `RerunException` / `StopException` still propagate.

## What changed under the hood

- New centralized `render_friendly_error(...)` helper + shared `handle_sql_retry_click()` callback in `utils/chat_bot_helper.py`. Three callers (in-history `_render_error`, the failure branch of `normal_message_flow`, the CSV upload path) all funnel through it.
- `_render_error` now embeds the Retry button only when the message is the *active* SQL error (`message.query == st.session_state.last_failed_sql` and `pending_sql_error` is true). Historical ERROR messages get the friendly card without the misleading Retry button.
- Direct `st.error` calls removed from chat-flow paths in `utils/vanna_calls.py` (SQL run, chart, summary, followup, etc.). Each caller already had fallback logic; we just stop drawing red walls. CSV-upload paths in `views/chat_bot.py` now use the friendly helper too.

## Test plan

- [x] `uv run pytest tests/utils/test_friendly_errors.py -vs` — 11 new tests for collapsible rendering, retry-button gating (active vs stale), no-`st.stop` on SQL failure, top-level safety net catches surprise exceptions, Streamlit control-flow exceptions still propagate.
- [x] `uv run pytest -m "not milvus" --ignore=tests/sample_db/test_schema_matches_redshift.py --deselect tests/utils/test_ollama_thinking_stream.py` — **1041 passed, 3 skipped**. Two excluded items are environment-dependent (missing Redshift catalog JSON / no Ollama model loaded) and unrelated to this change.
- [x] `uv run ruff check` / `ruff format --check` on changed files — no new lint or format regressions over `main`.
- [ ] Manual smoke (recommended before merge): run a query that fails (`select * from nonexistent`), confirm the friendly card, click Retry, verify the LLM gets the error context. Then with the card on screen, type a brand-new question and confirm it processes without needing to dismiss the error first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)