### PR TITLE
feat(user-settings): symmetric Profile + Password tab (#125)

### DIFF
--- a/views/user.py
+++ b/views/user.py
@@ -410,9 +410,9 @@ def pop_train(type):
 
 st.title("User Settings")
 
-tabs = ["Change Password"]
+tabs = ["My Account"]
 if st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
-    tabs = ["Change Password", "Training Data", "Manage Users"]
+    tabs = ["My Account", "Training Data", "Manage Users"]
 tab_objects = st.tabs(tabs)
 tab1 = tab_objects[0]
 tab2 = tab_objects[1] if len(tab_objects) > 1 else None
@@ -429,10 +429,10 @@ with tab1:
         except Exception:
             _me = None
         if _me is not None:
-            st.markdown("**My Profile**")
+            st.markdown("**Profile**")
             with st.form("my_profile_form"):
-                my_email = st.text_input("My Email", value=_me.email or "")
-                my_organization = st.text_input("My Organization", value=_me.organization or "")
+                my_email = st.text_input("Email", value=_me.email or "")
+                my_organization = st.text_input("Organization", value=_me.organization or "")
                 if st.form_submit_button("Save Profile", type="primary"):
                     ok = update_user(
                         int(user_id),
@@ -449,11 +449,12 @@ with tab1:
                         )
             st.divider()
 
+    st.markdown("**Change Password**")
     with st.form("change_password_form"):
         current_password = st.text_input("Current Password", type="password")
         new_password = st.text_input("New Password", type="password")
         confirm_new_password = st.text_input("Confirm New Password", type="password")
-        submit_button = st.form_submit_button("Change Password")
+        submit_button = st.form_submit_button("Change Password", type="primary")
 
         if submit_button:
             if new_password != confirm_new_password:


### PR DESCRIPTION
Closes #125. Refines the User Settings → Change Password tab into a coherent **My Account** surface.

## Summary
- Rename tab "Change Password" → "My Account" in both `tabs = [...]` list literals (`views/user.py:413` non-admin, `:415` admin).
- Symmetric markdown section headers: **Profile** and **Change Password**.
- Drop the redundant "My " prefix from Profile field labels (Email, Organization).
- Both form submit buttons use `type="primary"` (Save Profile already was; Change Password now is).
- Keep the existing `st.divider()` between the two forms.

## Test plan
- [x] `git diff views/user.py` matches the refined Sequential Implementation Plan exactly (6 lines changed, scoped to lines 413–456).
- [x] Streamlit boots; User Settings page loads without errors.
- [x] As admin, three tabs render in order: `My Account`, `Training Data`, `Manage Users` (Playwright snapshot confirms).
- [x] `My Account` tab shows: `**Profile**` header → Email/Organization fields → primary `Save Profile` button → divider → `**Change Password**` header → password fields → primary `Change Password` button.
- [x] Both submit buttons have `data-testid="stBaseButton-primaryFormSubmit"` / `kind="primaryFormSubmit"`.
- [x] Mismatched-password submission surfaces "New password and confirmation do not match." — confirms the password form's submit handler still routes through the existing validation path with the new primary button.
- [x] No changes to `orm/functions.py`, `orm/models.py`, or any other file. No new third-party deps.

## Non-functional
- Non-admin role gating unchanged — both `tabs = [...]` literals updated together so admin and non-admin branches don't drift.
- Defensive guards at `views/user.py:31–39` (cookies fallback) and `:426–430` (`SessionLocal()` try/except) preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)