### PR TITLE
fix(chat): wire follow-up magic commands into legacy non-agentic flow (#114)

### DIFF
--- a/tests/utils/test_followup_legacy_dispatch.py
+++ b/tests/utils/test_followup_legacy_dispatch.py
@@ -85,6 +85,24 @@ def test_get_last_assistant_dataframe_returns_none_when_no_history(monkeypatch):
     assert cbh.get_last_assistant_dataframe() is None
 
 
+def test_get_last_assistant_dataframe_returns_none_on_corrupt_most_recent(monkeypatch):
+    """If the newest assistant df is corrupt, return None — never silently fall back
+    to an older frame, which would mislead the caller into running follow-up commands
+    against stale data."""
+    import utils.chat_bot_helper as cbh
+
+    df_old = pd.DataFrame({"a": [1, 2, 3]})
+    messages = [
+        _FakeMessage("assistant", dataframe=df_old.to_json(date_format="iso")),
+        _FakeMessage("user"),
+        _FakeMessage("assistant", dataframe="not-valid-json{["),  # newest, corrupt
+    ]
+    fake_st = _fake_st(messages)
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    assert cbh.get_last_assistant_dataframe() is None
+
+
 def test_get_last_assistant_dataframe_tolerates_messages_none(monkeypatch):
     """Defensive: session_state.messages can legitimately be missing at boot."""
     import utils.chat_bot_helper as cbh

--- a/tests/utils/test_followup_legacy_dispatch.py
+++ b/tests/utils/test_followup_legacy_dispatch.py
@@ -1,0 +1,200 @@
+"""Regression tests for issue #114.
+
+`FOLLOW_UP_MAGIC_RENDERERS` was unreachable in non-agentic mode because
+`views/chat_bot.py` only forwarded a `previous_df` when `agentic_mode=True`.
+The fix:
+
+1. Adds `get_last_assistant_dataframe()` to recover the most recent dataframe
+   from session-state message history.
+2. Restructures `is_magic_do_magic()` so the main MAGIC_RENDERERS and the
+   FOLLOW_UP_MAGIC_RENDERERS are checked independently — the slash commands
+   are no longer suppressed when a `previous_df` is supplied.
+
+These tests pin the new dispatch contract.
+"""
+
+import types
+from contextlib import nullcontext
+
+import pandas as pd
+
+
+def _fake_st(messages=None):
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    st.session_state.update({"messages": messages or [], "agentic_mode": False})
+
+    # Make st.secrets behave like a dict supporting `.get(key, default)`.
+    st.secrets = {"features": {"semantic_magic_enabled": False}}
+
+    st.chat_message = lambda *_a, **_k: nullcontext()
+    st.empty = lambda: None
+    st.rerun = lambda: None
+    st.stop = lambda: None
+    st.markdown = lambda *_a, **_k: None
+    st.toast = lambda *_a, **_k: None
+    st.write = lambda *_a, **_k: None
+    return st
+
+
+class _FakeMessage:
+    def __init__(self, role, dataframe=None):
+        self.role = role
+        self.dataframe = dataframe
+
+
+# ---------------- get_last_assistant_dataframe ----------------
+
+
+def test_get_last_assistant_dataframe_returns_most_recent(monkeypatch):
+    import utils.chat_bot_helper as cbh
+
+    df_old = pd.DataFrame({"a": [1]})
+    df_new = pd.DataFrame({"b": [2, 3]})
+    messages = [
+        _FakeMessage("user"),
+        _FakeMessage("assistant", dataframe=df_old.to_json(date_format="iso")),
+        _FakeMessage("user"),
+        _FakeMessage("assistant", dataframe=df_new.to_json(date_format="iso")),
+        _FakeMessage("assistant"),  # no dataframe, ignored
+    ]
+    fake_st = _fake_st(messages)
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    out = cbh.get_last_assistant_dataframe()
+    assert out is not None
+    assert list(out.columns) == ["b"]
+    assert out["b"].tolist() == [2, 3]
+
+
+def test_get_last_assistant_dataframe_returns_none_when_no_history(monkeypatch):
+    import utils.chat_bot_helper as cbh
+
+    monkeypatch.setattr(cbh, "st", _fake_st([]))
+    assert cbh.get_last_assistant_dataframe() is None
+
+
+def test_get_last_assistant_dataframe_tolerates_messages_none(monkeypatch):
+    """Defensive: session_state.messages can legitimately be missing at boot."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st(None)
+    # Don't seed messages at all
+    fake_st.session_state.pop("messages", None)
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    assert cbh.get_last_assistant_dataframe() is None
+
+
+# ---------------- is_magic_do_magic dispatch ----------------
+
+
+def test_slash_command_still_works_when_previous_df_set(monkeypatch):
+    """Regression: providing a previous_df must not suppress MAGIC_RENDERERS."""
+    import utils.magic_functions as mf
+
+    monkeypatch.setattr(mf, "st", _fake_st())
+    monkeypatch.setattr(mf, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(mf, "get_current_group_id", lambda: None)
+
+    calls = []
+
+    def fake_help(question, params, previous_df):
+        calls.append(("help", question, previous_df))
+
+    # Patch the bound function via the registry, not by name
+    original = mf.MAGIC_RENDERERS[r"^/help$"]["func"]
+    mf.MAGIC_RENDERERS[r"^/help$"]["func"] = fake_help
+    try:
+        df = pd.DataFrame({"x": [1, 2]})
+        handled = mf.is_magic_do_magic("/help", previous_df=df)
+    finally:
+        mf.MAGIC_RENDERERS[r"^/help$"]["func"] = original
+
+    assert handled is True
+    assert calls == [("help", "/help", None)], (
+        "Slash command must route to MAGIC_RENDERERS with previous_df=None even when "
+        "a previous dataframe is supplied"
+    )
+
+
+def test_bare_followup_command_dispatches_when_previous_df_set(monkeypatch):
+    """`head 3` should route to FOLLOW_UP_MAGIC_RENDERERS when previous_df is set."""
+    import utils.magic_functions as mf
+
+    monkeypatch.setattr(mf, "st", _fake_st())
+    monkeypatch.setattr(mf, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(mf, "get_current_group_id", lambda: None)
+
+    calls = []
+
+    def fake_head(question, params, previous_df):
+        calls.append((question, params, previous_df))
+
+    pattern = r"^head\s+(?P<num_rows>\d+)$"
+    original = mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"]
+    mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"] = fake_head
+    try:
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        handled = mf.is_magic_do_magic("head 3", previous_df=df)
+    finally:
+        mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"] = original
+
+    assert handled is True
+    assert len(calls) == 1
+    question, params, df_arg = calls[0]
+    assert question == "head 3"
+    assert params == {"num_rows": "3"}
+    assert df_arg is df, "FOLLOW_UP handler must receive the supplied previous_df"
+
+
+def test_bare_followup_command_ignored_when_no_previous_df(monkeypatch):
+    """`head 3` with no prior dataframe must NOT match — falls through to LLM."""
+    import utils.magic_functions as mf
+
+    monkeypatch.setattr(mf, "st", _fake_st())
+    monkeypatch.setattr(mf, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(mf, "get_current_group_id", lambda: None)
+
+    calls = []
+    pattern = r"^head\s+(?P<num_rows>\d+)$"
+    original = mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"]
+    mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"] = lambda *a, **k: calls.append(a)
+    try:
+        handled = mf.is_magic_do_magic("head 3", previous_df=None)
+    finally:
+        mf.FOLLOW_UP_MAGIC_RENDERERS[pattern]["func"] = original
+
+    assert handled is False
+    assert calls == []
+
+
+def test_slash_command_without_previous_df_still_works(monkeypatch):
+    """Baseline guard — the legacy non-agentic slash-command path is unchanged."""
+    import utils.magic_functions as mf
+
+    monkeypatch.setattr(mf, "st", _fake_st())
+    monkeypatch.setattr(mf, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(mf, "get_current_group_id", lambda: None)
+
+    calls = []
+    original = mf.MAGIC_RENDERERS[r"^/help$"]["func"]
+    mf.MAGIC_RENDERERS[r"^/help$"]["func"] = lambda q, p, df: calls.append((q, df))
+    try:
+        handled = mf.is_magic_do_magic("/help", previous_df=None)
+    finally:
+        mf.MAGIC_RENDERERS[r"^/help$"]["func"] = original
+
+    assert handled is True
+    assert calls == [("/help", None)]

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -477,6 +477,10 @@ def get_last_assistant_dataframe():
     Used to drive `FOLLOW_UP_MAGIC_RENDERERS` in the legacy (non-agentic) chat flow so
     bare follow-up commands like `head 3` or `distribution glucose` can operate on the
     previous result without requiring agentic mode.
+
+    If the most recent assistant message carrying a `dataframe` payload fails to decode,
+    return None — never silently fall back to an older message, which would mislead the
+    caller into running a follow-up against stale data.
     """
     messages = st.session_state.get("messages") or []
     for msg in reversed(messages):
@@ -484,7 +488,7 @@ def get_last_assistant_dataframe():
             try:
                 return pd.read_json(StringIO(msg.dataframe))
             except Exception:
-                continue
+                return None
     return None
 
 

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -471,6 +471,23 @@ def get_unique_messages():
     return unique_messages
 
 
+def get_last_assistant_dataframe():
+    """Return the most recent assistant message's DataFrame (decoded from JSON), or None.
+
+    Used to drive `FOLLOW_UP_MAGIC_RENDERERS` in the legacy (non-agentic) chat flow so
+    bare follow-up commands like `head 3` or `distribution glucose` can operate on the
+    previous result without requiring agentic mode.
+    """
+    messages = st.session_state.get("messages") or []
+    for msg in reversed(messages):
+        if msg.role == RoleType.ASSISTANT.value and getattr(msg, "dataframe", None):
+            try:
+                return pd.read_json(StringIO(msg.dataframe))
+            except Exception:
+                continue
+    return None
+
+
 def set_feedback(index: int, value: str, feedback_comment: str = None):
     message = st.session_state.messages[index]
     message.feedback = value

--- a/utils/magic_functions.py
+++ b/utils/magic_functions.py
@@ -476,7 +476,28 @@ def is_magic_do_magic(question, previous_df=None):
             st.session_state["semantic_magic_result"] = None
             return False  # User declined, proceed to normal flow
 
-        # STEP 1: Try exact regex matching (existing behavior - highest priority)
+        # STEP 1a: Try main MAGIC_RENDERERS first — handles /-prefixed commands
+        # (/help, /tables, /describe, …) plus the bare `loop` and history-search.
+        # These are always available, regardless of whether a previous dataframe exists.
+        for key, meta in MAGIC_RENDERERS.items():
+            match = re.match(key, question)  # .strip()
+            if match:
+                if meta["func"] != _followup and meta["func"] != _history_search:
+                    add_message(
+                        Message(
+                            RoleType.ASSISTANT,
+                            "Sounds like magic!",
+                            MessageType.TEXT,
+                            group_id=get_current_group_id(),
+                        )
+                    )
+                meta["func"](question, match.groupdict(), None)
+                return True
+
+        # STEP 1b: If a previous dataframe is available, try FOLLOW_UP_MAGIC_RENDERERS
+        # for bare follow-up syntax (`head 3`, `distribution glucose`, `heatmap`, …).
+        # Available in both legacy and agentic modes — the caller is responsible for
+        # supplying previous_df from session history.
         if previous_df is not None:
             for key, meta in FOLLOW_UP_MAGIC_RENDERERS.items():
                 match = re.match(key, question.strip())
@@ -491,31 +512,16 @@ def is_magic_do_magic(question, previous_df=None):
                     )
                     meta["func"](question, match.groupdict(), previous_df)
                     return True
-        else:
-            for key, meta in MAGIC_RENDERERS.items():
-                match = re.match(key, question)  # .strip()
-                if match:
-                    if meta["func"] != _followup and meta["func"] != _history_search:
-                        add_message(
-                            Message(
-                                RoleType.ASSISTANT,
-                                "Sounds like magic!",
-                                MessageType.TEXT,
-                                group_id=get_current_group_id(),
-                            )
-                        )
-                    meta["func"](question, match.groupdict(), None)
-                    return True
 
-        # STEP 2: Semantic classification for non-regex queries
-        # Skip semantic classification for follow-up context (previous_df is set)
-        # Also check feature flag
+        # STEP 2: Semantic classification for non-regex queries.
+        # Gated on the agentic_mode toggle (agent handles natural language directly)
+        # and the feature flag. Runs in legacy mode regardless of whether a previous
+        # dataframe is available — the classifier targets MAGIC_RENDERERS (slash
+        # commands), which are independent of follow-up state.
         semantic_enabled = st.secrets.get("features", {}).get("semantic_magic_enabled", True)
-        # In agentic mode, skip the LLM classifier — the agent handles natural language.
-        # Literal slash commands (handled in STEP 1 above) still work.
         if st.session_state.get("agentic_mode", False):
             semantic_enabled = False
-        if previous_df is None and semantic_enabled:
+        if semantic_enabled:
             from utils.semantic_magic_service import SemanticMagicService
 
             result = SemanticMagicService.classify(question, MAGIC_RENDERERS)

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -11,6 +11,7 @@ from orm.functions import (
     update_user_preferences,
 )
 from utils.chat_bot_helper import (
+    get_last_assistant_dataframe,
     get_message_group_css,
     get_unique_messages,
     get_vn,
@@ -528,10 +529,13 @@ my_question = st.session_state.get("my_question", None)
 # No persistent panel / st.stop() needed — users can also just type a new question.
 
 if my_question:
+    # Surface the previous result for follow-up magic commands (`head 3`,
+    # `distribution glucose`, …). Agentic mode keeps its session-state df;
+    # legacy mode pulls the latest assistant message's dataframe from history.
     if st.session_state.get("agentic_mode", False):
         previous_df = st.session_state.get("df")
     else:
-        previous_df = None
+        previous_df = get_last_assistant_dataframe()
     magic_response = is_magic_do_magic(my_question, previous_df=previous_df)
     if magic_response == True:
         st.stop()


### PR DESCRIPTION
Closes #114.

## Summary
Bare follow-up commands documented by `/followuphelp` — `head 3`, `distribution glucose`, `heatmap`, `describe`, … — never reached `FOLLOW_UP_MAGIC_RENDERERS` in legacy mode. Two intertwined causes:

1. `views/chat_bot.py` only supplied a `previous_df` when `agentic_mode=True`.
2. `is_magic_do_magic` used an exclusive `if/else` so any `previous_df` suppressed the main `MAGIC_RENDERERS` (slash commands).

That second bug means even agentic mode lost `/describe`, `/head`, etc. once the agent had a stored dataframe.

## Changes
- **`utils/chat_bot_helper.py`** — adds `get_last_assistant_dataframe()` that scans `st.session_state.messages` in reverse for the most recent assistant message carrying a DataFrame (JSON-decoded back via `pd.read_json(StringIO(...))`).
- **`views/chat_bot.py`** — in legacy mode, derive `previous_df` from history so follow-up dispatch is reachable.
- **`utils/magic_functions.py`** — `is_magic_do_magic` now checks `MAGIC_RENDERERS` first (independent of `previous_df`), then `FOLLOW_UP_MAGIC_RENDERERS` when a dataframe is supplied. Drops the `previous_df is None` gate on the semantic classifier (the `agentic_mode` toggle already handles its skip case).
- **`tests/utils/test_followup_legacy_dispatch.py`** — 7 new regression tests covering the helper and the new dispatch precedence.

## Behavior matrix

| input | previous_df | legacy before | legacy after | agentic before | agentic after |
|---|---|---|---|---|---|
| `/help` | none | MAGIC ✅ | MAGIC ✅ | MAGIC ✅ | MAGIC ✅ |
| `/help` | set  | MAGIC ✅ (df unused) | MAGIC ✅ | **fell through** ❌ | MAGIC ✅ |
| `head 3` | none | LLM (fallthrough) | LLM (fallthrough) | LLM | LLM |
| `head 3` | set  | **unreachable** ❌ | FOLLOW_UP ✅ | FOLLOW_UP ✅ | FOLLOW_UP ✅ |

## Test plan
- [x] `uv run pytest tests/utils/test_followup_legacy_dispatch.py -v` (7/7 pass)
- [x] `uv run pytest tests/utils/test_semantic_magic.py tests/agent/flows/test_slash_command_compat.py tests/utils/test_message_ordering.py` (31/31 pass — adjacent suites unaffected)
- [x] `uv run ruff check` clean on all 4 changed files
- [ ] Manual: legacy mode, run `/head diabetes.5` → result. Then type `head 3` → returns 3 rows of same table via FOLLOW_UP handler
- [ ] Manual: legacy mode, `/help` after a prior result still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)