### PR TITLE
feat(user): import_users() reads email + organization, delegates to create_user

### DIFF
--- a/tests/views/test_user_import.py
+++ b/tests/views/test_user_import.py
@@ -49,7 +49,7 @@ def _df_with_mixed_rows() -> pd.DataFrame:
                 "start_password": "pw",
                 "First Name ": "Charlie",
                 "Last Name ": "Brown",
-                "Email": "",
+                "Email": float("nan"),
                 "Organization": "Acme",
             },
             # Missing organization
@@ -59,7 +59,7 @@ def _df_with_mixed_rows() -> pd.DataFrame:
                 "First Name ": "Dave",
                 "Last Name ": "Lee",
                 "Email": "dave@example.com",
-                "Organization": "",
+                "Organization": float("nan"),
             },
             # Malformed email
             {

--- a/tests/views/test_user_import.py
+++ b/tests/views/test_user_import.py
@@ -1,0 +1,190 @@
+"""End-to-end smoke test for views.user.import_users().
+
+Drives the importer against an in-memory SQLite using a constructed pandas
+DataFrame (no file I/O) and asserts the full mixed-row behavior: valid rows
+persist with email + organization populated; rows missing either field are
+skipped; malformed-email / duplicate-username / duplicate-email rows are
+skipped via the create_user() delegation introduced by Feature Spec #100.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from orm.functions import create_user
+from orm.models import User, UserRole
+
+
+def _doctor_role_id(session_factory) -> int:
+    with session_factory() as session:
+        return session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+
+
+def _df_with_mixed_rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            # Valid row 1
+            {
+                "UserID": "alice",
+                "start_password": "pw",
+                "First Name ": "Alice",
+                "Last Name ": "Smith",
+                "Email": "alice@example.com",
+                "Organization": "Acme",
+            },
+            # Valid row 2
+            {
+                "UserID": "bob",
+                "start_password": "pw",
+                "First Name ": "Bob",
+                "Last Name ": "Jones",
+                "Email": "bob@example.com",
+                "Organization": "Acme",
+            },
+            # Missing email
+            {
+                "UserID": "charlie",
+                "start_password": "pw",
+                "First Name ": "Charlie",
+                "Last Name ": "Brown",
+                "Email": "",
+                "Organization": "Acme",
+            },
+            # Missing organization
+            {
+                "UserID": "dave",
+                "start_password": "pw",
+                "First Name ": "Dave",
+                "Last Name ": "Lee",
+                "Email": "dave@example.com",
+                "Organization": "",
+            },
+            # Malformed email
+            {
+                "UserID": "eve",
+                "start_password": "pw",
+                "First Name ": "Eve",
+                "Last Name ": "Khan",
+                "Email": "not-an-email",
+                "Organization": "Acme",
+            },
+            # Duplicate username (pre-seeded as "dup-username" below)
+            {
+                "UserID": "dup-username",
+                "start_password": "pw",
+                "First Name ": "Dup",
+                "Last Name ": "User",
+                "Email": "different@example.com",
+                "Organization": "Acme",
+            },
+            # Duplicate email (case-different from pre-seeded "existing@example.com")
+            {
+                "UserID": "frank",
+                "start_password": "pw",
+                "First Name ": "Frank",
+                "Last Name ": "Adams",
+                "Email": "EXISTING@example.com",
+                "Organization": "Acme",
+            },
+        ]
+    )
+
+
+def test_import_users_handles_mixed_rows(in_memory_orm_session, monkeypatch):
+    """7-row import: 2 valid + 5 failures (missing email, missing org, bad
+    format, dup username, dup email). Asserts the persisted state and the
+    Streamlit error/success surface."""
+    # views/user.py:24 does `from orm.models import SessionLocal, ...` which
+    # re-binds the symbol into views.user's namespace. The conftest fixture
+    # only patches orm.models.SessionLocal and orm.functions.SessionLocal —
+    # we need to additionally patch views.user.SessionLocal so the importer's
+    # role-lookup block uses the in-memory engine.
+    import orm.models  # noqa: F401 — ensure module is loaded so we can introspect SessionLocal
+    import views.user
+
+    monkeypatch.setattr(views.user, "SessionLocal", views.user.SessionLocal)
+    # The fixture has already replaced orm.models.SessionLocal with the
+    # in-memory sessionmaker, but views.user's local binding pre-dates that
+    # patch — re-import it now.
+    from orm.models import SessionLocal as _new_session_local
+
+    monkeypatch.setattr(views.user, "SessionLocal", _new_session_local)
+
+    role_id = _doctor_role_id(in_memory_orm_session)
+
+    # orm.functions._get_current_user_id reads st.session_state.cookies; outside
+    # a Streamlit runtime that raises AttributeError. Patch orm.functions.st
+    # with a MagicMock so the admin-action audit-log path no-ops cleanly.
+    import orm.functions
+
+    mock_orm_st = MagicMock()
+    mock_orm_st.session_state.cookies.get.return_value = None
+    monkeypatch.setattr(orm.functions, "st", mock_orm_st)
+
+    # Pre-seed one user for duplicate detection (username = "dup-username",
+    # email = "existing@example.com").
+    assert (
+        create_user(
+            "dup-username",
+            "pw",
+            "Dup",
+            "Existing",
+            role_id,
+            email="existing@example.com",
+            organization="Acme",
+        )
+        is True
+    )
+
+    # Build the DataFrame and patch the file-discovery / Excel-load path so
+    # import_users() doesn't touch the disk.
+    df = _df_with_mixed_rows()
+
+    mock_st = MagicMock()
+    # st.expander is used as a context manager; make it return a MagicMock.
+    mock_st.expander.return_value.__enter__ = lambda self_: self_
+    mock_st.expander.return_value.__exit__ = lambda self_, *args: False
+
+    with (
+        patch.object(views.user, "get_user_list_excel", return_value=df),
+        patch.object(views.user, "st", mock_st),
+        patch("os.path.exists", return_value=True),
+    ):
+        result = views.user.import_users()
+
+    # import_users returns True when any user was successfully imported.
+    assert result is True
+
+    # Persisted state: pre-seeded user plus exactly 2 new rows (alice, bob).
+    with in_memory_orm_session() as session:
+        rows = session.query(User).order_by(User.username).all()
+        usernames = [u.username for u in rows]
+        assert usernames == ["alice", "bob", "dup-username"]
+
+        alice = next(u for u in rows if u.username == "alice")
+        bob = next(u for u in rows if u.username == "bob")
+        assert alice.email == "alice@example.com"
+        assert alice.organization == "Acme"
+        assert bob.email == "bob@example.com"
+        assert bob.organization == "Acme"
+
+    # Success surface: success was called with a message that includes "2".
+    assert mock_st.success.called, "st.success was not called"
+    success_args = " ".join(str(a) for call in mock_st.success.call_args_list for a in call.args)
+    assert "2" in success_args
+
+    # Failure surface: all 5 expected failures appear in st.text calls inside
+    # the failures expander.
+    text_calls = " ".join(str(a) for call in mock_st.text.call_args_list for a in call.args)
+    # Charlie: "Missing email"
+    assert "charlie" in text_calls.lower() or "Missing email" in text_calls
+    # Dave: "Missing organization"
+    assert "dave" in text_calls.lower() or "Missing organization" in text_calls
+    # Eve: malformed email -> create_user rejected
+    assert "eve" in text_calls.lower()
+    # dup-username: duplicate username -> create_user rejected
+    assert "dup-username" in text_calls
+    # Frank: duplicate email -> create_user rejected
+    assert "frank" in text_calls.lower()

--- a/views/user.py
+++ b/views/user.py
@@ -50,6 +50,24 @@ except Exception:
 logger = get_logger(__name__)
 
 
+def _cell_text(raw) -> str:
+    """Return the cleaned text for a spreadsheet cell.
+
+    pandas reads blank Excel cells as float NaN, which str()-ifies to 'nan'
+    (truthy) and would silently bypass the empty-field pre-flight checks.
+    Returns "" when the cell is missing, NaN, or whitespace-only.
+    """
+    if raw is None:
+        return ""
+    try:
+        if pd.isna(raw):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    text = str(raw).strip()
+    return "" if text.lower() == "nan" else text
+
+
 def import_users():
     """
     Import users from Excel file and save them to the database.
@@ -120,15 +138,16 @@ def import_users():
                     "physician": role_map.get("doctor", None),
                 }
             )
+            _patient_fallback_role_id = role_map.get("patient", 1)
 
         for index, row in df.iterrows():
             try:
-                username = str(row.get("UserID", "")).strip()
-                password = str(row.get("start_password", "")).strip()
-                first_name = str(row.get("First Name ", "")).strip()  # Note the space after 'Name'
-                last_name = str(row.get("Last Name ", "")).strip()  # Note the space after 'Name'
-                email = str(row.get("Email", row.get("email", ""))).strip()
-                organization = str(row.get("Organization", row.get("organization", ""))).strip()
+                username = _cell_text(row.get("UserID"))
+                password = _cell_text(row.get("start_password"))
+                first_name = _cell_text(row.get("First Name "))  # trailing space
+                last_name = _cell_text(row.get("Last Name "))  # trailing space
+                email = _cell_text(row.get("Email", row.get("email")))
+                organization = _cell_text(row.get("Organization", row.get("organization")))
                 role_name = "Doctor"  # Default role since not in Excel
 
                 # Skip rows with missing required data
@@ -148,10 +167,7 @@ def import_users():
                 # Map role name to role ID
                 role_id = role_map.get(role_name.lower())
                 if not role_id:
-                    # Default to Patient role if role not found
-                    with SessionLocal() as fallback_session:
-                        default_role = fallback_session.query(UserRole).filter(UserRole.role_name == "Patient").first()
-                        role_id = default_role.id if default_role else 1
+                    role_id = _patient_fallback_role_id
                     logger.warning(f"Role '{role_name}' not found for user {username}, defaulting to Patient")
 
                 # Delegate format + uniqueness validation and persistence to
@@ -649,7 +665,6 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                 "📁 Import users from Excel file: `./utils/config/user_list.xlsx`. "
                 "Required columns: UserID, start_password, First Name, Last Name, Email, Organization."
             )
-            st.caption("Expected columns: UserID, start_password, 'First Name ', 'Last Name '")
             if st.button("Import Users", type="primary", help="Import users from ./utils/config/user_list.xlsx"):
                 import_users()
 

--- a/views/user.py
+++ b/views/user.py
@@ -1,10 +1,8 @@
-import hashlib
 import io
 
 import pandas as pd
 import streamlit as st
 from pandas import DataFrame
-from sqlalchemy import func
 
 from orm.functions import (
     admin_change_password,
@@ -27,16 +25,27 @@ from utils.chat_bot_helper import get_vn
 from utils.enums import ThemeType
 from utils.vanna_calls import auto_generate_sql_pairs, refresh_stats, train_all
 
-# Get the current user ID from session state cookies
-user_id = st.session_state.cookies.get("user_id")
+# Get the current user ID from session state cookies. Guarded so the module
+# stays importable when no Streamlit runtime is attached (e.g., pytest);
+# mirrors the defensive pattern in orm.functions._get_current_user_id.
+try:
+    user_id = st.session_state.cookies.get("user_id")
+except Exception:
+    user_id = None
 # Get the current user role from session state (not cookies) and default to least privileged
-user_role = st.session_state.get("user_role", RoleTypeEnum.PATIENT.value)
+try:
+    user_role = st.session_state.get("user_role", RoleTypeEnum.PATIENT.value)
+except Exception:
+    user_role = RoleTypeEnum.PATIENT.value
 # Don't get training data at module load time - get it when rendering the page
 # df = vn.get_training_data()
 
 from utils.quick_logger import get_logger, pvlog
 
-pvlog("debug", f"{st.session_state.to_dict()=}")
+try:
+    pvlog("debug", f"{st.session_state.to_dict()=}")
+except Exception:
+    pass
 
 logger = get_logger(__name__)
 
@@ -44,7 +53,14 @@ logger = get_logger(__name__)
 def import_users():
     """
     Import users from Excel file and save them to the database.
-    Expected columns in Excel: username, password, first_name, last_name, role_name
+
+    Expected columns: UserID, start_password, First Name, Last Name, Email, Organization.
+    Both `Email` / `email` and `Organization` / `organization` casings are accepted.
+
+    Rows with missing or invalid fields are skipped and surfaced in the
+    failures expander. Validation + persistence is delegated to
+    `orm.functions.create_user`, which enforces email format, email
+    uniqueness (case-insensitive), and organization presence.
     """
     try:
         import os
@@ -93,12 +109,11 @@ def import_users():
         failed_count = 0
         failed_users = []
 
+        # Look up roles once (read-only) so the per-row create_user calls don't
+        # need their own UserRole query.
         with SessionLocal() as session:
-            # Get all existing roles for mapping
             roles = session.query(UserRole).all()
             role_map = {role.role_name.lower(): role.id for role in roles}
-
-            # Also check for common variations
             role_map.update(
                 {
                     "administrator": role_map.get("admin", None),
@@ -106,73 +121,62 @@ def import_users():
                 }
             )
 
-            # Process each row in the DataFrame
-            for index, row in df.iterrows():
-                try:
-                    # Extract user data with default values if columns are missing
-                    username = str(row.get("UserID", "")).strip()
-                    password = str(row.get("start_password", "")).strip()
-                    first_name = str(row.get("First Name ", "")).strip()  # Note the space after 'Name'
-                    last_name = str(row.get("Last Name ", "")).strip()  # Note the space after 'Name'
-                    role_name = "Doctor"  # Default role since not in Excel
+        for index, row in df.iterrows():
+            try:
+                username = str(row.get("UserID", "")).strip()
+                password = str(row.get("start_password", "")).strip()
+                first_name = str(row.get("First Name ", "")).strip()  # Note the space after 'Name'
+                last_name = str(row.get("Last Name ", "")).strip()  # Note the space after 'Name'
+                email = str(row.get("Email", row.get("email", ""))).strip()
+                organization = str(row.get("Organization", row.get("organization", ""))).strip()
+                role_name = "Doctor"  # Default role since not in Excel
 
-                    # Skip rows with missing required data
-                    if not username or not password:
-                        failed_count += 1
-                        failed_users.append(f"Row {index + 2}: Missing username or password")
-                        continue
+                # Skip rows with missing required data
+                if not username or not password:
+                    failed_count += 1
+                    failed_users.append(f"Row {index + 2}: Missing username or password")
+                    continue
+                if not email:
+                    failed_count += 1
+                    failed_users.append(f"Row {index + 2} ({username}): Missing email")
+                    continue
+                if not organization:
+                    failed_count += 1
+                    failed_users.append(f"Row {index + 2} ({username}): Missing organization")
+                    continue
 
-                    # Check if user already exists
-                    existing_user = session.query(User).filter(func.lower(User.username) == username.lower()).first()
-
-                    if existing_user:
-                        failed_count += 1
-                        failed_users.append(f"{username}: Already exists")
-                        continue
-
-                    # Map role name to role ID
-                    role_id = role_map.get(role_name.lower())
-                    if not role_id:
-                        # Default to Patient role if role not found
-                        default_role = session.query(UserRole).filter(UserRole.role_name == "Patient").first()
+                # Map role name to role ID
+                role_id = role_map.get(role_name.lower())
+                if not role_id:
+                    # Default to Patient role if role not found
+                    with SessionLocal() as fallback_session:
+                        default_role = fallback_session.query(UserRole).filter(UserRole.role_name == "Patient").first()
                         role_id = default_role.id if default_role else 1
-                        logger.warning(f"Role '{role_name}' not found for user {username}, defaulting to Patient")
+                    logger.warning(f"Role '{role_name}' not found for user {username}, defaulting to Patient")
 
-                    # Hash the password using SHA-256 (matching existing pattern)
-                    hashed_password = hashlib.sha256(password.encode()).hexdigest()
-
-                    # Create new user
-                    new_user = User(
-                        username=username,
-                        password=hashed_password,
-                        first_name=first_name if first_name else username,
-                        last_name=last_name if last_name else "",
-                        user_role_id=role_id,
-                        show_sql=True,
-                        show_table=True,
-                        show_plotly_code=False,
-                        show_chart=False,
-                        show_question_history=True,
-                        show_summary=True,
-                        voice_input=False,
-                        speak_summary=False,
-                        show_suggested=False,
-                        show_followup=False,
-                        show_elapsed_time=True,
-                        llm_fallback=False,
-                        min_message_id=0,
+                # Delegate format + uniqueness validation and persistence to
+                # create_user — single source of truth per Epic #98.
+                ok = create_user(
+                    username,
+                    password,
+                    first_name if first_name else username,
+                    last_name if last_name else "",
+                    role_id,
+                    email=email,
+                    organization=organization,
+                )
+                if ok:
+                    success_count += 1
+                else:
+                    failed_count += 1
+                    failed_users.append(
+                        f"{username}: create_user rejected (duplicate username/email, bad email format, or invalid input)"
                     )
 
-                    session.add(new_user)
-                    success_count += 1
-
-                except Exception as e:
-                    failed_count += 1
-                    failed_users.append(f"{row.get('username', f'Row {index + 2}')}: {str(e)}")
-                    logger.error(f"Error importing user at row {index + 2}: {e}")
-
-            # Commit all successful imports
-            session.commit()
+            except Exception as e:
+                failed_count += 1
+                failed_users.append(f"{row.get('username', f'Row {index + 2}')}: {str(e)}")
+                logger.error(f"Error importing user at row {index + 2}: {e}")
 
         # Display results
         if success_count > 0:
@@ -641,7 +645,10 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
 
             st.divider()
             st.markdown("**Bulk User Import**")
-            st.info("📁 Import users from Excel file: `./utils/config/user_list.xlsx`")
+            st.info(
+                "📁 Import users from Excel file: `./utils/config/user_list.xlsx`. "
+                "Required columns: UserID, start_password, First Name, Last Name, Email, Organization."
+            )
             st.caption("Expected columns: UserID, start_password, 'First Name ', 'Last Name '")
             if st.button("Import Users", type="primary", help="Import users from ./utils/config/user_list.xlsx"):
                 import_users()


### PR DESCRIPTION
## Summary

Closes #100. Second Feature Spec of Epic #98.

`import_users()` in `views/user.py` now reads the new required Email + Organization columns from the spreadsheet and switches per-row persistence from the raw `User(...)` constructor to `create_user()` — picking up the format / uniqueness validation gates delivered by #99 as the single source of truth.

## What's added

**`import_users()` updates:**
- Docstring updated to list the new required columns. Both `Email`/`email` and `Organization`/`organization` casings accepted.
- Two new pre-flight skips: missing email or missing organization → row skipped with a row-number-tagged failure.
- Per-row insertion switched from raw `User(...)` + `session.add()` to `create_user(...)` with the new keyword args. Previous duplicate-username pre-check removed (create_user owns it).
- Pre-loop `SessionLocal()` context now scopes only the role lookup; per-row sessions belong to `create_user`. Stray `session.commit()` after the loop removed.
- Streamlit info text for the bulk-import dropdown mentions the required columns.
- `hashlib` and `sqlalchemy.func` imports removed — both were only used by code paths that now live inside `create_user`.

**Module-load defensive guards (small spillover):**
- `views/user.py:30-50` wraps three module-level Streamlit accesses (`st.session_state.cookies.get`, `st.session_state.get`, `pvlog(...)`) in `try/except Exception` so the module stays importable when no Streamlit runtime is attached. Mirrors the same pattern in `orm/functions._get_current_user_id`. Behavior under a real runtime is unchanged.

**Test:**
- New `tests/views/test_user_import.py` — single end-to-end smoke test with a 7-row DataFrame (2 valid + 1 missing-email + 1 missing-organization + 1 malformed-email + 1 duplicate-username + 1 duplicate-email-case-insensitive). Uses the in-memory SQLite fixture, patches `views.user.SessionLocal` + `views.user.st` + `views.user.get_user_list_excel` + `orm.functions.st` + `os.path.exists`.

## Test plan

- [x] `tests/views/test_user_import.py` — single mixed-row smoke test, green.
- [x] Full suite `uv run pytest -m "not milvus"` — **1219 passing**, same 18 pre-existing environmental failures. No regressions.
- [x] Ruff: 3 pre-existing errors in `views/user.py` (down from 4 on main — my refactor removed the use of `hashlib` and `sqlalchemy.func` and I cleaned up the dangling imports). No new errors introduced.

## What's intentionally NOT in this PR

- Real Email + Organization input fields in the admin Create-User and Edit-User forms, plus the new "My Profile" self-edit section — Feature Spec #101.
- The placeholder kwargs in `views/user.py:623` (admin "Create New User" form) introduced in PR #102 stay in place until #101 replaces them with real inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)