### PR TITLE
feat(errors): admin Errors page with filters, drill-down, JSON export, and fallback drain

### DIFF
--- a/app.py
+++ b/app.py
@@ -92,9 +92,15 @@ if st.session_state.get("user_role") == 0:  # RoleTypeEnum.ADMIN.value = 0
         title="Agentic Analytics",
         icon="🧠",
     )
+    errors_page = st.Page(
+        page="views/errors.py",
+        title="Errors",
+        icon="⚠️",
+    )
     pages.append(analytics_page)
     pages.append(feedback_page)
     pages.append(agent_analytics_page)
+    pages.append(errors_page)
 
 pg = st.navigation(pages=pages)
 

--- a/tests/views/test_errors.py
+++ b/tests/views/test_errors.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from orm.error_read_model import DEFAULT_SOURCES, ErrorRow, ErrorSource
 from views.errors_helpers import (
+    MAX_ROW_LIMIT,
     _csv_to_set,
     _export_filename,
     _format_results_table,
@@ -422,3 +423,51 @@ class TestQueryFilteredSmoke:
             fallback_config=cfg,
         )
         assert [r["error_message"] for r in rows_dicts] == ["match"]
+
+    def test_query_filtered_applies_max_row_limit(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from orm import error_read_model
+        from orm.models import Base, ErrorLog
+        from utils.error_fallback_sink import (
+            ErrorLoggingConfig,
+            _reset_handler_cache,
+        )
+
+        _reset_handler_cache()
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+        monkeypatch.setattr(error_read_model, "SessionLocal", Session)
+
+        with Session() as session:
+            for i in range(MAX_ROW_LIMIT + 50):
+                session.add(
+                    ErrorLog(
+                        category="sql_execution",
+                        severity="error",
+                        error_type="RuntimeError",
+                        error_message=f"error-{i}",
+                        created_at=dt.datetime.now() - dt.timedelta(hours=1),
+                    )
+                )
+            session.commit()
+
+        cfg = ErrorLoggingConfig(
+            fallback_path=tmp_path / "limit.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+
+        rows_dicts, _ = _query_filtered(
+            days=7,
+            sources_csv="error_log",
+            categories_csv="",
+            severities_csv="",
+            search="",
+            user_id_text="",
+            fallback_config=cfg,
+        )
+        assert len(rows_dicts) == MAX_ROW_LIMIT

--- a/tests/views/test_errors.py
+++ b/tests/views/test_errors.py
@@ -1,0 +1,424 @@
+"""Tests for views.errors_helpers (Phase 1: pure helpers)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pandas as pd
+
+from orm.error_read_model import DEFAULT_SOURCES, ErrorRow, ErrorSource
+from views.errors_helpers import (
+    _csv_to_set,
+    _export_filename,
+    _format_results_table,
+    _parse_user_id,
+    _pretty_context_data,
+    _query_filtered,
+    _resolve_sources,
+    _time_range_to_since,
+)
+
+
+def _make_row(**overrides) -> ErrorRow:
+    base = dict(
+        id="error_log:1",
+        source=ErrorSource.ERROR_LOG,
+        created_at=dt.datetime(2026, 6, 5, 12, 0, 0),
+        user_id=None,
+        category=None,
+        severity=None,
+        error_type=None,
+        error_message=None,
+        stack_trace=None,
+        question=None,
+        generated_sql=None,
+        llm_provider=None,
+        llm_model=None,
+        context_data=None,
+        group_id=None,
+        run_id=None,
+        message_id=None,
+        auto_retry_attempted=None,
+        retry_successful=None,
+        retry_count=None,
+    )
+    base.update(overrides)
+    return ErrorRow(**base)
+
+
+# ── _time_range_to_since ──────────────────────────────────────────────────
+
+
+class TestTimeRangeToSince:
+    def _within(self, when: dt.datetime, expected: dt.datetime, tolerance_s: int = 5) -> bool:
+        return abs((when - expected).total_seconds()) <= tolerance_s
+
+    def test_7_days(self):
+        result = _time_range_to_since(7)
+        expected = dt.datetime.now() - dt.timedelta(days=7)
+        assert self._within(result, expected)
+
+    def test_30_days(self):
+        result = _time_range_to_since(30)
+        expected = dt.datetime.now() - dt.timedelta(days=30)
+        assert self._within(result, expected)
+
+    def test_90_days(self):
+        result = _time_range_to_since(90)
+        expected = dt.datetime.now() - dt.timedelta(days=90)
+        assert self._within(result, expected)
+
+
+# ── _resolve_sources ──────────────────────────────────────────────────────
+
+
+class TestResolveSources:
+    def test_empty_csv_returns_default_sources(self):
+        assert _resolve_sources("") == set(DEFAULT_SOURCES)
+
+    def test_one_value_returns_subset(self):
+        assert _resolve_sources("error_log") == {ErrorSource.ERROR_LOG}
+
+    def test_two_values(self):
+        assert _resolve_sources("error_log,agent_run") == {
+            ErrorSource.ERROR_LOG,
+            ErrorSource.AGENT_RUN,
+        }
+
+    def test_unknown_value_is_silently_ignored(self):
+        # Defensive: an unknown source from a corrupted cache key should not raise.
+        assert _resolve_sources("error_log,bogus") == {ErrorSource.ERROR_LOG}
+
+    def test_whitespace_tolerated(self):
+        assert _resolve_sources(" error_log , agent_run ") == {
+            ErrorSource.ERROR_LOG,
+            ErrorSource.AGENT_RUN,
+        }
+
+
+# ── _format_results_table ─────────────────────────────────────────────────
+
+
+class TestFormatResultsTable:
+    EXPECTED_COLUMNS = [
+        "created_at",
+        "source",
+        "category",
+        "severity",
+        "error_type",
+        "error_message",
+    ]
+
+    def test_empty_input_returns_empty_dataframe_with_columns(self):
+        df = _format_results_table([])
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == self.EXPECTED_COLUMNS
+        assert len(df) == 0
+
+    def test_populated_full_field_round_trip(self):
+        rows = [
+            _make_row(
+                source=ErrorSource.AGENT_RUN,
+                category="agent_run",
+                severity="warning",
+                error_type="ToolCapReached",
+                error_message="too many tool calls",
+            ),
+            _make_row(
+                source=ErrorSource.FALLBACK_SINK,
+                category="sql_execution",
+                severity="error",
+                error_type="RuntimeError",
+                error_message="boom",
+            ),
+        ]
+        df = _format_results_table(rows)
+        assert list(df.columns) == self.EXPECTED_COLUMNS
+        assert len(df) == 2
+        # Enum → string value
+        assert list(df["source"]) == ["agent_run", "fallback_sink"]
+        assert list(df["category"]) == ["agent_run", "sql_execution"]
+        assert list(df["severity"]) == ["warning", "error"]
+        assert list(df["error_type"]) == ["ToolCapReached", "RuntimeError"]
+        assert list(df["error_message"]) == ["too many tool calls", "boom"]
+
+    def test_none_optionals_become_empty_strings(self):
+        rows = [_make_row()]
+        df = _format_results_table(rows)
+        assert df["category"][0] == ""
+        assert df["severity"][0] == ""
+        assert df["error_type"][0] == ""
+        assert df["error_message"][0] == ""
+        # source still serializes (required field, never None)
+        assert df["source"][0] == "error_log"
+
+
+# ── _csv_to_set ───────────────────────────────────────────────────────────
+
+
+class TestCsvToSet:
+    def test_empty_returns_none(self):
+        assert _csv_to_set("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _csv_to_set("   ") is None
+
+    def test_single_value(self):
+        assert _csv_to_set("sql_execution") == {"sql_execution"}
+
+    def test_multiple_values(self):
+        assert _csv_to_set("a,b,c") == {"a", "b", "c"}
+
+    def test_strips_whitespace(self):
+        assert _csv_to_set(" a , b ") == {"a", "b"}
+
+    def test_empty_tokens_filtered_out(self):
+        assert _csv_to_set("a,,b,") == {"a", "b"}
+
+
+# ── _parse_user_id ────────────────────────────────────────────────────────
+
+
+class TestParseUserId:
+    def test_empty_returns_none(self):
+        assert _parse_user_id("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _parse_user_id("   ") is None
+
+    def test_valid_int_returns_int(self):
+        assert _parse_user_id("42") == 42
+
+    def test_whitespace_padded_int(self):
+        assert _parse_user_id("  7  ") == 7
+
+    def test_zero_is_allowed(self):
+        assert _parse_user_id("0") == 0
+
+    def test_negative_returns_none(self):
+        assert _parse_user_id("-5") is None
+
+    def test_non_numeric_returns_none(self):
+        assert _parse_user_id("abc") is None
+
+    def test_decimal_returns_none(self):
+        assert _parse_user_id("3.14") is None
+
+
+# ── _pretty_context_data ──────────────────────────────────────────────────
+
+
+class TestPrettyContextData:
+    def test_none_returns_none(self):
+        assert _pretty_context_data(None) is None
+
+    def test_empty_returns_none(self):
+        assert _pretty_context_data("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert _pretty_context_data("   ") is None
+
+    def test_valid_json_object_pretty_printed(self):
+        result = _pretty_context_data('{"a": 1, "b": "x"}')
+        assert result is not None
+        import json as _json
+
+        # Round-trips back to the same dict
+        assert _json.loads(result) == {"a": 1, "b": "x"}
+        # And is indented (more than one line)
+        assert "\n" in result
+
+    def test_valid_json_array_pretty_printed(self):
+        result = _pretty_context_data("[1, 2, 3]")
+        assert result is not None
+        assert "\n" in result
+
+    def test_invalid_json_returns_raw_text(self):
+        raw = "not valid json {{"
+        assert _pretty_context_data(raw) == raw
+
+
+# ── _export_filename ──────────────────────────────────────────────────────
+
+
+class TestExportFilename:
+    def test_ends_with_json_extension(self):
+        name = _export_filename(dt.datetime(2026, 6, 5), "error_log")
+        assert name.endswith(".json")
+
+    def test_includes_since_iso(self):
+        name = _export_filename(dt.datetime(2026, 6, 5, 12, 0, 0), "error_log")
+        assert "20260605T120000" in name
+
+    def test_explicit_until_overrides_now(self):
+        name = _export_filename(
+            dt.datetime(2026, 6, 5),
+            "error_log",
+            until=dt.datetime(2026, 7, 1, 9, 30, 45),
+        )
+        assert "20260701T093045" in name
+
+    def test_empty_sources_csv_becomes_all(self):
+        name = _export_filename(dt.datetime(2026, 6, 5), "")
+        assert "all" in name
+
+    def test_multiple_sources_joined_with_dash(self):
+        name = _export_filename(dt.datetime(2026, 6, 5), "error_log,agent_run")
+        assert "error_log-agent_run" in name
+
+    def test_single_source_preserved(self):
+        name = _export_filename(dt.datetime(2026, 6, 5), "fallback_sink")
+        assert "fallback_sink" in name
+
+
+# ── _query_filtered smoke test (cross-source) ─────────────────────────────
+
+
+class TestQueryFilteredSmoke:
+    """End-to-end shape check that the view's data helper composes the read
+    model + fallback adapter correctly. Uses an in-memory SQLite plus a
+    tmp JSONL fallback file. Mirrors the pattern in
+    tests/orm/test_error_read_model.py without re-testing the read-model
+    semantics — just verifies the view's composition."""
+
+    def test_view_helper_returns_rows_from_all_three_sources(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from orm import error_read_model
+        from orm.models import AgentRun, Base, ErrorLog
+        from utils.error_fallback_sink import (
+            ErrorLoggingConfig,
+            _reset_handler_cache,
+            write_fallback_record,
+        )
+
+        _reset_handler_cache()
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+        monkeypatch.setattr(error_read_model, "SessionLocal", Session)
+
+        with Session() as session:
+            session.add(
+                ErrorLog(
+                    category="sql_execution",
+                    severity="error",
+                    error_type="RuntimeError",
+                    error_message="from-error-log",
+                    created_at=dt.datetime.now() - dt.timedelta(hours=1),
+                )
+            )
+            session.add(
+                AgentRun(
+                    run_id="smoke-run-1",
+                    session_id="smoke-sess",
+                    user_id=1,
+                    user_role=0,
+                    status="error",
+                    success=False,
+                    error_type="ToolError",
+                    error="from-agent-run",
+                    created_at=dt.datetime.now() - dt.timedelta(hours=2),
+                )
+            )
+            session.commit()
+
+        cfg = ErrorLoggingConfig(
+            fallback_path=tmp_path / "smoke.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+        write_fallback_record(
+            {
+                "created_at": (dt.datetime.now() - dt.timedelta(hours=3)).isoformat(),
+                "category": "sql_execution",
+                "severity": "error",
+                "error_type": "FallbackError",
+                "error_message": "from-fallback",
+                "user_id": 1,
+            },
+            config=cfg,
+        )
+
+        rows_dicts, counts = _query_filtered(
+            days=7,
+            sources_csv="",  # default = all three
+            categories_csv="",
+            severities_csv="",
+            search="",
+            user_id_text="",
+            fallback_config=cfg,
+        )
+
+        # All three sources present
+        messages = {r["error_message"] for r in rows_dicts}
+        assert "from-error-log" in messages
+        assert "from-agent-run" in messages
+        assert "from-fallback" in messages
+
+        # Counts include each source
+        assert counts["error_log"] >= 1
+        assert counts["agent_run"] >= 1
+        assert counts["fallback_sink"] >= 1
+
+        # Sorted descending by created_at (ErrorLog is newest)
+        assert rows_dicts[0]["error_message"] == "from-error-log"
+
+        # Every payload is JSON-serializable (no Enum, no datetime objects)
+        import json as _json
+
+        _json.dumps(rows_dicts)
+
+    def test_view_helper_respects_filters(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from orm import error_read_model
+        from orm.models import Base, ErrorLog
+        from utils.error_fallback_sink import (
+            ErrorLoggingConfig,
+            _reset_handler_cache,
+        )
+
+        _reset_handler_cache()
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+        monkeypatch.setattr(error_read_model, "SessionLocal", Session)
+
+        with Session() as session:
+            for cat, msg in [
+                ("sql_execution", "match"),
+                ("chart_generation", "skip-1"),
+                ("sql_execution", "skip-2"),
+            ]:
+                session.add(
+                    ErrorLog(
+                        category=cat,
+                        severity="error",
+                        error_type="RuntimeError",
+                        error_message=msg,
+                        created_at=dt.datetime.now() - dt.timedelta(hours=1),
+                    )
+                )
+            session.commit()
+
+        cfg = ErrorLoggingConfig(
+            fallback_path=tmp_path / "x.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+
+        rows_dicts, _ = _query_filtered(
+            days=7,
+            sources_csv="error_log",
+            categories_csv="sql_execution",
+            severities_csv="",
+            search="match",
+            user_id_text="",
+            fallback_config=cfg,
+        )
+        assert [r["error_message"] for r in rows_dicts] == ["match"]

--- a/views/errors.py
+++ b/views/errors.py
@@ -21,6 +21,7 @@ import streamlit as st
 from orm.error_read_model import ErrorSource
 from orm.models import ErrorCategory, ErrorSeverity, RoleTypeEnum
 from utils.error_fallback_sink import try_drain_fallback_to_db
+from utils.quick_logger import get_logger
 from views.errors_helpers import (
     MAX_ROW_LIMIT,
     _export_filename,
@@ -39,6 +40,8 @@ _KNOWN_SEVERITIES = [s.value for s in ErrorSeverity]
 # short compared to admin_analytics's 300s.
 ERRORS_CACHE_TTL_SECONDS = 60
 
+logger = get_logger(__name__)
+
 
 def _guard_admin() -> None:
     if st.session_state.get("user_role") != RoleTypeEnum.ADMIN.value:
@@ -46,11 +49,32 @@ def _guard_admin() -> None:
         st.stop()
 
 
-def _kpi_card(label: str, value) -> None:
+def _kpi_card(
+    label: str,
+    value,
+    help_text: str | None = None,
+    dim: bool = False,
+) -> None:
+    """Render one source-count badge.
+
+    When ``dim=True`` (the source is excluded by the Sources chip filter
+    above), the label is struck through and the value rendered at 50%
+    opacity so the admin sees both the per-source total *and* that the
+    source is currently filtered out of the results list.
+    """
     c = st.container(border=True)
     with c:
-        st.markdown(f"**{label}**")
-        st.markdown(f"<h3 style='margin-top:0'>{value}</h3>", unsafe_allow_html=True)
+        if dim:
+            st.markdown(f"**~~{label}~~**")
+            st.markdown(
+                f"<h3 style='margin-top:0; opacity:0.5'>{value}</h3>",
+                unsafe_allow_html=True,
+            )
+        else:
+            st.markdown(f"**{label}**")
+            st.markdown(f"<h3 style='margin-top:0'>{value}</h3>", unsafe_allow_html=True)
+        if help_text:
+            st.caption(help_text)
 
 
 @st.cache_data(ttl=ERRORS_CACHE_TTL_SECONDS, show_spinner="Loading errors...")
@@ -146,13 +170,33 @@ rows_dicts, counts = _load(
     user_id_text,
 )
 
+_KPI_HELP_TEXT = (
+    "Total in the selected time range. Not affected by category / severity / "
+    "user / search filters — those narrow the table below only."
+)
+
 cols = st.columns(3)
 with cols[0]:
-    _kpi_card("Error Log", counts.get(ErrorSource.ERROR_LOG.value, 0))
+    _kpi_card(
+        "Error Log",
+        counts.get(ErrorSource.ERROR_LOG.value, 0),
+        help_text=_KPI_HELP_TEXT,
+        dim=ErrorSource.ERROR_LOG.value not in selected_source_values,
+    )
 with cols[1]:
-    _kpi_card("Agent Runs", counts.get(ErrorSource.AGENT_RUN.value, 0))
+    _kpi_card(
+        "Agent Runs",
+        counts.get(ErrorSource.AGENT_RUN.value, 0),
+        help_text=_KPI_HELP_TEXT,
+        dim=ErrorSource.AGENT_RUN.value not in selected_source_values,
+    )
 with cols[2]:
-    _kpi_card("Fallback File", counts.get(ErrorSource.FALLBACK_SINK.value, 0))
+    _kpi_card(
+        "Fallback File",
+        counts.get(ErrorSource.FALLBACK_SINK.value, 0),
+        help_text=_KPI_HELP_TEXT,
+        dim=ErrorSource.FALLBACK_SINK.value not in selected_source_values,
+    )
 
 st.divider()
 
@@ -281,6 +325,7 @@ with st.expander("Maintenance — drain pending fallback records"):
             _load.clear()
             st.rerun()
         except Exception as exc:  # pragma: no cover — defensive in UI
+            logger.exception("Errors page: try_drain_fallback_to_db raised")
             st.error(f"Drain failed: {exc}")
 
 # Helper reserved for a future migration replacing the inline expander rendering.

--- a/views/errors.py
+++ b/views/errors.py
@@ -1,0 +1,283 @@
+"""Admin Errors page — unified view across thrive_error_log,
+thrive_agent_run failures, and the JSONL fallback file.
+
+Phase 1: skeleton + admin gate + time-range + source-count badges +
+source filter chips + basic results table. Subsequent phases add the
+category / severity / user / search filters (Phase 2), per-row drill-down
+expanders (Phase 3), JSON export (Phase 4), and the fallback drain
+button + smoke tests (Phase 5).
+
+Consumes :func:`orm.error_read_model.query_errors` and
+:func:`orm.error_read_model.count_errors_by_source` from PR #96, plus
+the pure helpers in :mod:`views.errors_helpers`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import streamlit as st
+
+from orm.error_read_model import ErrorSource
+from orm.models import ErrorCategory, ErrorSeverity, RoleTypeEnum
+from utils.error_fallback_sink import try_drain_fallback_to_db
+from views.errors_helpers import (
+    _export_filename,
+    _format_results_table,
+    _pretty_context_data,
+    _query_filtered,
+    _time_range_to_since,
+)
+
+# Known categories include every ErrorCategory enum value plus the synthetic
+# "agent_run" used for thrive_agent_run failures (see orm.error_read_model).
+_KNOWN_CATEGORIES = sorted([c.value for c in ErrorCategory] + ["agent_run"])
+_KNOWN_SEVERITIES = [s.value for s in ErrorSeverity]
+
+# Admins often watch errors arrive in near-real-time, so the TTL is
+# short compared to admin_analytics's 300s.
+ERRORS_CACHE_TTL_SECONDS = 60
+
+
+def _guard_admin() -> None:
+    if st.session_state.get("user_role") != RoleTypeEnum.ADMIN.value:
+        st.error("You don't have permission to view this page.")
+        st.stop()
+
+
+def _kpi_card(label: str, value) -> None:
+    c = st.container(border=True)
+    with c:
+        st.markdown(f"**{label}**")
+        st.markdown(f"<h3 style='margin-top:0'>{value}</h3>", unsafe_allow_html=True)
+
+
+@st.cache_data(ttl=ERRORS_CACHE_TTL_SECONDS, show_spinner="Loading errors...")
+def _load(
+    days: int,
+    sources_csv: str,
+    categories_csv: str,
+    severities_csv: str,
+    search: str,
+    user_id_text: str,
+) -> tuple[list[dict], dict[str, int]]:
+    """Thin ``@st.cache_data`` wrapper around :func:`_query_filtered`.
+
+    All inputs are stringly typed so the resulting tuple stays hashable
+    for Streamlit's cache key.
+    """
+    return _query_filtered(
+        days,
+        sources_csv,
+        categories_csv,
+        severities_csv,
+        search,
+        user_id_text,
+    )
+
+
+# ── Page render (runs every Streamlit script execution) ───────────────────
+
+
+_guard_admin()
+
+st.title("Errors")
+st.caption("Unified view across the application database, agentic-run failures, and the durable fallback file.")
+
+range_choice = st.radio(
+    "Time Range",
+    options=[7, 30, 90],
+    index=1,  # default to 30 days
+    format_func=lambda d: f"{d} days",
+    horizontal=True,
+    key="errors_days",
+)
+
+source_options = [s.value for s in ErrorSource]
+selected_source_values = st.multiselect(
+    "Sources",
+    options=source_options,
+    default=source_options,
+    key="errors_sources",
+)
+sources_csv = ",".join(sorted(selected_source_values))
+
+with st.expander("Filters", expanded=False):
+    filter_cols = st.columns(2)
+    with filter_cols[0]:
+        selected_categories = st.multiselect(
+            "Categories",
+            options=_KNOWN_CATEGORIES,
+            default=[],
+            key="errors_categories",
+            help="Leave empty to include all categories.",
+        )
+        search_text = st.text_input(
+            "Search (error message or question)",
+            value="",
+            key="errors_search",
+            help="Case-insensitive substring match. Literal % and _ are matched.",
+        )
+    with filter_cols[1]:
+        selected_severities = st.multiselect(
+            "Severities",
+            options=_KNOWN_SEVERITIES,
+            default=[],
+            key="errors_severities",
+            help="Leave empty to include all severities.",
+        )
+        user_id_text = st.text_input(
+            "User ID",
+            value="",
+            key="errors_user_id",
+            help="Optional. Leave empty to include all users.",
+        )
+
+categories_csv = ",".join(sorted(selected_categories))
+severities_csv = ",".join(sorted(selected_severities))
+
+rows_dicts, counts = _load(
+    range_choice,
+    sources_csv,
+    categories_csv,
+    severities_csv,
+    search_text,
+    user_id_text,
+)
+
+cols = st.columns(3)
+with cols[0]:
+    _kpi_card("Error Log", counts.get(ErrorSource.ERROR_LOG.value, 0))
+with cols[1]:
+    _kpi_card("Agent Runs", counts.get(ErrorSource.AGENT_RUN.value, 0))
+with cols[2]:
+    _kpi_card("Fallback File", counts.get(ErrorSource.FALLBACK_SINK.value, 0))
+
+st.divider()
+
+st.caption(f"Showing {len(rows_dicts)} error(s) under the current filters.")
+
+export_payload = json.dumps(rows_dicts, indent=2)
+export_name = _export_filename(_time_range_to_since(range_choice), sources_csv)
+st.download_button(
+    label="⬇️ Export filtered errors as JSON",
+    data=export_payload,
+    file_name=export_name,
+    mime="application/json",
+    disabled=not rows_dicts,
+    help="Downloads the currently visible rows with every field — not the entire table.",
+)
+
+if not rows_dicts:
+    st.info("No errors match the current filters in the selected range.")
+else:
+    for row in rows_dicts:
+        sev = (row.get("severity") or "?").upper()
+        cat = row.get("category") or "?"
+        et = row.get("error_type") or "?"
+        when = (row.get("created_at") or "")[:19].replace("T", " ")
+        msg = row.get("error_message") or ""
+        msg_preview = (msg[:80] + "…") if len(msg) > 80 else msg
+        label = f"{sev} · {cat} · {et} · {when}"
+        if msg_preview:
+            label = f"{label} — {msg_preview}"
+
+        with st.expander(label):
+            left, right = st.columns([2, 1])
+            with left:
+                st.markdown("**Error message**")
+                st.code(row.get("error_message") or "(none)", language="text")
+
+                if row.get("question"):
+                    st.markdown("**Question**")
+                    st.write(row["question"])
+
+                if row.get("generated_sql"):
+                    st.markdown("**Generated SQL**")
+                    st.code(row["generated_sql"], language="sql")
+
+                if row.get("stack_trace"):
+                    st.markdown("**Stack trace**")
+                    st.code(row["stack_trace"], language="text")
+
+                ctx_pretty = _pretty_context_data(row.get("context_data"))
+                if ctx_pretty:
+                    st.markdown("**Context data**")
+                    st.code(ctx_pretty, language="json")
+
+            with right:
+                st.markdown("**Metadata**")
+                st.write(f"Source: `{row.get('source', '?')}`")
+                st.write(f"Created: `{row.get('created_at', '?')}`")
+                if row.get("user_id") is not None:
+                    st.write(f"User ID: `{row['user_id']}`")
+                if row.get("group_id"):
+                    st.write(f"Group ID: `{row['group_id']}`")
+                if row.get("message_id") is not None:
+                    st.write(f"Message ID: `{row['message_id']}`")
+                if row.get("llm_provider"):
+                    st.write(f"LLM provider: `{row['llm_provider']}`")
+                if row.get("llm_model"):
+                    st.write(f"LLM model: `{row['llm_model']}`")
+
+                if row.get("source") == "agent_run" and row.get("run_id"):
+                    st.markdown("---")
+                    st.markdown("**Agent run**")
+                    st.write(f"Run ID: `{row['run_id']}`")
+                    try:
+                        st.page_link(
+                            "views/agent_analytics.py",
+                            label="Open Agentic Analytics →",
+                            icon="🧠",
+                        )
+                    except Exception:
+                        # st.page_link is only valid inside a registered
+                        # Streamlit page — skip the link if the runtime
+                        # isn't multipage-aware.
+                        pass
+                elif row.get("run_id"):
+                    st.write(f"Run ID: `{row['run_id']}`")
+
+                retry_fields = (
+                    row.get("auto_retry_attempted"),
+                    row.get("retry_successful"),
+                    row.get("retry_count"),
+                )
+                if any(v is not None for v in retry_fields):
+                    st.markdown("---")
+                    st.markdown("**Retry**")
+                    st.write(f"Attempted: `{row.get('auto_retry_attempted')}`")
+                    st.write(f"Successful: `{row.get('retry_successful')}`")
+                    st.write(f"Count: `{row.get('retry_count')}`")
+
+st.divider()
+with st.expander("Maintenance — drain pending fallback records"):
+    fb_count = counts.get(ErrorSource.FALLBACK_SINK.value, 0)
+    st.write(
+        f"There are currently **{fb_count}** record(s) in the durable fallback "
+        "file waiting to be replayed into `thrive_error_log`. These are records "
+        "that fired while the app SQLite was unavailable."
+    )
+    if st.button(
+        "Drain pending fallback records into the DB",
+        disabled=fb_count == 0,
+        type="secondary",
+        key="errors_drain_button",
+    ):
+        try:
+            n = try_drain_fallback_to_db()
+            if n > 0:
+                st.success(f"Replayed {n} record(s) into thrive_error_log.")
+            else:
+                st.info(
+                    "No records were replayed — the fallback file was empty "
+                    "or all records were duplicates of existing rows."
+                )
+            # Bust the load cache so the per-source badges refresh.
+            _load.clear()
+            st.rerun()
+        except Exception as exc:  # pragma: no cover — defensive in UI
+            st.error(f"Drain failed: {exc}")
+
+# Helper reserved for a future migration replacing the inline expander rendering.
+_ = _format_results_table

--- a/views/errors.py
+++ b/views/errors.py
@@ -22,6 +22,7 @@ from orm.error_read_model import ErrorSource
 from orm.models import ErrorCategory, ErrorSeverity, RoleTypeEnum
 from utils.error_fallback_sink import try_drain_fallback_to_db
 from views.errors_helpers import (
+    MAX_ROW_LIMIT,
     _export_filename,
     _format_results_table,
     _pretty_context_data,
@@ -155,7 +156,10 @@ with cols[2]:
 
 st.divider()
 
-st.caption(f"Showing {len(rows_dicts)} error(s) under the current filters.")
+caption_text = f"Showing {len(rows_dicts)} error(s) under the current filters."
+if len(rows_dicts) >= MAX_ROW_LIMIT:
+    caption_text += f" (capped at {MAX_ROW_LIMIT} — narrow the time range or apply more filters to see older rows)"
+st.caption(caption_text)
 
 export_payload = json.dumps(rows_dicts, indent=2)
 export_name = _export_filename(_time_range_to_since(range_choice), sources_csv)

--- a/views/errors_helpers.py
+++ b/views/errors_helpers.py
@@ -21,6 +21,8 @@ from orm.error_read_model import (
 )
 from utils.error_fallback_sink import ErrorLoggingConfig
 
+MAX_ROW_LIMIT = 500
+
 _RESULT_COLUMNS = (
     "created_at",
     "source",
@@ -147,6 +149,7 @@ def _query_filtered(
         user_id=_parse_user_id(user_id_text),
         search=search.strip() or None,
         fallback_config=fallback_config,
+        limit=MAX_ROW_LIMIT,
     )
     counts = count_errors_by_source(since, fallback_config=fallback_config)
     return (

--- a/views/errors_helpers.py
+++ b/views/errors_helpers.py
@@ -1,0 +1,176 @@
+"""Pure helpers for the Errors admin page (views/errors.py).
+
+Split out so unit tests can import them without triggering the Streamlit
+script that lives at the bottom of ``views/errors.py``. No Streamlit
+imports in this module — only stdlib, pandas, and the read model.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+
+import pandas as pd
+
+from orm.error_read_model import (
+    DEFAULT_SOURCES,
+    ErrorRow,
+    ErrorSource,
+    count_errors_by_source,
+    query_errors,
+)
+from utils.error_fallback_sink import ErrorLoggingConfig
+
+_RESULT_COLUMNS = (
+    "created_at",
+    "source",
+    "category",
+    "severity",
+    "error_type",
+    "error_message",
+)
+
+
+def _time_range_to_since(days: int) -> dt.datetime:
+    """Return the ``since`` cutoff for a 'last N days' filter."""
+    return dt.datetime.now() - dt.timedelta(days=days)
+
+
+def _resolve_sources(csv: str) -> set[ErrorSource]:
+    """Parse the comma-separated source value list used as a cache key.
+
+    Empty string → :data:`DEFAULT_SOURCES`. Unknown / malformed values
+    are silently dropped so a corrupted cache key cannot crash the page.
+    """
+    if not csv or not csv.strip():
+        return set(DEFAULT_SOURCES)
+    out: set[ErrorSource] = set()
+    for piece in csv.split(","):
+        token = piece.strip()
+        if not token:
+            continue
+        try:
+            out.add(ErrorSource(token))
+        except ValueError:
+            continue
+    return out
+
+
+def _csv_to_set(csv: str) -> set[str] | None:
+    """Parse a comma-separated filter string into a set or ``None``.
+
+    Empty / whitespace-only input returns ``None`` (which the read-model
+    adapters interpret as "no filter"). Per-value whitespace is stripped.
+    """
+    if not csv or not csv.strip():
+        return None
+    tokens = {piece.strip() for piece in csv.split(",") if piece.strip()}
+    return tokens or None
+
+
+def _parse_user_id(text: str) -> int | None:
+    """Parse a user-id text input into ``int | None``.
+
+    Empty input, whitespace-only, non-numeric, or negative values all
+    return ``None`` so the filter degenerates to "no user filter" rather
+    than raising.
+    """
+    if not text or not text.strip():
+        return None
+    try:
+        value = int(text.strip())
+    except (TypeError, ValueError):
+        return None
+    if value < 0:
+        return None
+    return value
+
+
+def _export_filename(
+    since: dt.datetime,
+    sources_csv: str,
+    until: dt.datetime | None = None,
+) -> str:
+    """Build a descriptive filename for the JSON export download.
+
+    Format: ``errors_<since>_<until>_<sources>.json``. Empty
+    ``sources_csv`` becomes ``"all"``.
+    """
+    since_iso = since.strftime("%Y%m%dT%H%M%S")
+    until_iso = (until or dt.datetime.now()).strftime("%Y%m%dT%H%M%S")
+    src_summary = sources_csv.replace(",", "-") if sources_csv else "all"
+    return f"errors_{since_iso}_{until_iso}_{src_summary}.json"
+
+
+def _pretty_context_data(text: str | None) -> str | None:
+    """Pretty-print a JSON-string ``context_data`` field for the drill-down.
+
+    Returns the input unchanged if it's not valid JSON (so partial JSON
+    or other formats are still visible to the admin). ``None`` and empty
+    strings round-trip as ``None``.
+    """
+    if not text or not text.strip():
+        return None
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return text
+    try:
+        return json.dumps(parsed, indent=2, default=str)
+    except (TypeError, ValueError):
+        return text
+
+
+def _query_filtered(
+    days: int,
+    sources_csv: str,
+    categories_csv: str,
+    severities_csv: str,
+    search: str,
+    user_id_text: str,
+    *,
+    fallback_config: ErrorLoggingConfig | None = None,
+) -> tuple[list[dict], dict[str, int]]:
+    """Compose the view's data load from stringly-typed widget inputs.
+
+    Returns ``(rows_as_dicts, counts_by_source_value)``. Counts are
+    deliberately unfiltered so the per-source badges show the full
+    available total under the selected time range.
+    """
+    since = _time_range_to_since(days)
+    selected = _resolve_sources(sources_csv) or set(DEFAULT_SOURCES)
+    rows = query_errors(
+        since,
+        sources=selected,
+        categories=_csv_to_set(categories_csv),
+        severities=_csv_to_set(severities_csv),
+        user_id=_parse_user_id(user_id_text),
+        search=search.strip() or None,
+        fallback_config=fallback_config,
+    )
+    counts = count_errors_by_source(since, fallback_config=fallback_config)
+    return (
+        [r.to_dict() for r in rows],
+        {src.value: n for src, n in counts.items()},
+    )
+
+
+def _format_results_table(rows: list[ErrorRow]) -> pd.DataFrame:
+    """Build the basic results table shown above the per-row drill-down.
+
+    Empty input returns a DataFrame with the expected columns but no
+    rows so downstream Streamlit code can safely render an empty grid.
+    None values on optional columns become empty strings for display.
+    """
+    if not rows:
+        return pd.DataFrame(columns=list(_RESULT_COLUMNS))
+    return pd.DataFrame(
+        {
+            "created_at": [r.created_at for r in rows],
+            "source": [r.source.value for r in rows],
+            "category": [r.category or "" for r in rows],
+            "severity": [r.severity or "" for r in rows],
+            "error_type": [r.error_type or "" for r in rows],
+            "error_message": [r.error_message or "" for r in rows],
+        }
+    )


### PR DESCRIPTION
## Summary

Closes #94. Final Feature Spec of Epic #88 (Unified error visibility).

Adds a single admin-only Streamlit page (`views/errors.py`) that surfaces every error from the three sources unified by `orm.error_read_model` (#93): `thrive_error_log`, `thrive_agent_run` failures, and the JSONL fallback file from #89.

## What's added

**`views/errors.py`** — Streamlit page with:
- Admin gate (`_guard_admin()` + nav-time conditional registration in `app.py`)
- 7 / 30 / 90-day time-range selector
- Per-source filter chips (multiselect, default = all three)
- "Filters" expander with category multiselect (all `ErrorCategory` enum values + the synthetic `"agent_run"`), severity multiselect, substring search, and a user-id text input
- Three KPI badges driven by `count_errors_by_source()` (deliberately unfiltered — show full available totals)
- Per-row `st.expander` drill-down with two columns: left = `error_message` + `question` + `generated_sql` + `stack_trace` + pretty-printed `context_data`; right = `source` / `created_at` / `user_id` / `group_id` / `message_id` / `llm_provider` / `llm_model` + agent-run deep-link + retry block
- JSON export of the currently filtered rows via `st.download_button`, filename `errors_<since>_<until>_<sources>.json`
- Maintenance expander with a "Drain pending fallback records" button wrapping `try_drain_fallback_to_db()` that busts the `@st.cache_data` cache on success so the fallback badge refreshes

**`views/errors_helpers.py`** — pure helpers split out so unit tests can import them without triggering the Streamlit script in `views/errors.py`. Contains `_time_range_to_since`, `_resolve_sources`, `_csv_to_set`, `_parse_user_id`, `_pretty_context_data`, `_export_filename`, `_format_results_table`, and `_query_filtered` (the latter is what the cached `_load` in the view wraps).

**`app.py`** — registers the page inside the existing admin-only block alongside the other admin pages.

## Phasing

| Phase | What | Tests |
|---|---|---:|
| 1 | Skeleton + admin gate + nav wiring + source-count badges + basic results table | 11 |
| 2 | Filter controls (category / severity / user / substring search) + cache-key extension | 14 |
| 3 | Per-row drill-down expanders with all 19 fields | 6 |
| 4 | JSON export button | 6 |
| 5 | Drain action + cross-source smoke test (extracted `_query_filtered` for testability) | 2 |
| **Total** | 2 new modules, 1 modified, 1 new test file | **39 tests** |

## Test plan

- [x] 39 new unit + smoke tests in `tests/views/test_errors.py` all pass.
- [x] Full suite `uv run pytest -m "not milvus"` — **1207 pass** (1179 baseline + 28 net new in this branch). Same 18 pre-existing environmental failures (missing redshift catalog JSON, no local Ollama). No regressions.
- [x] `uv run ruff check` + `uv run ruff format` clean on the three new/touched files.
- [x] **Streamlit boots clean** on this branch (no import errors from `views/errors.py`). Login page renders normally — proves no startup regression.
- [ ] **Logged-in Playwright drill-down deferred** — I don't have test admin credentials. Manual verification needed:
  - Nav to "Errors" page appears in the admin sidebar (alongside Admin Analytics / Feedback Dashboard / Agentic Analytics).
  - Source-count badges match the corresponding tables.
  - Filter toggles narrow the results correctly (try a `%` in the search to confirm literal-LIKE behavior).
  - Drill-down expander shows every field present.
  - JSON export downloads valid JSON of the filtered rows.
  - "Drain pending fallback records" button replays the JSONL file into `thrive_error_log` and the badge drops to 0.

## Architecture / context

- No DB schema changes. No new runtime dependencies.
- Same PHI exposure as `thrive_error_log` today (admin trust boundary; no scrubbing in the view).
- `@st.cache_data(ttl=60)` — shorter than `admin_analytics`'s 300s because admin debugging often watches errors in near-real-time.
- `views/admin_analytics.py`'s Error Analysis tab is left untouched per the spec; a follow-up can replace it with a `st.page_link` to the new page if preferred.
- Per Epic #88's per-source isolation discussion: the underlying read-model semantics (per-source try/except for adapter failures, single session for both DB sources) are inherited from PR #96 — see the below-threshold findings on that PR for the docstring-vs-reality nuance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)