### PR TITLE
feat(user): add organization column + require email/organization on create_user

### DIFF
--- a/alembic/versions/aa611613d67b_add_user_organization.py
+++ b/alembic/versions/aa611613d67b_add_user_organization.py
@@ -1,0 +1,46 @@
+"""add organization column to thrive_user
+
+Adds a single nullable VARCHAR(120) `organization` column to ``thrive_user``
+so the bulk import and the admin create / edit / self-edit surfaces can
+record which org each user belongs to. Email already exists on the User
+model with `unique=True, collation="NOCASE"`; no schema change for email.
+
+Existing rows survive the migration with ``organization = NULL`` (Epic #98
+explicitly chose no backfill).
+
+Revision ID: aa611613d67b
+Revises: f95a95e2dbb1
+Create Date: 2026-06-06 11:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision: str = "aa611613d67b"
+down_revision: Union[str, Sequence[str], None] = "f95a95e2dbb1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    user_cols = {c["name"] for c in inspector.get_columns("thrive_user")}
+    if "organization" not in user_cols:
+        op.add_column(
+            "thrive_user",
+            sa.Column("organization", sa.String(length=120), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    user_cols = {c["name"] for c in inspector.get_columns("thrive_user")}
+    if "organization" in user_cols:
+        op.drop_column("thrive_user", "organization")

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import re
 
 import streamlit as st
 from sqlalchemy import case, func
@@ -8,6 +9,20 @@ from sqlalchemy.orm import joinedload
 from orm.models import Message, SessionLocal, User, UserRole
 from utils.enums import MessageType, RoleType
 from utils.quick_logger import get_logger
+
+# Lightweight email format check per Epic #98 — no MX lookups, no RFC compliance.
+# Requires at least one non-space + "@" + non-space + "." + non-space.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _is_valid_email(value: str | None) -> bool:
+    if value is None:
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    return bool(_EMAIL_RE.match(stripped))
+
 
 logger = get_logger(__name__)
 
@@ -189,7 +204,17 @@ def save_user_settings():
         logger.error(f"Error saving user settings: {e}")
 
 
-def create_user(username: str, password: str, first_name: str, last_name: str, role_id: int, theme: str = None) -> bool:
+def create_user(
+    username: str,
+    password: str,
+    first_name: str,
+    last_name: str,
+    role_id: int,
+    *,
+    email: str,
+    organization: str,
+    theme: str | None = None,
+) -> bool:
     """
     Create a new user with the specified details.
 
@@ -199,6 +224,10 @@ def create_user(username: str, password: str, first_name: str, last_name: str, r
         first_name: User's first name
         last_name: User's last name
         role_id: The ID of the user role
+        email: Required keyword-only. Validated against a lightweight regex
+            and rejected if a case-insensitive duplicate already exists.
+        organization: Required keyword-only. Stripped and rejected if empty.
+        theme: Optional theme preference.
 
     Returns:
         bool: True if user was created successfully, False otherwise
@@ -211,11 +240,24 @@ def create_user(username: str, password: str, first_name: str, last_name: str, r
         username = (username or "").strip()
         first_name = (first_name or "").strip()
         last_name = (last_name or "").strip()
+        email = (email or "").strip()
+        organization = (organization or "").strip()
+
+        # Validate email format and organization presence before opening a session.
+        if not _is_valid_email(email):
+            return False
+        if not organization:
+            return False
 
         with SessionLocal() as session:
             # Check if username already exists
             existing_user = session.query(User).filter(func.lower(User.username) == username.lower()).first()
             if existing_user:
+                return False
+
+            # Check if email already exists (case-insensitive).
+            existing_email = session.query(User).filter(func.lower(User.email) == email.lower()).first()
+            if existing_email:
                 return False
 
             # Hash the password using SHA-256 (matching existing pattern)
@@ -228,6 +270,8 @@ def create_user(username: str, password: str, first_name: str, last_name: str, r
                 first_name=first_name,
                 last_name=last_name,
                 user_role_id=role_id,
+                email=email,
+                organization=organization,
                 show_sql=True,
                 show_table=True,
                 show_plotly_code=False,

--- a/orm/models.py
+++ b/orm/models.py
@@ -175,6 +175,7 @@ class User(Base):
     # docs/superpowers/specs/2026-05-01-okta-oidc-integration-design.md §5.
     okta_sub = Column(String(255), nullable=True, unique=True)
     email = Column(String(320, collation="NOCASE"), nullable=True, unique=True)
+    organization = Column(String(120), nullable=True)
     created_at = Column(TIMESTAMP, server_default=func.now())
     updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
     show_sql = Column(Boolean, default=True)

--- a/tests/orm/test_agentic_mode_default.py
+++ b/tests/orm/test_agentic_mode_default.py
@@ -20,7 +20,18 @@ def test_create_user_defaults_agentic_mode_on(in_memory_orm_session):
     with in_memory_orm_session() as session:
         role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
 
-    assert create_user("newdoc", "pw", "New", "Doc", role_id) is True
+    assert (
+        create_user(
+            "newdoc",
+            "pw",
+            "New",
+            "Doc",
+            role_id,
+            email="newdoc@example.com",
+            organization="Acme",
+        )
+        is True
+    )
 
     with in_memory_orm_session() as session:
         user = session.query(User).filter(User.username == "newdoc").one()

--- a/tests/orm/test_create_user_trim.py
+++ b/tests/orm/test_create_user_trim.py
@@ -1,12 +1,21 @@
-"""create_user must trim whitespace from username/name fields.
+"""create_user behavior tests — whitespace trimming, required email + organization,
+email format validation, email uniqueness (case-insensitive), and organization
+stripping.
 
-A leading/trailing space in the username (e.g. from the admin create-user
-form) silently breaks login, because verify_user_credentials matches on the
-exact stored username. Regression test for the `" adlouhy"` case seen in dev.
+Original purpose: regression test for the `" adlouhy"` whitespace-in-username
+case that silently broke login. Extended in Epic #98 / Feature Spec #99 to
+cover the new required `email` and `organization` keyword-only parameters
+and their validation gates.
 """
+
+import pytest
 
 from orm.functions import create_user
 from orm.models import User, UserRole
+
+# Default keyword args every test that doesn't care about email / org passes
+# so existing tests keep focusing on what they actually exercise.
+_VALID = dict(email="user@example.com", organization="Acme")
 
 
 def _doctor_role_id(session_factory):
@@ -23,6 +32,7 @@ def test_create_user_trims_username_and_names(in_memory_orm_session):
         first_name="  Adrienne ",
         last_name=" Dlouhy  ",
         role_id=role_id,
+        **_VALID,
     )
     assert ok is True
 
@@ -37,6 +47,133 @@ def test_create_user_dedupes_against_trimmed_username(in_memory_orm_session):
     """A padded duplicate of an existing username must be rejected."""
     role_id = _doctor_role_id(in_memory_orm_session)
 
-    assert create_user("adlouhy", "pw", "A", "D", role_id) is True
+    assert create_user("adlouhy", "pw", "A", "D", role_id, **_VALID) is True
     # Same username with surrounding whitespace should be treated as a dup.
-    assert create_user("  adlouhy  ", "pw", "A", "D", role_id) is False
+    # Note: still pass valid email/org so the rejection is definitively for
+    # the username collision, not for missing fields.
+    assert (
+        create_user(
+            "  adlouhy  ",
+            "pw",
+            "A",
+            "D",
+            role_id,
+            email="different@example.com",
+            organization="Acme",
+        )
+        is False
+    )
+
+
+# ── New tests for email + organization (Epic #98 / Feature Spec #99) ──────
+
+
+def test_email_and_organization_persist_after_create(in_memory_orm_session):
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    ok = create_user(
+        "alice",
+        "pw",
+        "Alice",
+        "Smith",
+        role_id,
+        email="alice@example.com",
+        organization="Acme",
+    )
+    assert ok is True
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "alice").one()
+        assert user.email == "alice@example.com"
+        assert user.organization == "Acme"
+
+
+@pytest.mark.parametrize(
+    "bad_email",
+    ["foo", "@bar.com", "foo@", "foo@bar", "", "   "],
+)
+def test_email_format_invalid_rejected(in_memory_orm_session, bad_email):
+    role_id = _doctor_role_id(in_memory_orm_session)
+    ok = create_user(
+        "alice",
+        "pw",
+        "Alice",
+        "Smith",
+        role_id,
+        email=bad_email,
+        organization="Acme",
+    )
+    assert ok is False
+
+    with in_memory_orm_session() as session:
+        assert session.query(User).filter(User.username == "alice").first() is None
+
+
+def test_email_duplicate_rejected_case_insensitive(in_memory_orm_session):
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    assert (
+        create_user(
+            "alice",
+            "pw",
+            "Alice",
+            "Smith",
+            role_id,
+            email="User@Example.com",
+            organization="Acme",
+        )
+        is True
+    )
+    # Different username but same email (different case) — must be rejected.
+    assert (
+        create_user(
+            "bob",
+            "pw",
+            "Bob",
+            "Jones",
+            role_id,
+            email="user@example.com",
+            organization="Acme",
+        )
+        is False
+    )
+
+    with in_memory_orm_session() as session:
+        assert session.query(User).filter(User.username == "bob").first() is None
+
+
+def test_organization_empty_after_strip_rejected(in_memory_orm_session):
+    role_id = _doctor_role_id(in_memory_orm_session)
+    ok = create_user(
+        "alice",
+        "pw",
+        "Alice",
+        "Smith",
+        role_id,
+        email="alice@example.com",
+        organization="   ",
+    )
+    assert ok is False
+
+    with in_memory_orm_session() as session:
+        assert session.query(User).filter(User.username == "alice").first() is None
+
+
+def test_email_and_organization_stripped_before_persist(in_memory_orm_session):
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    ok = create_user(
+        "alice",
+        "pw",
+        "Alice",
+        "Smith",
+        role_id,
+        email="  alice@example.com  ",
+        organization="  Acme  ",
+    )
+    assert ok is True
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "alice").one()
+        assert user.email == "alice@example.com"
+        assert user.organization == "Acme"

--- a/views/user.py
+++ b/views/user.py
@@ -620,8 +620,18 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                     if not cu_username or not cu_password or not cu_first:
                         st.error("Please provide username, password, and first name.")
                     else:
+                        # TODO(#101): replace these placeholders with real Email + Organization
+                        # input fields. Keeping the form functional in the gap between #99 (which
+                        # adds the required keyword-only args) and #101 (which wires the inputs).
                         ok = create_user(
-                            cu_username, cu_password, cu_first, cu_last, role_id_by_name.get(cu_role_name), cu_theme
+                            cu_username,
+                            cu_password,
+                            cu_first,
+                            cu_last,
+                            role_id_by_name.get(cu_role_name),
+                            email=f"{cu_username}@placeholder.local",
+                            organization="(not set)",
+                            theme=cu_theme,
                         )
                         if ok:
                             st.success("User created.")


### PR DESCRIPTION
## Summary

Closes #99. Foundation Feature Spec of Epic #98 (Expand user import + create_user to capture email and organization).

Adds the `organization` column to `thrive_user` via an additive Alembic migration and extends `create_user()` in `orm/functions.py` to require `email` and `organization` as keyword-only parameters. Lightweight email format validation (no MX, no RFC) + case-insensitive uniqueness enforcement against the existing `email` UNIQUE constraint. Existing rows stay NULL — no backfill.

## What's added

**Schema:**
- New migration `alembic/versions/aa611613d67b_add_user_organization.py` adds a nullable `VARCHAR(120)` `organization` column. Uses the inspector-guarded idempotent pattern from `f95a95e2dbb1_agentic_run_logging`.
- `orm/models.py` adds `organization = Column(String(120), nullable=True)` after the existing `email` column.

**`create_user()`:**
- Required keyword-only parameters `email: str` and `organization: str`.
- New `_is_valid_email` helper at module level: lightweight regex `^[^@\s]+@[^@\s]+\.[^@\s]+$`.
- Pre-flight validation before opening a session: email format, empty-after-strip organization → `return False`.
- Inside the session, new case-insensitive duplicate-email check → `return False`.
- Both new fields are stripped before persistence.

**Tests** (`tests/orm/test_create_user_trim.py`):
- 5 new tests + parametrized email-format coverage (6 bad inputs).
- Existing trim tests updated via a `_VALID` defaults helper.

## Lockstep updates

- `tests/orm/test_agentic_mode_default.py:23` updated for the new required kwargs.
- `views/user.py:623` (admin "Create New User" form) gets placeholder `email=f"{cu_username}@placeholder.local"` and `organization="(not set)"` plus a `TODO(#101)` comment. Keeps the form functional between this PR and #101 (which will replace placeholders with real input fields per the Epic's spec).

## Test plan

- [x] 12 tests in `tests/orm/test_create_user_trim.py` (2 pre-existing + 5 new, with one parametrized over 6 bad email inputs) — all green.
- [x] `tests/orm/test_agentic_mode_default.py` updated and green.
- [x] Full suite `uv run pytest -m "not milvus"` — **1218 passing**, same 18 pre-existing environmental failures (missing redshift catalog JSON, no local Ollama). No regressions.
- [x] `uv run ruff check` + `uv run ruff format` clean on all new/touched files. (Note: `views/user.py` carries 4 pre-existing ruff errors unrelated to this PR — confirmed by running ruff against `main` before this commit.)
- [x] Local migration applied to `pgDatabase/db.sqlite3`: `alembic upgrade head` ran `f95a95e2dbb1 -> aa611613d67b` cleanly; `organization` column visible in `.schema thrive_user`.

## What's intentionally NOT in this PR

- `import_users()` switch from raw `User(...)` construction to `create_user()` — Feature Spec #100.
- Real Email + Organization input fields in the admin Create-User and Edit-User forms, plus the new "My Profile" self-edit section — Feature Spec #101.
- Backfill of existing rows — explicitly out of scope per Epic #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)