### PR TITLE
feat(logging): durable JSONL fallback for log_error when DB writes fail

### DIFF
--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -23,6 +23,7 @@ from orm.models import (
     SessionLocal,
     UserActivity,
 )
+from utils.error_fallback_sink import write_fallback_record
 from utils.quick_logger import get_logger
 
 logger = get_logger(__name__)
@@ -445,6 +446,30 @@ def log_error(
             session.refresh(error)
             return error
     except Exception as e:
+        try:
+            write_fallback_record(
+                {
+                    "created_at": datetime.now().isoformat(),
+                    "category": category.value,
+                    "severity": severity.value,
+                    "error_type": error_type,
+                    "error_message": error_message[:2000] if error_message else None,
+                    "stack_trace": traceback.format_exc() if include_traceback else None,
+                    "question": question[:1000] if question else None,
+                    "generated_sql": generated_sql,
+                    "llm_provider": llm_provider,
+                    "llm_model": llm_model,
+                    "context_data": json.dumps(context_data) if context_data else None,
+                    "user_id": user_id,
+                    "message_id": message_id,
+                    "group_id": group_id,
+                    "auto_retry_attempted": auto_retry_attempted,
+                    "retry_successful": retry_successful,
+                    "retry_count": retry_count,
+                }
+            )
+        except Exception:
+            pass  # write_fallback_record is already defensive; belt-and-braces
         logger.warning("Failed to log error: %s", e)
         return None
 

--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -421,6 +421,7 @@ def log_error(
     Returns:
         The created ErrorLog record, or None if logging failed
     """
+    captured_traceback = traceback.format_exc() if include_traceback else None
     try:
         with SessionLocal() as session:
             error = ErrorLog(
@@ -431,7 +432,7 @@ def log_error(
                 severity=severity.value,
                 error_type=error_type,
                 error_message=error_message[:2000] if error_message else None,
-                stack_trace=traceback.format_exc() if include_traceback else None,
+                stack_trace=captured_traceback,
                 question=question[:1000] if question else None,
                 generated_sql=generated_sql,
                 llm_provider=llm_provider,
@@ -454,7 +455,7 @@ def log_error(
                     "severity": severity.value,
                     "error_type": error_type,
                     "error_message": error_message[:2000] if error_message else None,
-                    "stack_trace": traceback.format_exc() if include_traceback else None,
+                    "stack_trace": captured_traceback,
                     "question": question[:1000] if question else None,
                     "generated_sql": generated_sql,
                     "llm_provider": llm_provider,

--- a/tests/utils/test_error_fallback_sink.py
+++ b/tests/utils/test_error_fallback_sink.py
@@ -1,0 +1,659 @@
+"""Tests for utils.error_fallback_sink (Phase 1: config + write_fallback_record)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.handlers as logging_handlers
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import Base, ErrorCategory, ErrorLog, ErrorSeverity
+from utils.error_fallback_sink import (
+    ErrorLoggingConfig,
+    _reset_handler_cache,
+    read_fallback_records,
+    try_drain_fallback_to_db,
+    write_fallback_record,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    _reset_handler_cache()
+    yield
+    _reset_handler_cache()
+
+
+def _make_config(tmp_path: Path, **overrides) -> ErrorLoggingConfig:
+    return ErrorLoggingConfig(
+        fallback_path=tmp_path / "error_fallback.jsonl",
+        fallback_max_bytes=overrides.get("fallback_max_bytes", 5_000_000),
+        fallback_backup_count=overrides.get("fallback_backup_count", 5),
+    )
+
+
+# ── ErrorLoggingConfig ────────────────────────────────────────────────────
+
+
+class TestErrorLoggingConfig:
+    def test_defaults(self):
+        cfg = ErrorLoggingConfig()
+        assert cfg.fallback_path.name == "error_fallback.jsonl"
+        assert cfg.fallback_path.parent.name == "logs"
+        assert cfg.fallback_max_bytes == 5_000_000
+        assert cfg.fallback_backup_count == 5
+
+    def test_from_secrets_full_overrides(self, tmp_path):
+        section = {
+            "fallback_path": str(tmp_path / "custom.jsonl"),
+            "fallback_max_bytes": 1024,
+            "fallback_backup_count": 2,
+        }
+        cfg = ErrorLoggingConfig.from_secrets(section)
+        assert cfg.fallback_path == tmp_path / "custom.jsonl"
+        assert cfg.fallback_max_bytes == 1024
+        assert cfg.fallback_backup_count == 2
+
+    def test_from_secrets_partial_uses_defaults(self):
+        defaults = ErrorLoggingConfig()
+        cfg = ErrorLoggingConfig.from_secrets({"fallback_max_bytes": 999})
+        assert cfg.fallback_max_bytes == 999
+        assert cfg.fallback_path == defaults.fallback_path
+        assert cfg.fallback_backup_count == defaults.fallback_backup_count
+
+    def test_from_secrets_none_returns_defaults(self):
+        cfg = ErrorLoggingConfig.from_secrets(None)
+        assert cfg == ErrorLoggingConfig()
+
+    def test_from_secrets_empty_dict_returns_defaults(self):
+        cfg = ErrorLoggingConfig.from_secrets({})
+        assert cfg == ErrorLoggingConfig()
+
+    def test_from_secrets_invalid_int_coerces_to_default(self):
+        defaults = ErrorLoggingConfig()
+        cfg = ErrorLoggingConfig.from_secrets({"fallback_max_bytes": "not-a-number", "fallback_backup_count": None})
+        assert cfg.fallback_max_bytes == defaults.fallback_max_bytes
+        assert cfg.fallback_backup_count == defaults.fallback_backup_count
+
+    def test_from_streamlit_missing_section_returns_defaults(self):
+        with patch(
+            "utils.error_fallback_sink._get_streamlit_section",
+            return_value=None,
+        ):
+            cfg = ErrorLoggingConfig.from_streamlit()
+        assert cfg == ErrorLoggingConfig()
+
+    def test_from_streamlit_empty_section_returns_defaults(self):
+        with patch(
+            "utils.error_fallback_sink._get_streamlit_section",
+            return_value={},
+        ):
+            cfg = ErrorLoggingConfig.from_streamlit()
+        assert cfg == ErrorLoggingConfig()
+
+    def test_from_streamlit_handles_import_failure(self):
+        with patch(
+            "utils.error_fallback_sink._get_streamlit_section",
+            side_effect=RuntimeError("streamlit not available"),
+        ):
+            cfg = ErrorLoggingConfig.from_streamlit()
+        assert cfg == ErrorLoggingConfig()
+
+
+# ── write_fallback_record ─────────────────────────────────────────────────
+
+
+class TestWriteFallbackRecord:
+    def test_appends_one_line_json(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        write_fallback_record({"a": 1, "b": "x"}, config=cfg)
+        contents = cfg.fallback_path.read_text(encoding="utf-8")
+        lines = [line for line in contents.splitlines() if line]
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == {"a": 1, "b": "x"}
+
+    def test_appends_multiple_lines_in_order(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        for i in range(3):
+            write_fallback_record({"i": i}, config=cfg)
+        contents = cfg.fallback_path.read_text(encoding="utf-8")
+        lines = [line for line in contents.splitlines() if line]
+        assert [json.loads(line)["i"] for line in lines] == [0, 1, 2]
+
+    def test_creates_parent_directory(self, tmp_path):
+        nested = tmp_path / "deep" / "nested" / "logs" / "fallback.jsonl"
+        cfg = ErrorLoggingConfig(
+            fallback_path=nested,
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+        write_fallback_record({"k": "v"}, config=cfg)
+        assert nested.exists()
+        assert json.loads(nested.read_text(encoding="utf-8").strip()) == {"k": "v"}
+
+    def test_handles_datetime_via_default_str(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        when = datetime(2026, 6, 5, 12, 34, 56)
+        write_fallback_record({"created_at": when}, config=cfg)
+        line = cfg.fallback_path.read_text(encoding="utf-8").strip()
+        payload = json.loads(line)
+        assert payload["created_at"] == str(when)
+
+    def test_defensive_on_serialize_failure(self, tmp_path):
+        cfg = _make_config(tmp_path)
+
+        class Boom:
+            def __str__(self):
+                raise RuntimeError("boom")
+
+            def __repr__(self):
+                raise RuntimeError("boom-repr")
+
+        # Must not raise.
+        write_fallback_record({"x": Boom()}, config=cfg)
+        # File may or may not exist; the contract is "does not raise".
+
+    def test_defensive_on_handler_failure(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        write_fallback_record({"a": 1}, config=cfg)
+
+        original_emit = logging_handlers.RotatingFileHandler.emit
+
+        def boom_emit(self, record):
+            raise OSError("disk full")
+
+        # Silence stdlib's stderr traceback during the failing-emit window.
+        monkeypatch.setattr(logging.Handler, "handleError", lambda self, record: None)
+        monkeypatch.setattr(logging_handlers.RotatingFileHandler, "emit", boom_emit)
+        write_fallback_record({"b": 2}, config=cfg)
+
+        # Restore emit and confirm subsequent writes still work.
+        monkeypatch.setattr(logging_handlers.RotatingFileHandler, "emit", original_emit)
+        write_fallback_record({"c": 3}, config=cfg)
+
+        contents = cfg.fallback_path.read_text(encoding="utf-8")
+        lines = [line for line in contents.splitlines() if line]
+        payloads = [json.loads(line) for line in lines]
+        keys_seen = {next(iter(p.keys())) for p in payloads}
+        assert "a" in keys_seen
+        assert "c" in keys_seen
+
+    def test_routes_to_configured_path(self, tmp_path):
+        cfg_a = ErrorLoggingConfig(
+            fallback_path=tmp_path / "a.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+        cfg_b = ErrorLoggingConfig(
+            fallback_path=tmp_path / "b.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+        write_fallback_record({"loc": "a"}, config=cfg_a)
+        write_fallback_record({"loc": "b"}, config=cfg_b)
+        assert json.loads(cfg_a.fallback_path.read_text("utf-8").strip()) == {"loc": "a"}
+        assert json.loads(cfg_b.fallback_path.read_text("utf-8").strip()) == {"loc": "b"}
+
+    def test_uses_streamlit_config_when_none_passed(self, tmp_path):
+        custom = tmp_path / "from_streamlit.jsonl"
+        custom_cfg = ErrorLoggingConfig(
+            fallback_path=custom,
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+        with patch(
+            "utils.error_fallback_sink.ErrorLoggingConfig.from_streamlit",
+            return_value=custom_cfg,
+        ):
+            write_fallback_record({"src": "streamlit"})
+        assert json.loads(custom.read_text("utf-8").strip()) == {"src": "streamlit"}
+
+
+# ── read_fallback_records ─────────────────────────────────────────────────
+
+
+class TestReadFallbackRecords:
+    def _write(self, cfg: ErrorLoggingConfig, i: int, seconds: int) -> dict:
+        payload = {
+            "created_at": f"2026-06-05T12:00:{seconds:02d}",
+            "i": i,
+            "category": "sql_execution",
+            "severity": "error",
+            "error_type": "RuntimeError",
+            "error_message": f"boom-{i}",
+        }
+        write_fallback_record(payload, config=cfg)
+        return payload
+
+    def test_read_empty_when_no_file(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        records = read_fallback_records(since=datetime(2026, 1, 1), config=cfg)
+        assert records == []
+
+    def test_read_round_trips_written_records(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        expected = [self._write(cfg, i, i) for i in range(3)]
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert records == expected
+
+    def test_read_filters_by_since(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        for i in range(5):
+            self._write(cfg, i, i)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 3), config=cfg)
+        assert [r["i"] for r in records] == [3, 4]
+
+    def test_read_filters_by_until(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        for i in range(5):
+            self._write(cfg, i, i)
+        records = read_fallback_records(
+            since=datetime(2026, 6, 5, 12, 0, 0),
+            until=datetime(2026, 6, 5, 12, 0, 2),
+            config=cfg,
+        )
+        assert [r["i"] for r in records] == [0, 1, 2]
+
+    def test_read_respects_limit(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        for i in range(5):
+            self._write(cfg, i, i)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), limit=2, config=cfg)
+        assert [r["i"] for r in records] == [0, 1]
+
+    def test_read_returns_chronological_order(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        # Write out of order
+        self._write(cfg, 2, 20)
+        self._write(cfg, 0, 0)
+        self._write(cfg, 1, 10)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert [r["i"] for r in records] == [0, 1, 2]
+
+    def test_read_includes_rotated_backups(self, tmp_path):
+        cfg = ErrorLoggingConfig(
+            fallback_path=tmp_path / "rot.jsonl",
+            fallback_max_bytes=80,  # forces rotation after each ~42-byte record
+            fallback_backup_count=5,
+        )
+        for i in range(4):
+            self._write(cfg, i, i)
+        # Confirm rotation actually happened
+        rotated = [p.name for p in tmp_path.iterdir() if p.name.startswith("rot.jsonl")]
+        assert any(name.endswith(".1") for name in rotated), f"expected rotation, got files: {rotated}"
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert {r["i"] for r in records} == {0, 1, 2, 3}
+
+    def test_read_skips_malformed_lines(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        self._write(cfg, 1, 1)
+        # Append garbage manually
+        with cfg.fallback_path.open("a", encoding="utf-8") as f:
+            f.write("not-json-at-all\n")
+            f.write("{partial: json\n")
+            f.write('"just-a-string"\n')  # valid JSON but not a dict
+        self._write(cfg, 2, 2)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert [r["i"] for r in records] == [1, 2]
+
+    def test_read_skips_records_without_created_at(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        write_fallback_record({"i": 1}, config=cfg)  # no created_at
+        self._write(cfg, 2, 5)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert [r["i"] for r in records] == [2]
+
+    def test_read_skips_records_with_unparsable_created_at(self, tmp_path):
+        cfg = _make_config(tmp_path)
+        write_fallback_record({"created_at": "not-a-date", "i": 1}, config=cfg)
+        self._write(cfg, 2, 5)
+        records = read_fallback_records(since=datetime(2026, 6, 5, 12, 0, 0), config=cfg)
+        assert [r["i"] for r in records] == [2]
+
+
+# ── try_drain_fallback_to_db ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def fresh_db(monkeypatch):
+    from utils import error_fallback_sink
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+    monkeypatch.setattr(error_fallback_sink, "SessionLocal", Session)
+    return Session
+
+
+class TestTryDrainFallbackToDb:
+    def _write_full(self, cfg: ErrorLoggingConfig, i: int, seconds: int) -> dict:
+        payload = {
+            "created_at": f"2026-06-05T12:00:{seconds:02d}",
+            "category": "sql_execution",
+            "severity": "error",
+            "error_type": "RuntimeError",
+            "error_message": f"boom-{i}",
+        }
+        write_fallback_record(payload, config=cfg)
+        return payload
+
+    def test_drain_moves_records_to_db_and_clears_files(self, tmp_path, fresh_db):
+        cfg = _make_config(tmp_path)
+        for i in range(3):
+            self._write_full(cfg, i, i)
+
+        count = try_drain_fallback_to_db(config=cfg)
+
+        assert count == 3
+        assert not cfg.fallback_path.exists()
+        with fresh_db() as session:
+            rows = session.query(ErrorLog).order_by(ErrorLog.error_message).all()
+            assert len(rows) == 3
+            assert {r.error_message for r in rows} == {"boom-0", "boom-1", "boom-2"}
+            assert all(r.category == "sql_execution" for r in rows)
+            assert all(r.severity == "error" for r in rows)
+
+    def test_drain_returns_zero_when_no_file(self, tmp_path, fresh_db):
+        cfg = _make_config(tmp_path)
+        count = try_drain_fallback_to_db(config=cfg)
+        assert count == 0
+        with fresh_db() as session:
+            assert session.query(ErrorLog).count() == 0
+
+    def test_drain_idempotent_on_existing_keys(self, tmp_path, fresh_db):
+        cfg = _make_config(tmp_path)
+        for i in range(2):
+            self._write_full(cfg, i, i)
+
+        first = try_drain_fallback_to_db(config=cfg)
+        assert first == 2
+
+        # Re-write the same logical records.
+        for i in range(2):
+            self._write_full(cfg, i, i)
+
+        second = try_drain_fallback_to_db(config=cfg)
+        assert second == 0
+        with fresh_db() as session:
+            assert session.query(ErrorLog).count() == 2
+
+    def test_drain_skips_records_missing_required_fields(self, tmp_path, fresh_db):
+        cfg = _make_config(tmp_path)
+        self._write_full(cfg, 0, 0)
+        # Missing error_type and error_message
+        write_fallback_record(
+            {
+                "created_at": "2026-06-05T12:00:05",
+                "category": "general",
+                "severity": "error",
+            },
+            config=cfg,
+        )
+
+        count = try_drain_fallback_to_db(config=cfg)
+        assert count == 1
+        with fresh_db() as session:
+            rows = session.query(ErrorLog).all()
+            assert len(rows) == 1
+            assert rows[0].error_message == "boom-0"
+
+    def test_drain_handles_commit_failure(self, tmp_path, monkeypatch, fresh_db):
+        cfg = _make_config(tmp_path)
+        self._write_full(cfg, 0, 0)
+
+        from utils import error_fallback_sink
+
+        original_factory = error_fallback_sink.SessionLocal
+
+        def broken_factory():
+            session = original_factory()
+
+            def boom():
+                raise RuntimeError("commit failed")
+
+            session.commit = boom
+            return session
+
+        monkeypatch.setattr(error_fallback_sink, "SessionLocal", broken_factory)
+
+        count = try_drain_fallback_to_db(config=cfg)
+        assert count == 0
+        assert cfg.fallback_path.exists()
+
+    def test_drain_does_not_raise_on_unexpected_errors(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._write_full(cfg, 0, 0)
+
+        from utils import error_fallback_sink
+
+        def broken_factory():
+            raise RuntimeError("DB unreachable")
+
+        monkeypatch.setattr(error_fallback_sink, "SessionLocal", broken_factory)
+
+        count = try_drain_fallback_to_db(config=cfg)
+        assert count == 0
+        assert cfg.fallback_path.exists()
+
+    def test_drain_preserves_field_round_trip(self, tmp_path, fresh_db):
+        cfg = _make_config(tmp_path)
+        payload = {
+            "created_at": "2026-06-05T12:00:00",
+            "category": "sql_execution",
+            "severity": "critical",
+            "error_type": "OperationalError",
+            "error_message": "connection refused",
+            "stack_trace": "Traceback (most recent call last):\n  File ...",
+            "question": "How many patients?",
+            "generated_sql": "SELECT COUNT(*) FROM patients",
+            "llm_provider": "anthropic",
+            "llm_model": "claude-3-5-sonnet",
+            "context_data": '{"db_host": "localhost"}',
+            "user_id": 42,
+            "message_id": 100,
+            "group_id": "uuid-abc-123",
+            "auto_retry_attempted": True,
+            "retry_successful": False,
+            "retry_count": 3,
+        }
+        write_fallback_record(payload, config=cfg)
+
+        count = try_drain_fallback_to_db(config=cfg)
+        assert count == 1
+
+        with fresh_db() as session:
+            row = session.query(ErrorLog).first()
+            assert row.category == "sql_execution"
+            assert row.severity == "critical"
+            assert row.error_type == "OperationalError"
+            assert row.error_message == "connection refused"
+            assert row.stack_trace.startswith("Traceback")
+            assert row.question == "How many patients?"
+            assert row.generated_sql == "SELECT COUNT(*) FROM patients"
+            assert row.llm_provider == "anthropic"
+            assert row.llm_model == "claude-3-5-sonnet"
+            assert row.context_data == '{"db_host": "localhost"}'
+            assert row.user_id == 42
+            assert row.message_id == 100
+            assert row.group_id == "uuid-abc-123"
+            assert row.auto_retry_attempted is True
+            assert row.retry_successful is False
+            assert row.retry_count == 3
+            assert row.created_at == datetime(2026, 6, 5, 12, 0, 0)
+
+
+# ── log_error integration ─────────────────────────────────────────────────
+
+
+class TestLogErrorIntegration:
+    """Verify orm.logging_functions.log_error falls back to the JSONL sink
+    when the SQLite write fails, and that the convenience wrappers inherit
+    the same behavior because they delegate to log_error."""
+
+    def _patch_streamlit_config(self, monkeypatch, cfg: ErrorLoggingConfig):
+        monkeypatch.setattr(
+            "utils.error_fallback_sink.ErrorLoggingConfig.from_streamlit",
+            classmethod(lambda _cls: cfg),
+        )
+
+    def _patch_session_factory_to_raise(self, monkeypatch):
+        from orm import logging_functions
+
+        def boom_factory():
+            raise RuntimeError("DB unreachable")
+
+        monkeypatch.setattr(logging_functions, "SessionLocal", boom_factory)
+
+    def test_log_error_falls_back_when_session_raises(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        from orm import logging_functions
+
+        result = logging_functions.log_error(
+            category=ErrorCategory.SQL_EXECUTION,
+            severity=ErrorSeverity.ERROR,
+            error_type="OperationalError",
+            error_message="connection refused",
+            user_id=42,
+            group_id="grp-xyz",
+            include_traceback=False,
+        )
+
+        assert result is None
+        records = read_fallback_records(since=datetime(2000, 1, 1), config=cfg)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["category"] == "sql_execution"
+        assert rec["severity"] == "error"
+        assert rec["error_type"] == "OperationalError"
+        assert rec["error_message"] == "connection refused"
+        assert rec["user_id"] == 42
+        assert rec["group_id"] == "grp-xyz"
+        assert "created_at" in rec
+
+    def test_log_sql_generation_error_inherits_fallback(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        from orm import logging_functions
+
+        result = logging_functions.log_sql_generation_error(
+            error=ValueError("bad sql"),
+            question="how many patients?",
+            user_id=1,
+            llm_provider="anthropic",
+            llm_model="claude-3-5-sonnet",
+            group_id="grp-abc",
+        )
+
+        assert result is None
+        records = read_fallback_records(since=datetime(2000, 1, 1), config=cfg)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["category"] == "sql_generation"
+        assert rec["error_type"] == "ValueError"
+        assert rec["error_message"] == "bad sql"
+        assert rec["question"] == "how many patients?"
+        assert rec["llm_provider"] == "anthropic"
+        assert rec["group_id"] == "grp-abc"
+
+    def test_log_sql_execution_error_inherits_fallback(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        from orm import logging_functions
+
+        result = logging_functions.log_sql_execution_error(
+            error=RuntimeError("syntax error near WHERE"),
+            sql="SELECT bad FROM nope",
+            question="bad query",
+            user_id=1,
+        )
+
+        assert result is None
+        records = read_fallback_records(since=datetime(2000, 1, 1), config=cfg)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["category"] == "sql_execution"
+        assert rec["error_type"] == "RuntimeError"
+        assert rec["generated_sql"] == "SELECT bad FROM nope"
+
+    def test_log_chart_generation_error_inherits_fallback(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        from orm import logging_functions
+
+        result = logging_functions.log_chart_generation_error(
+            error=TypeError("not a dataframe"),
+            user_id=1,
+            question="show chart",
+        )
+
+        assert result is None
+        records = read_fallback_records(since=datetime(2000, 1, 1), config=cfg)
+        assert len(records) == 1
+        assert records[0]["category"] == "chart_generation"
+        assert records[0]["error_type"] == "TypeError"
+
+    def test_log_error_does_not_raise_when_both_db_and_fallback_fail(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        # Make write_fallback_record itself raise (it normally swallows; we
+        # force a raise to verify log_error's own outer guard).
+        def boom_write(*args, **kwargs):
+            raise RuntimeError("fallback also broken")
+
+        monkeypatch.setattr(
+            "orm.logging_functions.write_fallback_record",
+            boom_write,
+        )
+
+        from orm import logging_functions
+
+        result = logging_functions.log_error(
+            category=ErrorCategory.GENERAL,
+            severity=ErrorSeverity.ERROR,
+            error_type="X",
+            error_message="y",
+            include_traceback=False,
+        )
+        assert result is None
+
+    def test_log_error_does_not_write_fallback_on_db_success(self, tmp_path, monkeypatch, fresh_db):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+
+        # Also point orm.logging_functions.SessionLocal at the same in-memory engine
+        # so the DB write succeeds via the fresh_db fixture's session.
+        from orm import logging_functions
+        from utils import error_fallback_sink
+
+        monkeypatch.setattr(logging_functions, "SessionLocal", error_fallback_sink.SessionLocal)
+
+        result = logging_functions.log_error(
+            category=ErrorCategory.SQL_EXECUTION,
+            severity=ErrorSeverity.ERROR,
+            error_type="OK",
+            error_message="happy path",
+            include_traceback=False,
+        )
+
+        assert result is not None
+        assert result.error_message == "happy path"
+        # Fallback file must not have been touched.
+        assert not cfg.fallback_path.exists()

--- a/tests/utils/test_error_fallback_sink.py
+++ b/tests/utils/test_error_fallback_sink.py
@@ -657,3 +657,28 @@ class TestLogErrorIntegration:
         assert result.error_message == "happy path"
         # Fallback file must not have been touched.
         assert not cfg.fallback_path.exists()
+
+    def test_log_error_fallback_preserves_caller_traceback(self, tmp_path, monkeypatch):
+        cfg = _make_config(tmp_path)
+        self._patch_streamlit_config(monkeypatch, cfg)
+        self._patch_session_factory_to_raise(monkeypatch)
+
+        from orm import logging_functions
+
+        try:
+            raise ValueError("caller-original-error")
+        except ValueError:
+            result = logging_functions.log_error(
+                category=ErrorCategory.GENERAL,
+                severity=ErrorSeverity.ERROR,
+                error_type="ValueError",
+                error_message="caller-original-error",
+                include_traceback=True,
+            )
+
+        assert result is None
+        records = read_fallback_records(since=datetime(2000, 1, 1), config=cfg)
+        assert len(records) == 1
+        stack_trace = records[0].get("stack_trace")
+        assert stack_trace is not None
+        assert "caller-original-error" in stack_trace

--- a/utils/error_fallback_sink.py
+++ b/utils/error_fallback_sink.py
@@ -1,0 +1,334 @@
+"""Durable fallback sink for error records.
+
+When :func:`orm.logging_functions.log_error` cannot write to the SQLite-backed
+``thrive_error_log`` table (file locked, disk full, connection unavailable),
+the error record is appended here instead so it is never silently dropped.
+
+The fallback file is a rotating JSONL log — one JSON object per line — that
+mirrors :class:`orm.models.ErrorLog`'s columns. The unified errors read
+model (Feature Spec #93) and the Errors admin page (Feature Spec #94)
+consume this file alongside ``thrive_error_log`` rows.
+
+Fallback record schema
+----------------------
+Each line in the fallback file is a JSON object. ``source`` is set by the
+writer (Feature Spec #93's normalizer); the other fields mirror
+``orm.models.ErrorLog``:
+
+- ``created_at``           ISO-8601 timestamp string
+- ``source``               constant ``"fallback_sink"`` (added by the read model)
+- ``category``             see ``orm.models.ErrorCategory``
+- ``severity``             see ``orm.models.ErrorSeverity``
+- ``error_type``           exception class name
+- ``error_message``        exception message
+- ``stack_trace``          str | null
+- ``question``             str | null
+- ``generated_sql``        str | null
+- ``llm_provider``         str | null
+- ``llm_model``            str | null
+- ``context_data``         JSON string | null
+- ``user_id``              int | null
+- ``message_id``           int | null
+- ``group_id``             str | null  — message-flow correlation UUID
+- ``auto_retry_attempted`` bool | null
+- ``retry_successful``     bool | null
+- ``retry_count``          int | null
+
+Config (``secrets.toml``)
+-------------------------
+    [error_logging]
+    fallback_path = "utils/logs/error_fallback.jsonl"
+    fallback_max_bytes = 5000000
+    fallback_backup_count = 5
+
+Absent section ⇒ defaults ⇒ behavior unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import logging.handlers
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+from sqlalchemy import and_, or_
+
+from orm.models import ErrorLog, SessionLocal
+
+_DEFAULT_LOG_DIR = Path(__file__).with_name("logs")
+_DEFAULT_PATH = _DEFAULT_LOG_DIR / "error_fallback.jsonl"
+_DEFAULT_MAX_BYTES = 5_000_000
+_DEFAULT_BACKUP_COUNT = 5
+
+_INITIALIZED_LOGGER_NAMES: set[str] = set()
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _get_streamlit_section() -> dict | None:
+    """Return the ``[error_logging]`` section from ``st.secrets``.
+
+    Exposed as a module-level helper so tests can patch it. Raises if
+    streamlit is unavailable; ``ErrorLoggingConfig.from_streamlit`` catches
+    that and returns defaults.
+    """
+    import streamlit as st  # local: streamlit may not be importable in unit tests
+
+    return dict(st.secrets.get("error_logging", {}))
+
+
+@dataclass(frozen=True)
+class ErrorLoggingConfig:
+    fallback_path: Path = _DEFAULT_PATH
+    fallback_max_bytes: int = _DEFAULT_MAX_BYTES
+    fallback_backup_count: int = _DEFAULT_BACKUP_COUNT
+
+    @classmethod
+    def from_secrets(cls, section: dict | None) -> "ErrorLoggingConfig":
+        section = dict(section or {})
+        return cls(
+            fallback_path=Path(section.get("fallback_path", _DEFAULT_PATH)),
+            fallback_max_bytes=_coerce_int(
+                section.get("fallback_max_bytes", _DEFAULT_MAX_BYTES),
+                _DEFAULT_MAX_BYTES,
+            ),
+            fallback_backup_count=_coerce_int(
+                section.get("fallback_backup_count", _DEFAULT_BACKUP_COUNT),
+                _DEFAULT_BACKUP_COUNT,
+            ),
+        )
+
+    @classmethod
+    def from_streamlit(cls) -> "ErrorLoggingConfig":
+        try:
+            section = _get_streamlit_section()
+        except Exception:
+            section = None
+        return cls.from_secrets(section)
+
+
+def _get_logger(config: ErrorLoggingConfig) -> logging.Logger:
+    """Lazy-init a dedicated logger writing to the configured rotating file."""
+    name = f"thrive.error_fallback.{config.fallback_path}"
+    logger = logging.getLogger(name)
+    if name not in _INITIALIZED_LOGGER_NAMES:
+        logger.propagate = False
+        logger.setLevel(logging.INFO)
+        config.fallback_path.parent.mkdir(parents=True, exist_ok=True)
+        handler = logging.handlers.RotatingFileHandler(
+            str(config.fallback_path),
+            maxBytes=config.fallback_max_bytes,
+            backupCount=config.fallback_backup_count,
+            encoding="utf-8",
+        )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        logger.addHandler(handler)
+        _INITIALIZED_LOGGER_NAMES.add(name)
+    return logger
+
+
+def _reset_handler_cache() -> None:
+    """Close + remove cached fallback handlers. Test helper; not for app use."""
+    for name in list(_INITIALIZED_LOGGER_NAMES):
+        logger = logging.getLogger(name)
+        for handler in list(logger.handlers):
+            try:
+                handler.close()
+            except Exception:
+                pass
+            logger.removeHandler(handler)
+    _INITIALIZED_LOGGER_NAMES.clear()
+
+
+def write_fallback_record(payload: dict, *, config: ErrorLoggingConfig | None = None) -> None:
+    """Append one JSON record to the rotating fallback file.
+
+    Never raises: any failure (serialization, I/O, missing config) is
+    swallowed so the caller's error-handling path cannot itself be broken
+    by a logging failure.
+    """
+    try:
+        cfg = config or ErrorLoggingConfig.from_streamlit()
+        line = json.dumps(payload, default=str)
+        _get_logger(cfg).info(line)
+    except Exception:
+        pass
+
+
+def _iter_fallback_files(config: ErrorLoggingConfig) -> Iterator[Path]:
+    """Yield the current fallback file followed by each rotated backup that exists."""
+    base = config.fallback_path
+    if base.exists():
+        yield base
+    for i in range(1, config.fallback_backup_count + 1):
+        rotated = base.with_name(f"{base.name}.{i}")
+        if rotated.exists():
+            yield rotated
+
+
+def read_fallback_records(
+    since: datetime,
+    until: datetime | None = None,
+    limit: int | None = None,
+    *,
+    config: ErrorLoggingConfig | None = None,
+) -> list[dict]:
+    """Return fallback records with ``created_at`` ∈ [since, until], sorted ascending.
+
+    Reads the current JSONL file and every rotated backup (``.1``…``.N``).
+    Records that are blank, malformed, not dicts, lack ``created_at``, or
+    have an unparsable ``created_at`` are silently skipped. File-open
+    failures on a single backup are tolerated so a corrupt file cannot
+    abort the read. ``limit`` is applied after sorting.
+    """
+    cfg = config or ErrorLoggingConfig.from_streamlit()
+    records: list[dict] = []
+
+    for path in _iter_fallback_files(cfg):
+        try:
+            with path.open("r", encoding="utf-8") as fp:
+                for line in fp:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except (json.JSONDecodeError, ValueError):
+                        continue
+                    if not isinstance(payload, dict):
+                        continue
+                    created_raw = payload.get("created_at")
+                    if not created_raw:
+                        continue
+                    try:
+                        when = datetime.fromisoformat(str(created_raw))
+                    except (TypeError, ValueError):
+                        continue
+                    if when < since:
+                        continue
+                    if until is not None and when > until:
+                        continue
+                    records.append(payload)
+        except OSError:
+            continue
+
+    records.sort(key=lambda r: str(r.get("created_at", "")))
+    if limit is not None:
+        records = records[:limit]
+    return records
+
+
+_REQUIRED_FOR_DB = ("created_at", "category", "severity", "error_type", "error_message")
+
+
+def _build_error_log_row(payload: dict, when: datetime) -> ErrorLog:
+    return ErrorLog(
+        created_at=when,
+        user_id=payload.get("user_id"),
+        message_id=payload.get("message_id"),
+        group_id=payload.get("group_id"),
+        category=payload["category"],
+        severity=payload["severity"],
+        error_type=payload["error_type"],
+        error_message=payload["error_message"],
+        stack_trace=payload.get("stack_trace"),
+        question=payload.get("question"),
+        generated_sql=payload.get("generated_sql"),
+        llm_provider=payload.get("llm_provider"),
+        llm_model=payload.get("llm_model"),
+        context_data=payload.get("context_data"),
+        auto_retry_attempted=bool(payload.get("auto_retry_attempted") or False),
+        retry_successful=payload.get("retry_successful"),
+        retry_count=int(payload.get("retry_count") or 0),
+    )
+
+
+def try_drain_fallback_to_db(*, config: ErrorLoggingConfig | None = None) -> int:
+    """Move pending fallback records into ``thrive_error_log``.
+
+    Returns the count of rows actually inserted. Idempotent — records whose
+    ``(created_at, error_type, error_message)`` already exists in the table
+    are skipped. Records missing any required NOT NULL field are dropped.
+    On any failure (read, query, insert, commit, file deletion), returns 0
+    and leaves the fallback files in place. Never raises.
+
+    Intended to be invoked manually from the Errors admin UI after the DB
+    has been confirmed reachable again — not called automatically.
+    """
+    try:
+        cfg = config or ErrorLoggingConfig.from_streamlit()
+
+        records = read_fallback_records(since=datetime.min, config=cfg)
+        if not records:
+            return 0
+
+        candidates: list[tuple[dict, datetime]] = []
+        for record in records:
+            if not all(record.get(k) for k in _REQUIRED_FOR_DB):
+                continue
+            try:
+                when = datetime.fromisoformat(str(record["created_at"]))
+            except (TypeError, ValueError):
+                continue
+            candidates.append((record, when))
+
+        if not candidates:
+            return 0
+
+        with SessionLocal() as session:
+            clauses = [
+                and_(
+                    ErrorLog.created_at == when,
+                    ErrorLog.error_type == rec.get("error_type"),
+                    ErrorLog.error_message == rec.get("error_message"),
+                )
+                for rec, when in candidates
+            ]
+            existing_keys: set[tuple] = set(
+                session.query(
+                    ErrorLog.created_at,
+                    ErrorLog.error_type,
+                    ErrorLog.error_message,
+                )
+                .filter(or_(*clauses))
+                .all()
+            )
+
+            new_rows: list[ErrorLog] = []
+            for rec, when in candidates:
+                key = (when, rec["error_type"], rec["error_message"])
+                if key in existing_keys:
+                    continue
+                new_rows.append(_build_error_log_row(rec, when))
+                existing_keys.add(key)  # guard against duplicates within the batch
+
+            if not new_rows:
+                # Nothing new to write, but files contained only dupes — safe to clear.
+                inserted = 0
+            else:
+                session.add_all(new_rows)
+                session.commit()
+                inserted = len(new_rows)
+
+        # Close cached handlers (so file handles release) then delete sources.
+        _reset_handler_cache()
+        base = cfg.fallback_path
+        paths = [base] + [base.with_name(f"{base.name}.{i}") for i in range(1, cfg.fallback_backup_count + 1)]
+        for path in paths:
+            try:
+                if path.exists():
+                    path.unlink()
+            except OSError:
+                pass
+
+        return inserted
+    except Exception:
+        return 0

--- a/utils/error_fallback_sink.py
+++ b/utils/error_fallback_sink.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 import json
 import logging
 import logging.handlers
+import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -64,6 +65,7 @@ _DEFAULT_MAX_BYTES = 5_000_000
 _DEFAULT_BACKUP_COUNT = 5
 
 _INITIALIZED_LOGGER_NAMES: set[str] = set()
+_CACHE_LOCK = threading.Lock()
 
 
 def _coerce_int(value: Any, default: int) -> int:
@@ -119,33 +121,35 @@ def _get_logger(config: ErrorLoggingConfig) -> logging.Logger:
     """Lazy-init a dedicated logger writing to the configured rotating file."""
     name = f"thrive.error_fallback.{config.fallback_path}"
     logger = logging.getLogger(name)
-    if name not in _INITIALIZED_LOGGER_NAMES:
-        logger.propagate = False
-        logger.setLevel(logging.INFO)
-        config.fallback_path.parent.mkdir(parents=True, exist_ok=True)
-        handler = logging.handlers.RotatingFileHandler(
-            str(config.fallback_path),
-            maxBytes=config.fallback_max_bytes,
-            backupCount=config.fallback_backup_count,
-            encoding="utf-8",
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        logger.addHandler(handler)
-        _INITIALIZED_LOGGER_NAMES.add(name)
+    with _CACHE_LOCK:
+        if name not in _INITIALIZED_LOGGER_NAMES:
+            logger.propagate = False
+            logger.setLevel(logging.INFO)
+            config.fallback_path.parent.mkdir(parents=True, exist_ok=True)
+            handler = logging.handlers.RotatingFileHandler(
+                str(config.fallback_path),
+                maxBytes=config.fallback_max_bytes,
+                backupCount=config.fallback_backup_count,
+                encoding="utf-8",
+            )
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            logger.addHandler(handler)
+            _INITIALIZED_LOGGER_NAMES.add(name)
     return logger
 
 
 def _reset_handler_cache() -> None:
     """Close + remove cached fallback handlers. Test helper; not for app use."""
-    for name in list(_INITIALIZED_LOGGER_NAMES):
-        logger = logging.getLogger(name)
-        for handler in list(logger.handlers):
-            try:
-                handler.close()
-            except Exception:
-                pass
-            logger.removeHandler(handler)
-    _INITIALIZED_LOGGER_NAMES.clear()
+    with _CACHE_LOCK:
+        for name in list(_INITIALIZED_LOGGER_NAMES):
+            logger = logging.getLogger(name)
+            for handler in list(logger.handlers):
+                try:
+                    handler.close()
+                except Exception:
+                    pass
+                logger.removeHandler(handler)
+        _INITIALIZED_LOGGER_NAMES.clear()
 
 
 def write_fallback_record(payload: dict, *, config: ErrorLoggingConfig | None = None) -> None:


### PR DESCRIPTION
## Summary

Closes #89. Foundation Feature Spec from Epic #88 (Unified error visibility).

Errors that hit `orm.logging_functions.log_error()` previously vanished when the app SQLite write itself failed — the `except` branch logged a warning and returned `None`, dropping the record. This change adds a rotating-file JSONL fallback sink so the record is preserved on disk and can be replayed into `thrive_error_log` once the DB is reachable again.

## What's added

**New `utils/error_fallback_sink.py`:**
- `write_fallback_record(payload)` — appends one JSON line per record to a rotating file (default `utils/logs/error_fallback.jsonl`). Never raises; missing config / serialization / I/O failures are swallowed so the caller's error path can't be broken by logging.
- `read_fallback_records(since, until=None, limit=None)` — streams current + rotated backups (`.1`, `.2`, …), filters by `created_at`, skips malformed / missing-field lines, returns chronological dicts. Consumed by the upcoming unified errors read model (#93).
- `try_drain_fallback_to_db()` — admin-triggered replay: bulk-inserts pending records into `thrive_error_log`, idempotent dedup on `(created_at, error_type, error_message)`, deletes source files on successful commit. Returns 0 and leaves files in place on any failure.
- `ErrorLoggingConfig` dataclass mirrors `agent/logging_config.py:AgentLoggingConfig`. Reads optional `[error_logging]` secrets section. Absent section ⇒ defaults ⇒ behavior unchanged.

**Modified `orm/logging_functions.py:log_error()`:**
- Inside the existing `except Exception` branch, calls `write_fallback_record(payload)` before the existing `logger.warning(...) ; return None`. Pure addition — success path, signature, and return type unchanged.
- Convenience wrappers (`log_sql_generation_error`, `log_sql_execution_error`, `log_chart_generation_error`) inherit the behavior for free because they delegate to `log_error`.

## Config (all optional)

```toml
[error_logging]
fallback_path = "utils/logs/error_fallback.jsonl"
fallback_max_bytes = 5000000
fallback_backup_count = 5
```

## Test plan

- [x] 40 new unit tests in `tests/utils/test_error_fallback_sink.py`:
  - `TestErrorLoggingConfig` (9): defaults, `from_secrets` overrides / partial / None / empty / invalid coercion, `from_streamlit` missing / empty / import failure.
  - `TestWriteFallbackRecord` (8): single-line JSON, ordering, parent-dir creation, `datetime` via `default=str`, defensive serialize / handler failure, per-config path routing, streamlit-config fallback.
  - `TestReadFallbackRecords` (10): empty / round-trip / since / until / limit / chronological / rotated backups / malformed lines / missing or unparsable `created_at`.
  - `TestTryDrainFallbackToDb` (7): moves + clears, no-file → 0, idempotent dedup, missing required fields skipped, commit failure preserves files, unexpected error → 0, full-field round-trip.
  - `TestLogErrorIntegration` (6): `log_error` falls back when SessionLocal raises, three convenience wrappers inherit, both-fail still returns None, success path doesn't touch fallback.
- [x] Full suite `uv run pytest -m "not milvus"` — 1089 passed; 18 pre-existing environmental failures unchanged (missing redshift catalog JSON; Ollama not running locally). No regressions.
- [x] `uv run ruff check` + `uv run ruff format` clean.
- [ ] Manual smoke: trigger a real DB lock on a running app, force an error, verify `utils/logs/error_fallback.jsonl` receives the record.

## What's intentionally NOT in this PR

- The unified errors read model that joins `thrive_error_log` + `thrive_agent_run` failures + this file (Feature Spec #93).
- The admin-only Errors page UI with filterable JSON export (Feature Spec #94).
- A `.gitignore` rule for `utils/logs/*.jsonl*` — left out to avoid bundling with an unrelated pre-existing local change; will land as a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)