### PR TITLE
fix(training): replace removed get_vn() in auto_enhance_schema (#111)

### DIFF
--- a/tests/utils/test_auto_enhance_schema.py
+++ b/tests/utils/test_auto_enhance_schema.py
@@ -1,0 +1,118 @@
+"""Regression tests for auto_enhance_schema().
+
+Issue #111: `auto_enhance_schema` called the long-removed `get_vn()` helper
+instead of `VannaService.from_streamlit_session()`, so train_all step 3 always
+raised NameError and was silently swallowed. These tests pin the call site to
+the correct factory so the regression cannot reappear.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+MOCK_SECRETS = {
+    "ai_keys": {"ollama_model": "test_model"},
+    "rag_model": {"chroma_path": "/tmp/test_chroma"},
+    "postgres": {
+        "host": "localhost",
+        "port": 5432,
+        "database": "test_db",
+        "user": "test_user",
+        "password": "test_pass",
+        "schema_name": "public",
+        "object_type": "tables",
+    },
+}
+
+
+class TestAutoEnhanceSchemaInvocation:
+    """Pin the call site at utils/vanna_calls.py:auto_enhance_schema()."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_streamlit(self):
+        status_cm = MagicMock()
+        status_cm.__enter__ = MagicMock(return_value=status_cm)
+        status_cm.__exit__ = MagicMock(return_value=False)
+        with (
+            patch("utils.vanna_calls.st.toast"),
+            patch("utils.vanna_calls.st.write"),
+            patch("utils.vanna_calls.st.success"),
+            patch("utils.vanna_calls.st.warning"),
+            patch("utils.vanna_calls.st.error"),
+            patch("utils.vanna_calls.st.status", return_value=status_cm),
+        ):
+            yield
+
+    def test_uses_vannaservice_factory_not_legacy_get_vn(self):
+        """Regression for #111: the function must call
+        ``VannaService.from_streamlit_session()`` rather than the removed
+        ``get_vn()`` helper.
+        """
+        from utils import vanna_calls
+
+        assert not hasattr(vanna_calls, "get_vn"), (
+            "get_vn was removed from the module; auto_enhance_schema must not reference it (issue #111)."
+        )
+
+        mock_service = MagicMock()
+        mock_service.get_training_data.return_value = pd.DataFrame()
+
+        with (
+            patch("utils.vanna_calls.st.secrets", new=MOCK_SECRETS),
+            patch(
+                "utils.vanna_calls.VannaService.from_streamlit_session",
+                return_value=mock_service,
+            ) as mock_factory,
+            patch(
+                "utils.vanna_calls.read_forbidden_from_json",
+                return_value=([], [], ""),
+            ),
+        ):
+            # Should not raise NameError. The function may early-exit because
+            # of empty mocks; that's fine — we only pin the factory call.
+            try:
+                vanna_calls.auto_enhance_schema(clear_existing=True)
+            except NameError as e:
+                pytest.fail(f"auto_enhance_schema raised NameError (issue #111 regression): {e}")
+            except Exception:
+                # Any other exception is acceptable for this regression test —
+                # we are only proving that the call site no longer references
+                # an undefined name.
+                pass
+
+        mock_factory.assert_called_once()
+
+    def test_clear_existing_path_does_not_raise_nameerror(self):
+        """The ``clear_existing=True`` branch was where the NameError lived.
+
+        Confirm the path executes far enough to call get_training_data on the
+        VannaService instance returned by from_streamlit_session — proving the
+        first statement of the function resolved a real callable, not the
+        deleted ``get_vn`` symbol.
+        """
+        from utils import vanna_calls
+
+        mock_service = MagicMock()
+        mock_service.get_training_data.return_value = pd.DataFrame()
+
+        with (
+            patch("utils.vanna_calls.st.secrets", new=MOCK_SECRETS),
+            patch(
+                "utils.vanna_calls.VannaService.from_streamlit_session",
+                return_value=mock_service,
+            ),
+            patch(
+                "utils.vanna_calls.read_forbidden_from_json",
+                return_value=([], [], ""),
+            ),
+        ):
+            try:
+                vanna_calls.auto_enhance_schema(clear_existing=True)
+            except NameError as e:
+                pytest.fail(f"auto_enhance_schema raised NameError on clear_existing path: {e}")
+            except Exception:
+                pass
+
+        mock_service.get_training_data.assert_called()

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -3295,7 +3295,7 @@ def auto_enhance_schema(clear_existing: bool = True):
         clear_existing: If True, remove existing auto-enhance documentation before
             re-adding (prevents duplicates on repeated runs). Defaults to True.
     """
-    vanna_service = get_vn()
+    vanna_service = VannaService.from_streamlit_session()
     forbidden_tables, forbidden_columns, forbidden_tables_str = read_forbidden_from_json()
     schema_name = get_configured_schema()
     object_type = get_configured_object_type()


### PR DESCRIPTION
Closes #111.

## Summary
One-line fix at `utils/vanna_calls.py:3298` — replaces the removed `get_vn()` helper with the current factory `VannaService.from_streamlit_session()`. Every \`Train All\` since commit \`87a1b967\` (2026-04-17) had step 3 (Auto-Enhance) crash with \`NameError\`, silently swallowed by \`train_all\`'s per-step \`try/except\`. Users never saw a UI error but lost the schema-enrichment that step 3 contributes (FK relationships, index docs, column stats, sample values, implicit relationships, structured docs, join paths, view docs).

## Changes
- \`utils/vanna_calls.py\`: \`get_vn()\` → \`VannaService.from_streamlit_session()\`.
- \`tests/utils/test_auto_enhance_schema.py\`: new regression suite. Two tests:
  1. \`test_uses_vannaservice_factory_not_legacy_get_vn\` — asserts the module no longer exports \`get_vn\`, mocks the factory, calls the function with \`clear_existing=True\`, and fails on \`NameError\`.
  2. \`test_clear_existing_path_does_not_raise_nameerror\` — confirms the \`clear_existing=True\` branch (where the NameError lived) executes far enough to invoke \`vanna_service.get_training_data()\`.

## Test plan
- \`uv run pytest tests/utils/test_auto_enhance_schema.py -q\` → 2 passed.
- \`uv run pytest -m \"not milvus\" --ignore=tests/sample_db/test_schema_matches_redshift.py --ignore=tests/utils/test_ollama_thinking_stream.py -q\` → 1266 passed (no regressions).
- \`uv run ruff check utils/vanna_calls.py\` → only 2 pre-existing unused-variable warnings at lines 2586 and 2716, unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)