### PR TITLE
feat(sql): dialect switch for Postgres vs Redshift

### DIFF
--- a/.streamlit/secrets_example.toml
+++ b/.streamlit/secrets_example.toml
@@ -44,7 +44,13 @@ password = "postgres"
 object_type = "tables"
 ## Database schema to query: default is "public"
 schema_name = "public"
-dialect = "redshift"
+## SQL dialect the LLM should emit. "postgresql" (default) for local Postgres,
+## "redshift" when deployed against an Amazon Redshift cluster (which speaks
+## the Postgres wire protocol but lacks STRING_AGG, CORR, array_position, etc.).
+## Read by every Vanna backend in utils/vanna_calls.py — the system prompt is
+## adjusted to include a Redshift cheat-sheet, and a few hardcoded
+## introspection queries branch to LISTAGG.
+# dialect = "postgresql"
 
 [analytics_db]
 ## Read-only warehouse the agent's clinical-data tools query against.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,11 @@ user = "postgres"
 password = "postgres"
 schema_name = "public"
 object_type = "tables"   # or "views"
+# dialect = "postgresql" # "postgresql" (default) or "redshift" — controls the
+                         # SQL dialect the LLM is prompted to emit. When set to
+                         # "redshift" the system prompt includes a cheat-sheet
+                         # (LISTAGG vs STRING_AGG, no CORR, etc.) and the
+                         # hardcoded index-introspection query branches.
 
 [analytics_db]
 # Read-only warehouse the agent's clinical-data tools query against.

--- a/tests/utils/test_dialect_switch.py
+++ b/tests/utils/test_dialect_switch.py
@@ -1,0 +1,218 @@
+"""Tests for the Postgres/Redshift dialect switch.
+
+Dialect is configured via [postgres].dialect in secrets.toml. It must
+propagate to every Vanna backend so the LLM system prompt names the
+right warehouse, and the few hardcoded introspection queries we own
+(STRING_AGG vs LISTAGG, etc.) must branch on it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from utils.thriveai_base import ThriveAI_Base
+from utils.vanna_calls import (
+    MyVannaAnthropicChromaDB,
+    MyVannaGeminiChromaDB,
+    MyVannaOllamaChromaDB,
+    VannaService,
+    extract_vanna_config_from_secrets,
+)
+
+
+# ---------- shared fixtures ----------
+
+
+def _secrets_dict(test_chromadb_path: str, dialect: str | None) -> dict:
+    postgres: dict = {
+        "host": "localhost",
+        "port": 5432,
+        "database": "thrive",
+        "user": "postgres",
+        "password": "postgres",
+    }
+    if dialect is not None:
+        postgres["dialect"] = dialect
+    return {
+        "ai_keys": {
+            "ollama_model": "llama3",
+            "vanna_api": "mock_vanna_api",
+            "vanna_model": "mock_vanna_model",
+            "anthropic_api": "mock_anthropic_api",
+            "anthropic_model": "claude-3-sonnet-20240229",
+            "gemini_model": "gemini-1.5-flash",
+            "gemini_api": "mock_gemini_api",
+        },
+        "rag_model": {"chroma_path": test_chromadb_path},
+        "postgres": postgres,
+        "security": {"allow_llm_to_see_data": True},
+    }
+
+
+@pytest.fixture
+def secrets_with_redshift_dialect(test_chromadb_path):
+    with patch("streamlit.secrets", new=_secrets_dict(test_chromadb_path, "redshift")):
+        yield
+
+
+@pytest.fixture
+def secrets_without_dialect(test_chromadb_path):
+    with patch("streamlit.secrets", new=_secrets_dict(test_chromadb_path, None)):
+        yield
+
+
+# ---------- config extraction ----------
+
+
+def test_extract_vanna_config_passes_dialect_through(secrets_with_redshift_dialect):
+    config = extract_vanna_config_from_secrets()
+    assert config["postgres"]["dialect"] == "redshift"
+
+
+def test_extract_vanna_config_omits_dialect_when_unset(secrets_without_dialect):
+    config = extract_vanna_config_from_secrets()
+    # Caller treats absence as "postgresql".
+    assert "dialect" not in config["postgres"]
+
+
+# ---------- backend dialect propagation ----------
+
+
+def test_ollama_chromadb_sets_self_dialect_from_secrets(secrets_with_redshift_dialect, test_chromadb_path):
+    with (
+        patch("utils.vanna_calls.ThriveAI_ChromaDB.__init__", return_value=None),
+        patch("utils.vanna_calls.Ollama.__init__", return_value=None),
+        patch("utils.vanna_calls.ThriveAI_Ollama.__init__", return_value=None),
+    ):
+        backend = MyVannaOllamaChromaDB(user_role=1, config={"path": test_chromadb_path})
+        assert backend.dialect == "redshift"
+
+
+def test_anthropic_chromadb_sets_self_dialect_from_secrets(secrets_with_redshift_dialect, test_chromadb_path):
+    with (
+        patch("utils.vanna_calls.ThriveAI_ChromaDB.__init__", return_value=None),
+        patch("utils.vanna_calls.Anthropic_Chat.__init__", return_value=None),
+    ):
+        backend = MyVannaAnthropicChromaDB(user_role=1, config={"path": test_chromadb_path})
+        assert backend.dialect == "redshift"
+
+
+def test_gemini_chromadb_sets_self_dialect_from_secrets(secrets_with_redshift_dialect, test_chromadb_path):
+    with (
+        patch("utils.vanna_calls.ThriveAI_ChromaDB.__init__", return_value=None),
+        patch("utils.vanna_calls.GoogleGeminiChat.__init__", return_value=None),
+        patch("google.generativeai.configure"),
+        patch("google.generativeai.GenerativeModel"),
+    ):
+        backend = MyVannaGeminiChromaDB(user_role=1, config={"path": test_chromadb_path})
+        assert backend.dialect == "redshift"
+
+
+def test_anthropic_chromadb_defaults_dialect_to_postgresql(secrets_without_dialect, test_chromadb_path):
+    with (
+        patch("utils.vanna_calls.ThriveAI_ChromaDB.__init__", return_value=None),
+        patch("utils.vanna_calls.Anthropic_Chat.__init__", return_value=None),
+    ):
+        backend = MyVannaAnthropicChromaDB(user_role=1, config={"path": test_chromadb_path})
+        assert backend.dialect == "postgresql"
+
+
+# ---------- system prompt content ----------
+
+
+def _make_prompt_stub(dialect: str) -> ThriveAI_Base:
+    """Return a ThriveAI_Base subclass instance suitable for testing get_sql_prompt."""
+
+    class _Stub(ThriveAI_Base):
+        def add_ddl_to_prompt(self, prompt, ddl_list, **kwargs):
+            return prompt
+
+        def add_documentation_to_prompt(self, prompt, doc_list, **kwargs):
+            return prompt
+
+        def system_message(self, m):
+            return {"role": "system", "content": m}
+
+        def user_message(self, m):
+            return {"role": "user", "content": m}
+
+        def assistant_message(self, m):
+            return {"role": "assistant", "content": m}
+
+        def generate_embedding(self, data, **kwargs):
+            return [0.1]
+
+        def submit_prompt(self, *a, **kw):
+            return ""
+
+    # VannaBase has many abstract storage methods we don't care about for
+    # prompt-content tests — neutralize the ABC machinery so we can build an
+    # instance without supplying them.
+    _Stub.__abstractmethods__ = frozenset()
+    stub = _Stub.__new__(_Stub)
+    stub.config = {"dialect": dialect, "schema": "public"}
+    stub.dialect = dialect
+    stub.schema = "public"
+    stub.max_tokens = 32_000
+    stub.static_documentation = ""
+    return stub
+
+
+def test_system_prompt_names_dialect():
+    redshift = _make_prompt_stub("redshift")
+    msgs = redshift.get_sql_prompt(
+        initial_prompt=None,
+        question="how many patients?",
+        question_sql_list=[],
+        ddl_list=[],
+        doc_list=[],
+    )
+    system_text = msgs[0]["content"]
+    assert "redshift expert" in system_text.lower()
+
+
+def test_system_prompt_includes_redshift_cheatsheet_only_for_redshift():
+    redshift = _make_prompt_stub("redshift")
+    postgres = _make_prompt_stub("postgresql")
+
+    redshift_text = redshift.get_sql_prompt(
+        initial_prompt=None, question="q", question_sql_list=[], ddl_list=[], doc_list=[]
+    )[0]["content"]
+    postgres_text = postgres.get_sql_prompt(
+        initial_prompt=None, question="q", question_sql_list=[], ddl_list=[], doc_list=[]
+    )[0]["content"]
+
+    # The cheat-sheet calls out LISTAGG as the Redshift equivalent of STRING_AGG.
+    assert "LISTAGG" in redshift_text
+    assert "LISTAGG" not in postgres_text
+    # And explicitly tells the LLM to avoid CORR on Redshift.
+    assert "CORR" in redshift_text
+    assert "CORR" not in postgres_text
+
+
+# ---------- _build_index_query dialect branch ----------
+
+
+def test_build_index_query_uses_string_agg_for_postgres():
+    svc = VannaService.__new__(VannaService)
+    svc.dialect = "postgresql"
+    sql = svc._build_index_query("public", "")
+    assert "STRING_AGG" in sql
+    assert "LISTAGG" not in sql
+
+
+def test_build_index_query_uses_listagg_for_redshift():
+    svc = VannaService.__new__(VannaService)
+    svc.dialect = "redshift"
+    sql = svc._build_index_query("public", "")
+    assert "LISTAGG" in sql
+    assert "STRING_AGG" not in sql
+
+
+def test_build_index_query_defaults_to_postgres_when_dialect_missing():
+    svc = VannaService.__new__(VannaService)
+    # No svc.dialect attribute set — current callers may not have one yet.
+    sql = svc._build_index_query("public", "")
+    assert "STRING_AGG" in sql

--- a/utils/thriveai_base.py
+++ b/utils/thriveai_base.py
@@ -5,6 +5,30 @@ from utils.quick_logger import get_logger
 logger = get_logger(__name__)
 
 
+_REDSHIFT_CHEATSHEET = (
+    "===Dialect Notes (Redshift) \n"
+    "Redshift differs from PostgreSQL in several places. When you emit SQL:\n"
+    " - Use LISTAGG(col, ', ') WITHIN GROUP (ORDER BY ...) instead of STRING_AGG(... ORDER BY ...).\n"
+    " - Redshift has no CORR() aggregate; compute correlation manually with AVG/STDDEV if needed.\n"
+    " - Do not use array_position(), array_agg(), or other Postgres array helpers.\n"
+    " - SUBSTRING(col FROM x FOR y) is portable; prefer it over SUBSTR variants.\n"
+    " - EXTRACT(YEAR FROM col), DATE_TRUNC, and CAST are all supported.\n"
+    " - Identifier quoting uses double quotes; string literals use single quotes.\n"
+)
+
+
+def dialect_cheatsheet(dialect: str | None) -> str:
+    """Return dialect-specific guidance for the system prompt.
+
+    Empty string when the active dialect doesn't need extra rules
+    (e.g. the default PostgreSQL path, which matches the bulk of our
+    training examples).
+    """
+    if (dialect or "").lower() == "redshift":
+        return _REDSHIFT_CHEATSHEET
+    return ""
+
+
 class ThriveAI_Base(VannaBase):
     """Base class for ThriveAI"""
 
@@ -12,6 +36,7 @@ class ThriveAI_Base(VannaBase):
         super().__init__(*args, **kwargs)
 
         self.schema = self.config.get("schema", "public")
+        self.dialect = self.config.get("dialect", getattr(self, "dialect", "postgresql"))
 
     def log(self, message: str, title: str = "Info"):
         """Override the deault log method, which is print, to use the logger."""
@@ -73,6 +98,8 @@ class ThriveAI_Base(VannaBase):
             f"6. Ensure that the output SQL is {self.dialect}-compliant and executable, and free of syntax errors. \n"
             f"7. Make sure to fully qualify table names with the schema name {self.schema}, even if not specified in the ddl. Eg. SELECT * FROM dw.customers;\n"
         )
+
+        initial_prompt += dialect_cheatsheet(self.dialect)
 
         initial_prompt += "=== Example Question/SQL Pairs \n"
 

--- a/utils/vanna_calls.py
+++ b/utils/vanna_calls.py
@@ -22,6 +22,7 @@ from vanna.legacy.vannadb import VannaDB_VectorStore
 
 from utils.chromadb_vector import ThriveAI_ChromaDB
 from utils.milvus_vector import ThriveAI_Milvus
+from utils.thriveai_base import dialect_cheatsheet
 from utils.quick_logger import calculate_process_performance, get_logger, pvlog, set_start_time
 from utils.thriveai_ollama import ThriveAI_Ollama
 
@@ -221,6 +222,8 @@ class MyVannaAnthropicChromaDB(ThriveAI_ChromaDB, Anthropic_Chat):
                     "model": st.secrets["ai_keys"]["anthropic_model"],
                 },
             )
+            self.schema = st.secrets["postgres"].get("schema_name", "public")
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
         except Exception as e:
             logger.exception("Error Configuring MyVannaAnthropicChromaDB: %s", e)
             raise
@@ -302,6 +305,9 @@ class MyVannaOllamaChromaDB(ThriveAI_ChromaDB, ThriveAI_Ollama):
             except Exception as ollama_init_err:
                 # In production we rely on ThriveAI_Ollama; silently ignore base call issues
                 logger.debug("Skipping base Ollama init: %s", ollama_init_err)
+            # Make dialect authoritative on the outer class so downstream code
+            # doesn't depend on which __init__ ran last.
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
         except Exception as e:
             logger.exception("Error Configuring MyVannaOllamaChromaDB: %s", e)
             raise
@@ -345,6 +351,9 @@ class MyVannaGeminiChromaDB(ThriveAI_ChromaDB, GoogleGeminiChat):
 
             logger.info(f"🎉 Fixed GoogleGeminiChat to use: {self.configured_model}")
 
+            self.schema = st.secrets["postgres"].get("schema_name", "public")
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
+
         except Exception as e:
             logger.exception("Error Configuring MyVannaGeminiChromaDB: %s", e)
             raise
@@ -373,6 +382,9 @@ class MyVannaGeminiMilvus(ThriveAI_Milvus, GoogleGeminiChat):
             genai.configure(api_key=self.configured_api_key)
             self.chat_model = genai.GenerativeModel(self.configured_model)
             self.model = self.configured_model
+
+            self.schema = st.secrets["postgres"].get("schema_name", "public")
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
         except Exception as e:
             logger.exception("Error Configuring MyVannaGeminiMilvus: %s", e)
             raise
@@ -411,6 +423,9 @@ class MyVannaOllamaMilvus(ThriveAI_Milvus, ThriveAI_Ollama):
                 self.static_documentation = ""
             if not hasattr(self, "language"):
                 self.language = None
+            # Authoritative dialect on the outer class (ThriveAI_Ollama already
+            # reads it from config, but other code paths look it up here).
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
         except Exception as e:
             logger.exception("Error Configuring MyVannaOllamaMilvus: %s", e)
             raise
@@ -477,6 +492,8 @@ class MyVannaOllamaMilvus(ThriveAI_Milvus, ThriveAI_Ollama):
             f"6. Ensure that the output SQL is {self.dialect}-compliant and executable, and free of syntax errors. \n"
         )
 
+        initial_prompt += dialect_cheatsheet(getattr(self, "dialect", None))
+
         initial_prompt += "===Similar Question and SQL Examples \n"
 
         message_log = [self.system_message(initial_prompt)]
@@ -515,6 +532,7 @@ class MyVannaOpenAIMilvus(ThriveAI_Milvus, OpenAI_Chat):
                 self.static_documentation = ""
             if not hasattr(self, "language"):
                 self.language = None
+            self.dialect = st.secrets["postgres"].get("dialect", "postgresql")
         except Exception as e:
             logger.exception("Error Configuring MyVannaOpenAIMilvus: %s", e)
             raise
@@ -580,6 +598,8 @@ class MyVannaOpenAIMilvus(ThriveAI_Milvus, OpenAI_Chat):
             "5. If the question has been asked and answered before, please repeat the answer exactly as it was given before. \n"
             f"6. Ensure that the output SQL is {self.dialect}-compliant and executable, and free of syntax errors. \n"
         )
+
+        initial_prompt += dialect_cheatsheet(getattr(self, "dialect", None))
 
         initial_prompt += "===Similar Question and SQL Examples \n"
 
@@ -1711,7 +1731,48 @@ class VannaService:
         return query
 
     def _build_index_query(self, schema_name: str, forbidden_tables_str: str) -> str:
-        """Build PostgreSQL query to discover index definitions."""
+        """Build a query to discover index definitions.
+
+        Branches on ``self.dialect`` because the column-list aggregation differs:
+        PostgreSQL uses ``STRING_AGG(... ORDER BY array_position(...))`` against
+        ``pg_index``/``pg_attribute``, while Redshift exposes index-like
+        information through ``SVV_REDSHIFT_COLUMNS``/``information_schema`` and
+        needs ``LISTAGG(...) WITHIN GROUP (ORDER BY ...)``.
+        """
+        dialect = (getattr(self, "dialect", "postgresql") or "postgresql").lower()
+        if dialect == "redshift":
+            # Redshift doesn't store true indexes the way Postgres does, but it
+            # surfaces sort/dist/primary-key column metadata through
+            # information_schema.table_constraints + key_column_usage. We approximate
+            # the Postgres result shape (one row per constraint, comma-joined column
+            # list) so downstream consumers don't need to care which warehouse we hit.
+            query = f"""
+                SELECT
+                    kcu.table_name AS table_name,
+                    tc.constraint_name AS index_name,
+                    CASE WHEN tc.constraint_type = 'UNIQUE' OR tc.constraint_type = 'PRIMARY KEY'
+                         THEN 'UNIQUE' ELSE 'NONUNIQUE' END AS index_type,
+                    CASE WHEN tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+                         THEN TRUE ELSE FALSE END AS is_unique,
+                    CASE WHEN tc.constraint_type = 'PRIMARY KEY'
+                         THEN TRUE ELSE FALSE END AS is_primary_key,
+                    LISTAGG(kcu.column_name, ', ') WITHIN GROUP (ORDER BY kcu.ordinal_position) AS columns
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                    ON tc.constraint_name = kcu.constraint_name
+                    AND tc.table_schema = kcu.table_schema
+                WHERE tc.table_schema = '{schema_name}'
+                  AND tc.constraint_type IN ('PRIMARY KEY', 'UNIQUE')
+            """
+            if forbidden_tables_str:
+                query += f" AND kcu.table_name NOT IN ({forbidden_tables_str})"
+            query += (
+                " GROUP BY kcu.table_name, tc.constraint_name, tc.constraint_type"
+                " ORDER BY kcu.table_name, tc.constraint_name"
+            )
+            return query
+
+        # Default: PostgreSQL
         query = f"""
             SELECT
                 t.relname AS table_name,
@@ -3792,9 +3853,7 @@ def _parse_markdown_table(text: str) -> str | None:
 
     def _is_separator(line: str) -> bool:
         return "|" in line and all(
-            part.strip().replace("-", "").replace(":", "") == ""
-            for part in line.split("|")
-            if part.strip()
+            part.strip().replace("-", "").replace(":", "") == "" for part in line.split("|") if part.strip()
         )
 
     # Slide through lines looking for: pipe-line, separator, pipe-line (header + sep + data)


### PR DESCRIPTION
## Summary

- Add a single config key (`[postgres].dialect`) that drives the SQL dialect the LLM is told to emit — `postgresql` (default, local dev) or `redshift` (prod).
- Wire `self.dialect` through every Vanna backend (Anthropic, Gemini, Ollama × ChromaDB/Milvus, OpenAI-Milvus) so the value is authoritative regardless of which mixin's `__init__` ran last.
- Inject a Redshift-only cheat-sheet into the system prompt (`LISTAGG` vs `STRING_AGG`, no `CORR`, no `array_position`, `SUBSTRING` over `SUBSTR`, etc.).
- Branch the one hardcoded Postgres-only introspection SQL we own — `VannaService._build_index_query` — to a `LISTAGG WITHIN GROUP` variant against `information_schema.table_constraints` when running on Redshift.
- Document the new key in `.streamlit/secrets_example.toml` and `CLAUDE.md`.

## Why

Production runs against Redshift; local dev runs against Postgres. Redshift speaks the Postgres wire protocol so the connection itself is fine, but generated SQL (and that one introspection query) used Postgres-only constructs and errored out on the deployed Redshift cluster. One env var, one codebase, correct SQL in both places.

## Out of scope (potential follow-ups)

- Filtering `utils/config/training_data.json` entries by dialect. The two `corr()` examples there would bias the LLM toward Postgres syntax if loaded, but the loader (`train_file()`) is already marked deprecated and isn't called from the app, so they're dormant. Worth revisiting if the CSV-import training path is repointed at that file.
- No transpiler safety-net (SQLGlot). Prompt-only is sufficient given the scope; can be added later without revisiting this work.

## Test plan

- [x] `uv run pytest tests/utils/test_dialect_switch.py` — 11 new tests cover config plumbing, per-backend dialect propagation, system-prompt cheat-sheet presence/absence, and the `_build_index_query` branch.
- [x] `uv run pytest tests/utils/` — 436 passed, 3 skipped, no regressions (one unrelated test that hits a real `localhost:11434` Ollama server was deselected).
- [x] `uv run ruff check` on touched files — clean (two pre-existing F841s on `vanna_calls.py` are unrelated).
- [ ] Local smoke with `[postgres].dialect` unset → SQL still runs against local Postgres.
- [ ] Prod smoke with `[postgres].dialect = "redshift"` → replay the `SUBSTR` question and a few aggregation queries; confirm no syntax errors.
- [ ] Trigger auto-enhance-schema against Redshift; confirm the new `LISTAGG` branch in `_build_index_query` executes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)