### PR TITLE
fix(chat): /clear and sidebar Clear no longer crash the page (#113)

### DIFF
--- a/tests/utils/test_clear_messages_regression.py
+++ b/tests/utils/test_clear_messages_regression.py
@@ -1,0 +1,70 @@
+"""Regression test for issue #113.
+
+When the user clicked the sidebar **Clear** button or typed the `/clear` magic
+command, `set_question(None)` set `st.session_state.messages = None`. On the
+very next render, `get_unique_messages()` crashed with:
+
+    TypeError: 'NoneType' object is not iterable
+
+The fix changes the reset value to an empty list. This test pins the contract
+so it cannot silently regress to `None`.
+"""
+
+import types
+from contextlib import nullcontext
+
+
+def _fake_st_with_message():
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    fake_msg = types.SimpleNamespace(id=42, role="user", content="hello")
+    st.session_state.update({"messages": [fake_msg], "min_message_id": 0})
+
+    st.chat_message = lambda *_a, **_k: nullcontext()
+    st.empty = lambda: None
+    st.rerun = lambda: None
+    st.toast = lambda *_a, **_k: None
+    st.markdown = lambda *_a, **_k: None
+    return st
+
+
+def test_set_question_none_leaves_messages_as_empty_list(monkeypatch):
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st_with_message()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "save_user_settings", lambda: None)
+
+    cbh.set_question(None)
+
+    # Must be an empty list, not None — otherwise get_unique_messages crashes
+    assert fake_st.session_state.messages == []
+    assert fake_st.session_state.messages is not None
+    assert fake_st.session_state.my_question is None
+    assert fake_st.session_state.min_message_id == 42
+
+
+def test_get_unique_messages_after_clear_does_not_crash(monkeypatch):
+    """End-to-end: clearing then calling get_unique_messages must not raise."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st_with_message()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "save_user_settings", lambda: None)
+
+    cbh.set_question(None)
+
+    # Before the fix this raised TypeError: 'NoneType' object is not iterable
+    result = cbh.get_unique_messages()
+    assert result == []

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -428,7 +428,7 @@ def set_question(question: str, render=True):
             save_user_settings()
             # Clear questions history when resetting
             st.session_state.my_question = None
-            st.session_state.messages = None
+            st.session_state.messages = []
 
     else:
         # For /followup commands, use the previous group to keep messages together


### PR DESCRIPTION
Closes #113.

## Summary
- `set_question(None)` was assigning `st.session_state.messages = None`, which crashed `get_unique_messages()` on the next render with `TypeError: 'NoneType' object is not iterable` (`utils/chat_bot_helper.py:464`).
- This bug affected the only two user-facing ways to clear chat history: the sidebar **Clear** button and the `/clear` magic command.
- The fix resets `messages` to `[]`, matching the convention every other reset site already uses (`utils/auth.py:83`, `utils/okta_auth.py:356`, `agent/session_reset.py:53`, `views/chat_bot.py:164`).
- Adds two regression tests pinning the contract.

## Test plan
- [x] `uv run pytest tests/utils/test_clear_messages_regression.py -v` (2/2 pass)
- [x] `uv run pytest tests/utils/test_message_ordering.py tests/utils/test_friendly_errors.py tests/utils/test_sql_error_persistence.py` (27/27 pass — adjacent suites unaffected)
- [ ] Manual: click sidebar **Clear** with messages present → no traceback
- [ ] Manual: type `/clear` with messages present → no traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)