### PR TITLE
feat(users): admin Export Users to CSV (#122, #123)

### DIFF
--- a/orm/functions.py
+++ b/orm/functions.py
@@ -356,6 +356,92 @@ def get_all_users():
         return []
 
 
+def _is_admin_db(admin_id: int) -> bool:
+    """Defense-in-depth role check: re-resolve the caller's role from the DB.
+
+    Does not consult ``st.session_state``. Returns True only when the row
+    exists and resolves to ``RoleTypeEnum.ADMIN``.
+    """
+    from orm.models import RoleTypeEnum
+
+    try:
+        with SessionLocal() as session:
+            row = (
+                session.query(User)
+                .options(joinedload(User.role))
+                .filter(User.id == admin_id)
+                .one_or_none()
+            )
+            if row is None or row.role is None:
+                return False
+            return row.role.role == RoleTypeEnum.ADMIN
+    except Exception as e:
+        logger.warning("Failed to verify admin role for user_id=%s: %s", admin_id, e)
+        return False
+
+
+def get_users_for_export(admin_id: int) -> tuple[list[dict], int]:
+    """Return the user roster in Bulk-Import-compatible CSV row shape.
+
+    Columns (in order): ``UserID, First Name, Last Name, Email, Organization, Role``.
+    Excludes ``password``, ``okta_sub``, and all preference fields.
+
+    Enforces an admin-only gate independently of UI state (defense in depth)
+    and writes a single ``thrive_admin_action`` row per call — ``success=True``
+    on the happy path, ``success=False`` with a rejection ``error_message`` when
+    the caller is not an admin.
+    """
+    from orm.logging_functions import log_admin_action
+    from orm.models import AdminActionType
+
+    if not _is_admin_db(admin_id):
+        log_admin_action(
+            admin_id=admin_id,
+            action_type=AdminActionType.USER_EXPORT,
+            description="Non-admin attempted user export",
+            target_entity_type="user",
+            success=False,
+            error_message="caller is not an admin",
+        )
+        return [], 0
+
+    try:
+        with SessionLocal() as session:
+            users = session.query(User).options(joinedload(User.role)).all()
+            rows = [
+                {
+                    "UserID": u.username,
+                    "First Name": u.first_name,
+                    "Last Name": u.last_name,
+                    "Email": u.email,
+                    "Organization": u.organization,
+                    "Role": u.role.role_name if u.role else "No Role",
+                }
+                for u in users
+            ]
+        n = len(rows)
+        log_admin_action(
+            admin_id=admin_id,
+            action_type=AdminActionType.USER_EXPORT,
+            description=f"Exported {n} users to CSV",
+            target_entity_type="user",
+            affected_count=n,
+            success=True,
+        )
+        return rows, n
+    except Exception as e:
+        logger.error("Error exporting users: %s", e)
+        log_admin_action(
+            admin_id=admin_id,
+            action_type=AdminActionType.USER_EXPORT,
+            description="User export failed",
+            target_entity_type="user",
+            success=False,
+            error_message=str(e),
+        )
+        return [], 0
+
+
 def update_user(
     user_id: int,
     username: str = None,

--- a/orm/models.py
+++ b/orm/models.py
@@ -124,6 +124,7 @@ class AdminActionType(enum.Enum):
     TRAINING_DELETE = "training_delete"
     TRAINING_IMPORT = "training_import"
     USER_IMPORT = "user_import"
+    USER_EXPORT = "user_export"
 
 
 class ErrorCategory(enum.Enum):

--- a/tests/orm/test_user_export.py
+++ b/tests/orm/test_user_export.py
@@ -1,0 +1,189 @@
+"""Tests for orm.functions.get_users_for_export (#122)."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import AdminAction, AdminActionType, Base, RoleTypeEnum, User, UserRole
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on both functions and logging_functions."""
+    from orm import functions as fns
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(fns, "SessionLocal", Session)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add_all(
+        [
+            UserRole(id=1, role_name="Admin", description="Admin", role=RoleTypeEnum.ADMIN),
+            UserRole(id=2, role_name="Doctor", description="Doctor", role=RoleTypeEnum.DOCTOR),
+            UserRole(id=3, role_name="Nurse", description="Nurse", role=RoleTypeEnum.NURSE),
+            UserRole(id=4, role_name="Patient", description="Patient", role=RoleTypeEnum.PATIENT),
+        ]
+    )
+    session.commit()
+
+
+def _seed_user(session, *, id, username, first, last, email, org, role_id, password="hash:abc"):
+    session.add(
+        User(
+            id=id,
+            user_role_id=role_id,
+            username=username,
+            first_name=first,
+            last_name=last,
+            password=password,
+            email=email,
+            organization=org,
+        )
+    )
+    session.commit()
+
+
+def test_admin_action_type_includes_user_export():
+    assert AdminActionType.USER_EXPORT.value == "user_export"
+
+
+def test_admin_caller_returns_rows_and_writes_audit(session_factory):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="Ada", last="Min", email="a@x.io", org="Org1", role_id=1)
+    _seed_user(s, id=2, username="doc1", first="Don", last="Doc", email="d@x.io", org="Org2", role_id=2)
+    _seed_user(s, id=3, username="pat1", first="Pat", last="Ient", email="p@x.io", org="Org3", role_id=4)
+
+    rows, n = get_users_for_export(admin_id=1)
+
+    assert n == 3
+    assert len(rows) == 3
+    # Audit row written
+    audit = s.query(AdminAction).all()
+    assert len(audit) == 1
+    assert audit[0].admin_id == 1
+    assert audit[0].action_type == "user_export"
+    assert audit[0].affected_count == 3
+    assert audit[0].success is True
+
+
+def test_admin_caller_rows_have_exact_column_keys_in_order(session_factory):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="Ada", last="Min", email="a@x.io", org="Org1", role_id=1)
+
+    rows, _ = get_users_for_export(admin_id=1)
+
+    expected_keys = ["UserID", "First Name", "Last Name", "Email", "Organization", "Role"]
+    assert list(rows[0].keys()) == expected_keys
+
+
+def test_admin_caller_row_values_match_user_fields(session_factory):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="Ada", last="Min", email="a@x.io", org="Org1", role_id=1)
+
+    rows, _ = get_users_for_export(admin_id=1)
+    row = rows[0]
+
+    assert row["UserID"] == "admin1"
+    assert row["First Name"] == "Ada"
+    assert row["Last Name"] == "Min"
+    assert row["Email"] == "a@x.io"
+    assert row["Organization"] == "Org1"
+    assert row["Role"] == "Admin"
+
+
+def test_returned_rows_exclude_sensitive_and_preference_fields(session_factory):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="Ada", last="Min", email="a@x.io", org="Org1", role_id=1)
+
+    rows, _ = get_users_for_export(admin_id=1)
+    row = rows[0]
+
+    forbidden = {
+        "password",
+        "okta_sub",
+        "theme",
+        "show_sql",
+        "show_table",
+        "agentic_mode",
+        "selected_llm_model",
+        "selected_llm_provider",
+        "show_chart",
+        "voice_input",
+    }
+    assert not (set(row.keys()) & forbidden)
+
+
+@pytest.mark.parametrize(
+    "non_admin_role_id",
+    [2, 3, 4],
+    ids=["doctor", "nurse", "patient"],
+)
+def test_non_admin_caller_rejects_and_logs_failure(session_factory, non_admin_role_id):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="A", last="M", email="a@x.io", org="O", role_id=1)
+    _seed_user(s, id=99, username="someone", first="S", last="O", email="s@x.io", org="O", role_id=non_admin_role_id)
+
+    rows, n = get_users_for_export(admin_id=99)
+
+    assert rows == []
+    assert n == 0
+    audit = s.query(AdminAction).all()
+    assert len(audit) == 1
+    assert audit[0].admin_id == 99
+    assert audit[0].action_type == "user_export"
+    assert audit[0].success is False
+    assert audit[0].error_message  # non-empty rejection message
+
+
+def test_unknown_caller_rejects_and_logs_failure(session_factory):
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    # No user with id=999 exists.
+
+    rows, n = get_users_for_export(admin_id=999)
+
+    assert (rows, n) == ([], 0)
+    audit = s.query(AdminAction).all()
+    assert len(audit) == 1
+    assert audit[0].success is False
+
+
+def test_admin_only_roster_succeeds_with_one_row(session_factory):
+    """Smallest legitimate success case: the admin themselves is the only user."""
+    from orm.functions import get_users_for_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=1, username="admin1", first="A", last="M", email="a@x.io", org="O", role_id=1)
+
+    rows, n = get_users_for_export(admin_id=1)
+
+    assert n == 1
+    assert rows[0]["UserID"] == "admin1"
+    audit = s.query(AdminAction).all()
+    assert len(audit) == 1
+    assert audit[0].success is True
+    assert audit[0].affected_count == 1

--- a/views/user.py
+++ b/views/user.py
@@ -16,6 +16,7 @@ from orm.functions import (
     get_user_questions_page,
     get_user_recent_questions,
     get_user_stats_for_all_users,
+    get_users_for_export,
     update_user,
     update_user_preferences,
 )
@@ -258,6 +259,45 @@ def export_training_data_to_csv():
     except Exception as e:
         st.error(f"An error occurred during CSV export: {e}")
         logger.error(f"CSV export error: {e}")
+
+
+def export_users_to_csv():
+    try:
+        try:
+            admin_id_raw = st.session_state.cookies.get("user_id")
+        except Exception:
+            admin_id_raw = None
+        if not admin_id_raw:
+            st.error("Could not determine current user.")
+            return
+        admin_id = int(admin_id_raw)
+
+        rows, n = get_users_for_export(admin_id)
+
+        if n == 0:
+            st.warning("No users available to export.")
+            return
+
+        df = DataFrame(rows)
+        csv_buffer = io.StringIO()
+        df.to_csv(csv_buffer, index=False)
+        csv_data = csv_buffer.getvalue()
+
+        import datetime
+
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"users_{timestamp}.csv"
+
+        st.download_button(
+            label="📥 Download CSV",
+            data=csv_data,
+            file_name=filename,
+            mime="text/csv",
+            help="Download users as CSV file",
+        )
+    except Exception as e:
+        st.error(f"An error occurred during CSV export: {e}")
+        logger.error(f"User export error: {e}")
 
 
 def import_training_data_from_csv(uploaded_file):
@@ -705,6 +745,15 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
             )
             if st.button("Import Users", type="primary", help="Import users from ./utils/config/user_list.xlsx"):
                 import_users()
+
+            st.divider()
+            st.markdown("**Export Users**")
+            st.info(
+                "📤 Download all users as CSV. Columns match Bulk User Import "
+                "(UserID, First Name, Last Name, Email, Organization, Role). "
+                "Passwords are not included."
+            )
+            export_users_to_csv()
 
         with right:
             st.markdown("**Edit Existing User**")


### PR DESCRIPTION
Closes #122 and #123. Implements the Admin user export Epic (#121) end-to-end.

## Summary
- **Backend (#122):** `AdminActionType.USER_EXPORT` + defense-in-depth `_is_admin_db` role helper + `get_users_for_export(admin_id) -> (rows, n)` in `orm/functions.py`. Reuses the existing `log_admin_action` writer.
- **UI (#123):** `export_users_to_csv()` mirrors the existing `export_training_data_to_csv` pattern. Rendered in the Manage Users tab below Bulk User Import.
- **Tests:** 10 new unit tests in `tests/orm/test_user_export.py` — admin happy path, column shape + ordering, sensitive-field exclusion, non-admin rejection per role (Doctor/Nurse/Patient), unknown caller, and admin-only roster. All green; full `tests/orm/` suite 143 passed.
- **Round-trip:** CSV header is `UserID,First Name,Last Name,Email,Organization,Role` — same columns as the Bulk Import minus the hashed `start_password`.
- **Audit:** every call writes one `thrive_admin_action` row with `action_type='user_export'`, `affected_count=n`, `success=True/False`.
- **No DB migration:** `AdminAction.action_type` is `String(50)` — adding the enum value is a code-only change.

## Test plan
- [x] `uv run pytest tests/orm/test_user_export.py` — 10 passed
- [x] `uv run pytest tests/orm/` — 143 passed
- [x] `uv run ruff check orm/functions.py orm/models.py tests/orm/test_user_export.py` — clean
- [x] Streamlit smoke: logged in as Admin, downloaded `users_YYYYMMDD_HHMMSS.csv`, verified header + 15 user rows, confirmed `AdminAction` row written with `affected_count=15, success=True`

## Heads-up (potential follow-up)
Because `st.download_button` requires data prepared at render time, `get_users_for_export` is invoked on every render of the Manage Users tab — so each tab visit writes an audit row, not just each download click. This matches `export_training_data_to_csv`'s behavior. If click-only auditing is wanted for compliance, follow up by gating the data load behind a session-state click flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)