### PR TITLE
fix(training): surface write_to_file_and_training failures to callers (#68)

### DIFF
--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -151,6 +151,7 @@ class TestAutoGenerateSqlPairs:
         from utils.vanna_calls import auto_generate_sql_pairs
 
         mock_from_session.return_value = mock_vanna_service
+        mock_write.return_value = True
         mock_st.progress.return_value = MagicMock()
         mock_st.empty.return_value = MagicMock()
 

--- a/tests/utils/test_auto_generate_sql_pairs.py
+++ b/tests/utils/test_auto_generate_sql_pairs.py
@@ -431,3 +431,40 @@ class TestAutoGenerateSqlPairs:
         assert results["passed"] == 0
         assert results["failed"] == 1
         assert "LLM generation failed" in results["details"][0]["reason"]
+
+    @patch("utils.vanna_calls.st")
+    @patch("utils.vanna_calls.write_to_file_and_training")
+    @patch("utils.vanna_calls.VannaService.from_streamlit_session")
+    def test_training_write_failure_counted_as_failed(self, mock_from_session, mock_write, mock_st, mock_vanna_service):
+        """If write_to_file_and_training returns False, the pair must be marked failed.
+
+        Regression test for issue #68: previously the function ignored the
+        return value of write_to_file_and_training, so a swallowed exception
+        was counted as a "passed" pair even though nothing was persisted.
+        """
+        from utils.vanna_calls import auto_generate_sql_pairs
+
+        mock_from_session.return_value = mock_vanna_service
+        mock_st.progress.return_value = MagicMock()
+        mock_st.empty.return_value = MagicMock()
+
+        # Generation + review both succeed, so we reach the training step.
+        mock_vanna_service.submit_prompt.side_effect = [
+            "QUESTION: How many patients?\nSQL: SELECT COUNT(*) FROM patients;",
+            "PASS",
+        ]
+        mock_vanna_service.vn.run_sql.return_value = pd.DataFrame({"count": [42]})
+        mock_vanna_service.check_references.return_value = "SELECT COUNT(*) FROM patients;"
+
+        # Simulate the training write itself failing.
+        mock_write.return_value = False
+
+        with patch("utils.security_validator.security_validator") as mock_sv:
+            mock_sv.validate_sql_content.return_value = (True, [])
+            results = auto_generate_sql_pairs(count=1)
+
+        mock_write.assert_called_once()
+        assert results["attempted"] == 1
+        assert results["passed"] == 0
+        assert results["failed"] == 1
+        assert "Training write failed" in results["details"][0]["reason"]

--- a/tests/utils/test_vanna_exception_handling.py
+++ b/tests/utils/test_vanna_exception_handling.py
@@ -319,7 +319,7 @@ class TestUtilityFunctionExceptions:
 
     @patch("streamlit.error")
     def test_write_to_file_and_training_exception(self, mock_st_error):
-        """Test that exceptions in write_to_file_and_training are handled properly."""
+        """Exceptions are caught, surfaced to the user, and reported as False."""
         # Mock all file operations to prevent them from affecting real files
         m = mock_open(read_data='{"sample_queries": [], "sample_documents": []}')
 
@@ -334,11 +334,34 @@ class TestUtilityFunctionExceptions:
             mock_get_instance.return_value = mock_service
             mock_service.train.side_effect = Exception("Training error")
 
-            # Should catch the exception
-            write_to_file_and_training({"question": "q", "query": "sql"})
+            # Should catch the exception and report failure to the caller
+            result = write_to_file_and_training({"question": "q", "query": "sql"})
 
+            assert result is False
             mock_st_error.assert_called_once()
             assert "Error writing to training_data.json" in mock_st_error.call_args[0][0]
+
+    @patch("streamlit.error")
+    def test_write_to_file_and_training_success_returns_true(self, mock_st_error):
+        """Successful training writes return True and do not surface any error."""
+        m = mock_open(read_data='{"sample_queries": [], "sample_documents": []}')
+
+        with (
+            patch("utils.vanna_calls.VannaService.from_streamlit_session") as mock_from_session,
+            patch("builtins.open", m),
+            patch("pathlib.Path.open", m),
+            patch("json.load", return_value={"sample_queries": [], "sample_documents": []}),
+            patch("json.dump") as mock_dump,
+        ):
+            mock_service = MagicMock()
+            mock_from_session.return_value = mock_service
+
+            result = write_to_file_and_training({"question": "new q", "query": "SELECT 1"})
+
+            assert result is True
+            mock_service.train.assert_called_once_with(question="new q", sql="SELECT 1")
+            mock_st_error.assert_not_called()
+            mock_dump.assert_called_once()
 
     @patch("streamlit.error")
     def test_remove_from_file_training_exception(self, mock_st_error):

--- a/tests/views/test_admin_feedback.py
+++ b/tests/views/test_admin_feedback.py
@@ -178,6 +178,7 @@ class TestApprovalWorkflow:
             mock_session.query.return_value.filter.return_value.first.return_value = mock_message
 
             with patch("views.admin_feedback.write_to_file_and_training") as mock_train:
+                mock_train.return_value = True
                 from views.admin_feedback import _approve_for_training
 
                 result = _approve_for_training(1, 2)
@@ -187,6 +188,43 @@ class TestApprovalWorkflow:
                 assert mock_message.training_status == "approved"
                 assert mock_message.reviewed_by == 2
                 mock_session.commit.assert_called_once()
+
+    def test_approve_for_training_training_failure_does_not_commit_approved(self):
+        """If write_to_file_and_training returns False, the DB must NOT advance to APPROVED.
+
+        Regression test for issue #68: previously the training write swallowed
+        all exceptions and returned None, so admin_feedback marked the message
+        APPROVED and committed even though nothing was persisted to ChromaDB.
+        """
+        original_status = "pending"
+        mock_message = MagicMock()
+        mock_message.question = "Test question"
+        mock_message.query = "SELECT * FROM test"
+        mock_message.training_status = original_status
+        mock_message.reviewed_by = None
+        mock_message.reviewed_at = None
+
+        with patch("views.admin_feedback.SessionLocal") as mock_session_local:
+            mock_session = MagicMock()
+            mock_session.__enter__ = MagicMock(return_value=mock_session)
+            mock_session.__exit__ = MagicMock(return_value=None)
+            mock_session_local.return_value = mock_session
+            mock_session.query.return_value.filter.return_value.first.return_value = mock_message
+
+            with patch("views.admin_feedback.write_to_file_and_training") as mock_train:
+                mock_train.return_value = False
+                from views.admin_feedback import _approve_for_training
+
+                result = _approve_for_training(1, 2)
+
+                assert result is False
+                mock_train.assert_called_once()
+                # In-memory status must be reverted to the original value.
+                assert mock_message.training_status == original_status
+                assert mock_message.reviewed_by is None
+                assert mock_message.reviewed_at is None
+                # Crucially: no commit happened, so the DB state did not advance.
+                mock_session.commit.assert_not_called()
 
     def test_reject_feedback_success(self):
         """Test that rejection updates status without training."""

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -2368,7 +2368,17 @@ def remove_from_file_training(new_entry: dict):
         logger.exception("Error removing entry from training_data.json: %s", e)
 
 
-def write_to_file_and_training(new_entry: dict):
+def write_to_file_and_training(new_entry: dict) -> bool:
+    """Persist a training pair to ChromaDB and the local training_data.json file.
+
+    Returns:
+        bool: True if the training write completed successfully, False if any
+        exception was caught. Callers that want to react to failures (e.g.,
+        avoid marking a record as APPROVED) should branch on this value.
+        Existing callers that ignore the return value continue to work
+        unchanged because the user-facing ``st.error`` message and exception
+        log are still emitted on failure.
+    """
     try:
         vanna_service = VannaService.from_streamlit_session()
         vanna_service.train(question=new_entry["question"], sql=new_entry["query"])
@@ -2393,9 +2403,11 @@ def write_to_file_and_training(new_entry: dict):
             pvlog("info", "New entry added to training_data.json", logger=logger)
         else:
             pvlog("info", "Duplicate entry found. No new entry added.", logger=logger)
+        return True
     except Exception as e:
         st.error(f"Error writing to training_data.json: {e}")
         logger.exception("%s", e)
+        return False
 
 
 def training_plan():
@@ -4015,8 +4027,13 @@ Does this result correctly answer the question? Respond PASS or FAIL."""
 
             # Step 5: Train the valid pair
             new_entry = {"question": question, "query": sql}
-            # write_to_file_and_training handles its own errors internally via st.error
-            write_to_file_and_training(new_entry)
+            # write_to_file_and_training returns False if the training write
+            # failed (the user-facing st.error and exception log are already
+            # emitted from inside the function). Treat that as a failed pair so
+            # we don't claim a successful training that never persisted.
+            if not write_to_file_and_training(new_entry):
+                _reject_pair(pair_detail, results, "Training write failed (see logs)")
+                continue
 
             pair_detail["status"] = "passed"
             results["passed"] += 1

--- a/views/admin_feedback.py
+++ b/views/admin_feedback.py
@@ -170,14 +170,21 @@ def _approve_for_training(message_id: int, reviewer_id: int) -> bool:
         # Trigger training before commit - if it fails, don't commit
         if message.question and message.query:
             new_entry = {"question": message.question, "query": message.query}
-            try:
-                write_to_file_and_training(new_entry)
-            except Exception:
-                # Revert status and log error
+            # write_to_file_and_training catches its own exceptions and shows a
+            # user-facing st.error; it returns False on failure. We must NOT
+            # advance training_status to APPROVED unless the underlying write
+            # actually succeeded, otherwise the DB will claim a pair was
+            # trained that never made it into ChromaDB / training_data.json.
+            if not write_to_file_and_training(new_entry):
+                # Revert in-memory status and bail out without committing so the
+                # approval stays pending and an admin can retry.
                 message.training_status = original_status
                 message.reviewed_by = None
                 message.reviewed_at = None
-                logger.exception("Failed to add message %s to training data", message_id)
+                logger.error(
+                    "Failed to add message %s to training data; approval not committed",
+                    message_id,
+                )
                 return False
 
         session.commit()


### PR DESCRIPTION
## Summary

`write_to_file_and_training()` in `utils/vanna_calls.py` previously caught all exceptions, displayed an `st.error(...)`, and returned `None` implicitly. Two callers had no way to detect the failure and silently advanced state as if training had succeeded:

- `auto_generate_sql_pairs()` counted the pair as "passed" even when the ChromaDB write failed.
- `_approve_for_training()` in `views/admin_feedback.py` set `training_status = APPROVED` and committed the change even though the vector store write never happened. The surrounding `try/except` could never fire because the inner function swallowed the exception.

This PR changes the contract of `write_to_file_and_training()` to return `bool` (True on success, False on failure) and updates both callers to branch on that value. The user-facing `st.error` message and exception log are unchanged, so other callers that ignore the return value (notably `utils/chat_bot_helper.py`) keep working as before.

Closes #68

## Changes Made

### `utils/vanna_calls.py`
- `write_to_file_and_training()` now returns `bool`. Success path returns `True`; the exception handler still calls `st.error(...)` (same wording) and `logger.exception(...)`, then returns `False`.
- `auto_generate_sql_pairs()` checks the return value and routes a `False` into the existing `_reject_pair(...)` failed-bucket path with reason `"Training write failed (see logs)"`.

### `views/admin_feedback.py`
- `_approve_for_training()` replaces the dead `try/except` (which could never fire because the inner function swallowed exceptions) with a bool check. On `False` it reverts the in-memory `training_status`, `reviewed_by`, and `reviewed_at` to their original values, logs an error, and returns `False` **without** calling `session.commit()`. The approval stays pending and the admin can retry.

### Tests
- `tests/utils/test_vanna_exception_handling.py` — existing failure-path test now asserts `result is False`; new `test_write_to_file_and_training_success_returns_true` covers the happy path.
- `tests/views/test_admin_feedback.py` — new `test_approve_for_training_training_failure_does_not_commit_approved` mocks the write to return `False` and asserts the session is **not** committed and the in-memory status is reverted.
- `tests/utils/test_auto_generate_sql_pairs.py` — new `test_training_write_failure_counted_as_failed` asserts a `False` return puts the pair in the failed bucket with the new reason string. Existing tests are unaffected because they use the default `MagicMock` return value, which is truthy.

## Design Decisions

The issue explicitly preferred a bool return over re-raising because it is **less disruptive** for callers that already ignore the return value. Both `utils/chat_bot_helper.py:492` (admin thumbs-up) and the equivalent code paths there continue to work unchanged — they still get the `st.error(...)` UI message and the exception log, they just don't react programmatically. Re-raising would have forced every caller to add a `try/except` or risk a bubbled exception in the Streamlit event loop.

Alternative considered: a sentinel object (e.g., `TrainingResult.SUCCESS`). Rejected as overengineered for a two-state outcome.

## Self-Review

A cynical second pass surfaced and corrected one thing:

- The original `except Exception` in `_approve_for_training` used `logger.exception(...)`, which captures the live traceback. After switching to a bool check there is no live exception in that branch, so `logger.exception` would log `NoneType: None`. Replaced with `logger.error(...)` (with a clearer message about the approval not being committed). The original traceback is still captured by the `logger.exception(...)` inside `write_to_file_and_training` itself.
- Verified the existing `auto_generate_sql_pairs` happy-path tests still pass — they rely on the default `MagicMock` return being truthy, which it is.
- Verified `utils/chat_bot_helper.py:492` (the third caller) is intentionally left alone per the issue's scope discipline.

## Testing

Test plan:

- [x] `uv run ruff check utils/vanna_calls.py views/admin_feedback.py tests/` — no new errors introduced by this change.
- [x] `uv run ruff format` on all changed files.
- [x] `uv run pytest -m "not milvus" tests/utils/test_vanna_exception_handling.py tests/views/test_admin_feedback.py tests/utils/test_auto_generate_sql_pairs.py -q` — 71 passed, 3 skipped.
- [x] Full suite: `uv run pytest -m "not milvus" --ignore=tests/sample_db/test_schema_matches_redshift.py --ignore=tests/utils/test_ollama_thinking_stream.py -q` — 1226 passed. The 3 failures + 10 errors all reproduce on `main` without these changes (Streamlit secrets / sqlite parameter env issues).
- [ ] Manual: trigger an admin approval with a forced ChromaDB write failure and confirm the message stays in `pending` state.

## Files Modified

- `utils/vanna_calls.py`
- `views/admin_feedback.py`
- `tests/utils/test_vanna_exception_handling.py`
- `tests/views/test_admin_feedback.py`
- `tests/utils/test_auto_generate_sql_pairs.py`