### PR TITLE
feat(theme): hide WellTellAI from user-facing theme selection (#108)

### DIFF
--- a/orm/models.py
+++ b/orm/models.py
@@ -193,7 +193,7 @@ class User(Base):
     confirm_magic_commands = Column(Boolean, default=True)  # True = show popup, False = auto-execute
     agentic_mode = Column(Boolean, default=True)
     min_message_id = Column(Integer, default=0)
-    theme = Column(String(50), default=ThemeType.WELLTELLAI.value)
+    theme = Column(String(50), default=ThemeType.THRIVEAI.value)
     selected_llm_provider = Column(String(50), default=None)
     selected_llm_model = Column(String(100), default=None)
 

--- a/tests/utils/test_enums.py
+++ b/tests/utils/test_enums.py
@@ -1,5 +1,5 @@
 import pytest
-from utils.enums import MessageType
+from utils.enums import MessageType, ThemeType, user_selectable_themes
 
 
 def test_tool_call_message_type_exists():
@@ -8,3 +8,21 @@ def test_tool_call_message_type_exists():
 
 def test_patient_chooser_message_type_exists():
     assert MessageType.PATIENT_CHOOSER.value == "patient_chooser"
+
+
+def test_user_selectable_themes_excludes_welltellai():
+    """#108 — WellTellAI must not appear in user-facing dropdowns."""
+    assert "WellTellAI" not in user_selectable_themes()
+
+
+def test_user_selectable_themes_includes_all_other_themes():
+    """Every ThemeType value other than WellTellAI must remain selectable."""
+    expected = [t.value for t in ThemeType if t.value != "WellTellAI"]
+    assert user_selectable_themes() == expected
+
+
+def test_welltellai_enum_member_still_parses():
+    """#108 — ThemeType.WELLTELLAI must stay in the enum so persisted DB
+    rows with theme='WellTellAI' continue to round-trip through the enum."""
+    assert ThemeType.WELLTELLAI.value == "WellTellAI"
+    assert ThemeType("WellTellAI") is ThemeType.WELLTELLAI

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -28,3 +28,11 @@ class ThemeType(Enum):
     THRIVEAI = "ThriveAI"
     WELLTELLAI = "WellTellAI"
     HEALTHELINK = "HEALTHeLINK"
+
+
+def user_selectable_themes() -> list[str]:
+    """Themes shown in user-facing dropdowns. WellTellAI is intentionally
+    excluded (#108) but remains in ThemeType so persisted DB rows still
+    parse — render-time fallback coerces them to the default theme."""
+    hidden = {ThemeType.WELLTELLAI.value}
+    return [t.value for t in ThemeType if t.value not in hidden]

--- a/utils/enums.py
+++ b/utils/enums.py
@@ -34,5 +34,5 @@ def user_selectable_themes() -> list[str]:
     """Themes shown in user-facing dropdowns. WellTellAI is intentionally
     excluded (#108) but remains in ThemeType so persisted DB rows still
     parse — render-time fallback coerces them to the default theme."""
-    hidden = {ThemeType.WELLTELLAI.value}
-    return [t.value for t in ThemeType if t.value not in hidden]
+    hidden = {ThemeType.WELLTELLAI}
+    return [t.value for t in ThemeType if t not in hidden]

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -26,7 +26,7 @@ from utils.magic_functions import is_magic_do_magic
 
 
 def get_themed_asset_path(asset_name):
-    theme = st.session_state.get("user_theme", ThemeType.WELLTELLAI.value).lower()
+    theme = st.session_state.get("user_theme", ThemeType.THRIVEAI.value).lower()
     return f"assets/themes/{theme}/{asset_name}"
 
 

--- a/views/user.py
+++ b/views/user.py
@@ -22,7 +22,7 @@ from orm.functions import (
 from orm.models import RoleTypeEnum, SessionLocal, User, UserRole
 from utils.authentication_management import get_user_list_excel
 from utils.chat_bot_helper import get_vn
-from utils.enums import ThemeType
+from utils.enums import ThemeType, user_selectable_themes
 from utils.vanna_calls import auto_generate_sql_pairs, refresh_stats, train_all
 
 # Get the current user ID from session state cookies. Guarded so the module
@@ -665,7 +665,7 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                 cu_role_name = st.selectbox(
                     "Role", options=role_names, index=role_names.index("Patient") if "Patient" in role_names else 0
                 )
-                theme_options = [t.value for t in ThemeType]
+                theme_options = user_selectable_themes()
                 cu_theme = st.selectbox("Theme", options=theme_options, index=0)
                 submitted = st.form_submit_button("Create User", type="primary")
                 if submitted:
@@ -853,7 +853,7 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                         options=role_names,
                         index=role_names.index(selected["role_name"]) if selected["role_name"] in role_names else 0,
                     )
-                    theme_options = [t.value for t in ThemeType]
+                    theme_options = user_selectable_themes()
                     current_theme = selected.get("theme", ThemeType.HEALTHELINK.value)
                     nu_theme = st.selectbox(
                         "Theme",


### PR DESCRIPTION
## Summary

The `WellTellAI` theme is removed from every user-facing dropdown while remaining a valid `ThemeType` enum member so persisted DB rows still parse. The new default is `ThriveAI`, applied to both the user table default and the chat-UI session-state fallback so theme-less or newly created users no longer silently re-acquire `WellTellAI`.

Closes #108

## Refinement decisions (applied)

1. **Replacement default:** `ThriveAI` — the primary product brand.
2. **No data migration.** Existing users with `theme = "WellTellAI"` keep their value in the DB; the render-time fallback coerces unknown themes safely, and the Edit User dropdown's existing `index=` guard falls back to index 0 when the stored value isn't in the filtered options list.
3. **Keep assets in tree.** `assets/themes/welltellai/` is untouched so the option can be re-enabled later without re-vendoring.
4. **Hide, don't remove.** `ThemeType.WELLTELLAI` stays in `utils/enums.py` so `ThemeType("WellTellAI")` continues to round-trip from the DB. A new `user_selectable_themes()` helper filters at the dropdown layer.

## Changes

- `utils/enums.py` — add `user_selectable_themes()` helper.
- `orm/models.py` — change `User.theme` default to `ThemeType.THRIVEAI.value`.
- `views/chat_bot.py` — change `get_themed_asset_path` fallback to `ThemeType.THRIVEAI.value`.
- `views/user.py` — Create User and Edit User dropdowns now call `user_selectable_themes()` instead of `[t.value for t in ThemeType]`. The Edit User selectbox's existing `index=theme_options.index(current_theme) if current_theme in theme_options else 0` guard already handles users whose stored theme is no longer in the filtered list.
- `tests/utils/test_enums.py` — three new tests:
  - `user_selectable_themes()` excludes `"WellTellAI"`.
  - `user_selectable_themes()` includes every other `ThemeType` value (order preserved).
  - `ThemeType.WELLTELLAI` and `ThemeType("WellTellAI")` still resolve.

## Design Decisions

Considered: (a) a module-level helper, (b) inlining the filter at each call site, (c) a classmethod on `ThemeType`. Picked (a) — matches the spec, centralizes the hidden-themes set, and gives one easy place to extend if more themes need to hide later. The Edit User dropdown is preserved with its existing `index=` guard so users currently storing `theme="WellTellAI"` see `ThriveAI` (index 0) instead of crashing on a `.index("WellTellAI")` against a list that no longer contains it.

## Self-Review

Cynical review checked LOGIC, EDGE CASES, SECURITY, CONVENTIONS, SCOPE, ERROR HANDLING, TESTS, and REGRESSIONS — all PASS. Specifically verified:

- `assets/themes/thriveai/` exists, so the chat-UI fallback path resolves cleanly.
- The Edit User selectbox's existing guard means an existing user with `theme="WellTellAI"` will see the dropdown default to `ThriveAI` (no crash).
- `tests/agent/test_session_reset.py` seeds `"user_theme": "welltellai"` and asserts the same value round-trips through the reset; that still passes (the test only checks the value is preserved, not what it is) so it's left untouched per spec.
- No new ruff findings introduced on the files I touched (pre-existing E402/E712/E722/F401/F541 errors on `main` are out of scope).

## Test plan

- [x] `uv run ruff check utils/enums.py orm/models.py views/chat_bot.py views/user.py tests/` — only pre-existing findings on `main` remain; no new findings on lines I touched.
- [x] `uv run ruff format utils/enums.py orm/models.py views/chat_bot.py views/user.py tests/utils/test_enums.py` — no changes needed.
- [x] `uv run pytest -m "not milvus" --ignore=tests/sample_db/test_schema_matches_redshift.py --ignore=tests/utils/test_ollama_thinking_stream.py -q` — 1226 passed; 3 pre-existing environmental failures (missing `secrets.toml`, missing `thrive_user` sqlite table, missing `cookies` in session state) and 10 unrelated errors in `test_vanna_ddl_training.py` / `TestGetChart` — none touch the surfaces this PR changes.
- [x] `uv run pytest tests/utils/test_enums.py tests/agent/test_session_reset.py -v` — 38 passed (the 3 new tests + the entire session-reset suite).
- [x] Smoke test: `python -c "from utils.enums import user_selectable_themes, ThemeType; print(user_selectable_themes()); print(ThemeType('WellTellAI'))"` returns `['ThriveAI', 'HEALTHeLINK']` and `ThemeType.WELLTELLAI`.
- [ ] Browser smoke test of admin Create User / Edit User forms left to the reviewer (the test environment has no `secrets.toml` so a live Streamlit run isn't reproducible here).

## Files modified

- `utils/enums.py`
- `orm/models.py`
- `views/chat_bot.py`
- `views/user.py`
- `tests/utils/test_enums.py`