### PR TITLE
feat(audit-trail): consolidated Question Audit Trail tab + retire duplicates (#134, #135, #136)

### DIFF
--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -12,6 +12,8 @@ import traceback
 from datetime import datetime, timedelta
 from typing import Any
 
+from sqlalchemy import func
+
 from orm.models import (
     ActivityType,
     AdminAction,
@@ -374,6 +376,248 @@ def get_admin_actions(
             return query.order_by(AdminAction.created_at.desc()).limit(limit).all()
     except Exception as e:
         logger.warning("Failed to get admin actions: %s", e)
+        return []
+
+
+# ============== Question Audit Trail ==============
+
+MAX_AUDIT_EXPORT_ROWS = 50_000
+_NO_ORG_SENTINEL = "(no org)"
+
+
+def _question_audit_base_query(session, filters: dict):
+    """Build the filtered base query over user-role Message rows joined to User.
+
+    Returns a SQLAlchemy query that selects the rows in reverse-chronological
+    order WITHOUT pagination. Used by both the paginated page helper and the
+    export helper.
+    """
+    from sqlalchemy import or_
+
+    from orm.models import Message, User
+    from utils.enums import MessageType, RoleType
+
+    days = int(filters.get("days") or 30)
+    usernames = filters.get("usernames") or []
+    orgs = filters.get("orgs") or []
+    search = filters.get("search") or None
+
+    since = datetime.utcnow() - timedelta(days=days)
+
+    query = (
+        session.query(
+            Message.id.label("user_message_id"),
+            Message.content.label("question"),
+            Message.created_at.label("asked_at"),
+            User.id.label("user_id"),
+            User.username.label("username"),
+            User.organization.label("organization"),
+        )
+        .join(User, User.id == Message.user_id)
+        .filter(Message.role == RoleType.USER.value, Message.created_at >= since)
+    )
+
+    if usernames:
+        query = query.filter(User.username.in_(usernames))
+
+    if orgs:
+        org_clauses = []
+        concrete = [o for o in orgs if o != _NO_ORG_SENTINEL]
+        if _NO_ORG_SENTINEL in orgs:
+            org_clauses.append(User.organization.is_(None))
+            org_clauses.append(User.organization == "")
+        if concrete:
+            org_clauses.append(User.organization.in_(concrete))
+        if org_clauses:
+            query = query.filter(or_(*org_clauses))
+
+    if search:
+        from sqlalchemy import exists
+        from sqlalchemy.orm import aliased
+
+        s = f"%{search.lower()}%"
+        SqlMsg = aliased(Message)
+        sql_exists = exists().where(
+            (SqlMsg.role == RoleType.ASSISTANT.value)
+            & (SqlMsg.type == MessageType.SQL.value)
+            & (SqlMsg.question == Message.content)
+            & (SqlMsg.user_id == Message.user_id)
+            & (SqlMsg.content.ilike(s))
+        )
+        query = query.filter(or_(Message.content.ilike(s), sql_exists))
+
+    return query.order_by(Message.created_at.desc())
+
+
+def _enrich_with_assistant_aggregates(session, base_rows: list) -> list[dict]:
+    """For each base row, attach sql_text / summary_text / dataframe_preview /
+    error_text (most recent assistant message of each type) and elapsed_seconds
+    (sum of assistant elapsed_time across all assistant rows for the question)."""
+    from orm.models import Message
+    from utils.enums import MessageType, RoleType
+
+    if not base_rows:
+        return []
+
+    user_ids = {r.user_id for r in base_rows}
+    questions = {r.question for r in base_rows}
+
+    assistant_rows = (
+        session.query(
+            Message.user_id.label("user_id"),
+            Message.question.label("question"),
+            Message.type.label("type"),
+            Message.content.label("content"),
+            Message.created_at.label("created_at"),
+            Message.elapsed_time.label("elapsed_time"),
+        )
+        .filter(
+            Message.role == RoleType.ASSISTANT.value,
+            Message.user_id.in_(user_ids),
+            Message.question.in_(questions),
+        )
+        .order_by(Message.created_at.desc())
+        .all()
+    )
+
+    chart_types = {
+        MessageType.PLOTLY_CHART.value,
+        MessageType.ST_LINE_CHART.value,
+        MessageType.ST_BAR_CHART.value,
+        MessageType.ST_AREA_CHART.value,
+        MessageType.ST_SCATTER_CHART.value,
+    }
+
+    by_key: dict[tuple[int, str], dict] = {}
+    for ar in assistant_rows:
+        key = (ar.user_id, ar.question)
+        acc = by_key.setdefault(
+            key,
+            {
+                "sql_text": None,
+                "summary_text": None,
+                "dataframe_preview": None,
+                "error_text": None,
+                "elapsed_seconds": 0.0,
+                "has_chart": False,
+            },
+        )
+        if ar.elapsed_time is not None:
+            try:
+                acc["elapsed_seconds"] += float(ar.elapsed_time)
+            except (TypeError, ValueError):
+                pass
+        # Rows arrive newest-first; keep the first (newest) per type.
+        if ar.type == MessageType.SQL.value and acc["sql_text"] is None:
+            acc["sql_text"] = ar.content
+        elif ar.type == MessageType.SUMMARY.value and acc["summary_text"] is None:
+            acc["summary_text"] = ar.content
+        elif ar.type == MessageType.DATAFRAME.value and acc["dataframe_preview"] is None:
+            acc["dataframe_preview"] = ar.content
+        elif ar.type == MessageType.ERROR.value and acc["error_text"] is None:
+            acc["error_text"] = ar.content
+        elif ar.type in chart_types:
+            acc["has_chart"] = True
+
+    items = []
+    for r in base_rows:
+        key = (r.user_id, r.question)
+        agg = by_key.get(key) or {
+            "sql_text": None,
+            "summary_text": None,
+            "dataframe_preview": None,
+            "error_text": None,
+            "elapsed_seconds": 0.0,
+            "has_chart": False,
+        }
+        has_error = bool(agg["error_text"])
+        has_success_artifact = bool(agg["summary_text"]) or bool(agg["dataframe_preview"]) or agg["has_chart"]
+        if has_error:
+            status = "Error"
+        elif has_success_artifact:
+            status = "Success"
+        else:
+            status = "Empty"
+        items.append(
+            {
+                "asked_at": r.asked_at,
+                "user_id": r.user_id,
+                "username": r.username,
+                "organization": r.organization,
+                "question": r.question,
+                "sql_text": agg["sql_text"],
+                "status": status,
+                "elapsed_seconds": float(agg["elapsed_seconds"]),
+                "summary_text": agg["summary_text"],
+                "dataframe_preview": agg["dataframe_preview"],
+                "error_text": agg["error_text"],
+                "user_message_id": r.user_message_id,
+            }
+        )
+    return items
+
+
+def get_question_audit_page(filters: dict, page: int = 1, page_size: int = 50) -> dict:
+    """Paginated question audit. Returns {"items": [...], "total": int}.
+
+    See Feature #134 spec for filter semantics and item shape.
+    """
+    try:
+        with SessionLocal() as session:
+            base_query = _question_audit_base_query(session, filters)
+            total = base_query.with_entities(func.count()).order_by(None).scalar() or 0
+            offset = max(0, (int(page) - 1) * int(page_size))
+            rows = base_query.offset(offset).limit(int(page_size)).all()
+            items = _enrich_with_assistant_aggregates(session, rows)
+            return {"items": items, "total": int(total)}
+    except Exception as e:
+        logger.warning("get_question_audit_page failed: %s", e)
+        return {"items": [], "total": 0}
+
+
+def get_question_audit_filter_options(days: int = 30) -> dict:
+    """Return distinct {usernames, orgs} for users with at least one
+    user-role Message in the date range. Lists sorted ascending. Includes
+    ``(no org)`` sentinel if any in-range user has NULL/empty organization."""
+    try:
+        from orm.models import Message, User
+        from utils.enums import RoleType
+
+        since = datetime.utcnow() - timedelta(days=int(days))
+        with SessionLocal() as session:
+            rows = (
+                session.query(User.username, User.organization)
+                .join(Message, Message.user_id == User.id)
+                .filter(Message.role == RoleType.USER.value, Message.created_at >= since)
+                .distinct()
+                .all()
+            )
+        usernames = sorted({r[0] for r in rows if r[0]})
+        orgs_raw = {r[1] for r in rows}
+        concrete_orgs = sorted({o for o in orgs_raw if o})
+        has_no_org = any((o is None) or (o == "") for o in orgs_raw)
+        orgs = ([_NO_ORG_SENTINEL] if has_no_org else []) + concrete_orgs
+        return {"usernames": usernames, "orgs": orgs}
+    except Exception as e:
+        logger.warning("get_question_audit_filter_options failed: %s", e)
+        return {"usernames": [], "orgs": []}
+
+
+def get_question_audit_export(filters: dict) -> list[dict]:
+    """Full filtered set with no pagination, capped at MAX_AUDIT_EXPORT_ROWS."""
+    try:
+        with SessionLocal() as session:
+            base_query = _question_audit_base_query(session, filters)
+            rows = base_query.limit(MAX_AUDIT_EXPORT_ROWS + 1).all()
+            if len(rows) > MAX_AUDIT_EXPORT_ROWS:
+                logger.warning(
+                    "get_question_audit_export hit MAX_AUDIT_EXPORT_ROWS=%s; truncating",
+                    MAX_AUDIT_EXPORT_ROWS,
+                )
+                rows = rows[:MAX_AUDIT_EXPORT_ROWS]
+            return _enrich_with_assistant_aggregates(session, rows)
+    except Exception as e:
+        logger.warning("get_question_audit_export failed: %s", e)
         return []
 
 

--- a/tests/orm/test_question_audit.py
+++ b/tests/orm/test_question_audit.py
@@ -1,0 +1,340 @@
+"""Tests for orm.logging_functions question-audit helpers (#134)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import Base, Message, RoleTypeEnum, User, UserRole
+from utils.enums import MessageType, RoleType
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add_all(
+        [
+            UserRole(id=1, role_name="Admin", description="Admin", role=RoleTypeEnum.ADMIN),
+            UserRole(id=4, role_name="Patient", description="Patient", role=RoleTypeEnum.PATIENT),
+        ]
+    )
+    session.commit()
+
+
+def _seed_user(session, *, id, username, org=None, role_id=4):
+    session.add(
+        User(
+            id=id,
+            user_role_id=role_id,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+            organization=org,
+        )
+    )
+    session.commit()
+
+
+def _add_question(session, *, user_id, content, when, elapsed=None, sql=None, summary=None, dataframe=None, error=None):
+    """Seed a user message + optional assistant rows (SQL / summary / dataframe / error)."""
+    session.add(
+        Message(
+            role=RoleType.USER,
+            content=content,
+            type=MessageType.TEXT,
+            user_id=user_id,
+        )
+    )
+    session.commit()
+    # Override created_at after insert (server_default=func.now() is set on insert)
+    last = session.query(Message).order_by(Message.id.desc()).first()
+    last.created_at = when
+    session.commit()
+
+    if sql is not None:
+        session.add(
+            Message(
+                role=RoleType.ASSISTANT,
+                content=sql,
+                type=MessageType.SQL,
+                user_id=user_id,
+                question=content,
+                elapsed_time=elapsed,
+            )
+        )
+    if summary is not None:
+        session.add(
+            Message(
+                role=RoleType.ASSISTANT,
+                content=summary,
+                type=MessageType.SUMMARY,
+                user_id=user_id,
+                question=content,
+            )
+        )
+    if dataframe is not None:
+        session.add(
+            Message(
+                role=RoleType.ASSISTANT,
+                content=dataframe,
+                type=MessageType.DATAFRAME,
+                user_id=user_id,
+                question=content,
+            )
+        )
+    if error is not None:
+        session.add(
+            Message(
+                role=RoleType.ASSISTANT,
+                content=error,
+                type=MessageType.ERROR,
+                user_id=user_id,
+                question=content,
+            )
+        )
+    session.commit()
+
+
+def _filters(usernames=None, orgs=None, days=30, search=None):
+    return {"usernames": usernames or [], "orgs": orgs or [], "days": days, "search": search}
+
+
+def test_empty_database_returns_empty(session_factory):
+    from orm.logging_functions import get_question_audit_filter_options, get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page == {"items": [], "total": 0}
+
+    opts = get_question_audit_filter_options(days=30)
+    assert opts == {"usernames": [], "orgs": []}
+
+
+def test_single_user_three_questions_reverse_chrono(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice", org="Acme")
+
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="q1 oldest", when=now - timedelta(hours=2))
+    _add_question(s, user_id=10, content="q2 middle", when=now - timedelta(hours=1))
+    _add_question(s, user_id=10, content="q3 newest", when=now)
+
+    result = get_question_audit_page(_filters(), page=1, page_size=50)
+    qs = [it["question"] for it in result["items"]]
+    assert qs == ["q3 newest", "q2 middle", "q1 oldest"]
+    assert result["total"] == 3
+
+
+def test_pagination(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(3):
+        _add_question(s, user_id=10, content=f"q{i}", when=base - timedelta(hours=i))
+
+    p1 = get_question_audit_page(_filters(), page=1, page_size=2)
+    p2 = get_question_audit_page(_filters(), page=2, page_size=2)
+    assert len(p1["items"]) == 2
+    assert len(p2["items"]) == 1
+    assert p1["total"] == 3 and p2["total"] == 3
+
+
+def test_username_filter(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _seed_user(s, id=11, username="bob")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="a-only", when=now)
+    _add_question(s, user_id=11, content="b-only", when=now)
+
+    result = get_question_audit_page(_filters(usernames=["alice"]), page=1, page_size=50)
+    qs = [it["question"] for it in result["items"]]
+    assert qs == ["a-only"]
+
+
+def test_org_filter_no_org_sentinel(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice", org="Acme")
+    _seed_user(s, id=11, username="bob", org=None)
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="acme-q", when=now)
+    _add_question(s, user_id=11, content="noorg-q", when=now)
+
+    noorg = get_question_audit_page(_filters(orgs=["(no org)"]), page=1, page_size=50)
+    assert [it["question"] for it in noorg["items"]] == ["noorg-q"]
+
+    acme = get_question_audit_page(_filters(orgs=["Acme"]), page=1, page_size=50)
+    assert [it["question"] for it in acme["items"]] == ["acme-q"]
+
+
+def test_date_filter_excludes_old_questions(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime.utcnow()
+    _add_question(s, user_id=10, content="recent", when=now - timedelta(days=1))
+    _add_question(s, user_id=10, content="old", when=now - timedelta(days=60))
+
+    result = get_question_audit_page(_filters(days=7), page=1, page_size=50)
+    qs = [it["question"] for it in result["items"]]
+    assert "recent" in qs
+    assert "old" not in qs
+
+
+def test_search_matches_question_content(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="What about John Doe today?", when=now)
+    _add_question(s, user_id=10, content="Show me yesterday's totals", when=now - timedelta(minutes=1))
+
+    result = get_question_audit_page(_filters(search="john doe"), page=1, page_size=50)
+    qs = [it["question"] for it in result["items"]]
+    assert qs == ["What about John Doe today?"]
+
+
+def test_search_matches_assistant_sql_content(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(
+        s,
+        user_id=10,
+        content="how many?",
+        when=now,
+        sql="SELECT count(*) FROM patient WHERE mrn = 12345",
+    )
+    _add_question(s, user_id=10, content="unrelated", when=now - timedelta(minutes=1))
+
+    result = get_question_audit_page(_filters(search="mrn = 12345"), page=1, page_size=50)
+    qs = [it["question"] for it in result["items"]]
+    assert qs == ["how many?"]
+
+
+def test_status_success_summary(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="ok", when=now, summary="here you go")
+
+    result = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert result["items"][0]["status"] == "Success"
+
+
+def test_status_error(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="fail", when=now, summary="partial", error="boom")
+
+    result = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert result["items"][0]["status"] == "Error"
+
+
+def test_status_empty(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="hanging", when=now)
+
+    result = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert result["items"][0]["status"] == "Empty"
+
+
+def test_elapsed_is_sum_across_assistant_rows(session_factory):
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_question(s, user_id=10, content="q", when=now, elapsed=1.5, sql="select 1", summary="ok")
+    last_assistant = (
+        s.query(Message).filter(Message.role == RoleType.ASSISTANT.value, Message.question == "q", Message.type == MessageType.SUMMARY.value).first()
+    )
+    last_assistant.elapsed_time = 0.25
+    s.commit()
+
+    result = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert result["items"][0]["elapsed_seconds"] == pytest.approx(1.75)
+
+
+def test_filter_options_returns_distinct_sorted(session_factory):
+    from orm.logging_functions import get_question_audit_filter_options
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice", org="Acme")
+    _seed_user(s, id=11, username="bob", org="Beta")
+    _seed_user(s, id=12, username="carol", org=None)
+    _seed_user(s, id=13, username="dave_no_questions", org="Gamma")  # no questions → excluded
+    now = datetime.utcnow()
+    _add_question(s, user_id=10, content="q1", when=now - timedelta(days=1))
+    _add_question(s, user_id=11, content="q2", when=now - timedelta(days=1))
+    _add_question(s, user_id=12, content="q3", when=now - timedelta(days=1))
+
+    opts = get_question_audit_filter_options(days=30)
+    assert opts["usernames"] == ["alice", "bob", "carol"]
+    assert opts["orgs"] == ["(no org)", "Acme", "Beta"]
+
+
+def test_export_returns_full_filtered_set_no_pagination(session_factory):
+    from orm.logging_functions import get_question_audit_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(7):
+        _add_question(s, user_id=10, content=f"q{i}", when=base - timedelta(hours=i))
+
+    rows = get_question_audit_export(_filters())
+    assert len(rows) == 7
+    # Same item shape as page items
+    assert "question" in rows[0]
+    assert "sql_text" in rows[0]
+    assert "status" in rows[0]

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -8,6 +8,9 @@ from sqlalchemy import case, func
 
 from orm.models import Message, RoleTypeEnum, SessionLocal, User
 from utils.enums import MessageType, RoleType
+from utils.quick_logger import get_logger
+
+logger = get_logger(__name__)
 
 # Cache TTL for analytics queries (5 minutes)
 ANALYTICS_CACHE_TTL_SECONDS = 300
@@ -321,9 +324,36 @@ def _render_overview_tab(days_int: int):
 
     st.divider()
 
-    # Latest Questions
+    # Latest Questions — compact preview that links to the canonical Audit Trail tab (#136).
     st.subheader("Latest Questions")
-    limit = st.selectbox("Show last", options=[25, 50, 100, 200], index=0, key="overview_limit")
+    from orm.logging_functions import get_question_audit_page
+
+    preview = get_question_audit_page(
+        {"usernames": [], "orgs": [], "days": days_int, "search": None},
+        page=1,
+        page_size=10,
+    )
+    preview_items = preview.get("items", [])
+    if preview_items:
+        compact_rows = [
+            {
+                "User": it["username"],
+                "Question": _truncate(it["question"], 120),
+                "Asked At": it["asked_at"],
+                "Status": _AUDIT_STATUS_EMOJI.get(it["status"], it["status"]),
+            }
+            for it in preview_items
+        ]
+        st.dataframe(pd.DataFrame(compact_rows), width="stretch", hide_index=True)
+    else:
+        st.info("No questions in the selected time range.")
+    if st.button("View full Audit Trail →", type="primary", key="overview_to_audit_btn"):
+        st.switch_page("views/admin_analytics.py")
+
+    st.divider()
+
+    # All Users Stats
+    st.subheader("All Users Stats")
     chart_types = [
         MessageType.PLOTLY_CHART.value,
         MessageType.ST_LINE_CHART.value,
@@ -331,66 +361,6 @@ def _render_overview_tab(days_int: int):
         MessageType.ST_AREA_CHART.value,
         MessageType.ST_SCATTER_CHART.value,
     ]
-    with SessionLocal() as session:
-        base = (
-            session.query(
-                Message.content.label("question"),
-                Message.created_at.label("asked_at"),
-                User.username.label("username"),
-            )
-            .join(User, User.id == Message.user_id)
-            .filter(Message.role == RoleType.USER.value)
-            .order_by(Message.created_at.desc())
-            .limit(int(limit))
-            .all()
-        )
-        questions = [row.question for row in base]
-        agg = []
-        if questions:
-            agg = (
-                session.query(
-                    Message.question.label("q"),
-                    func.sum(case((Message.type.in_(chart_types), 1), else_=0)).label("charts"),
-                    func.sum(case((Message.type == MessageType.DATAFRAME.value, 1), else_=0)).label("dataframes"),
-                    func.sum(case((Message.type == MessageType.SUMMARY.value, 1), else_=0)).label("summaries"),
-                    func.sum(case((Message.type == MessageType.ERROR.value, 1), else_=0)).label("errors"),
-                    func.sum(func.coalesce(Message.elapsed_time, 0)).label("elapsed"),
-                )
-                .filter(
-                    Message.role == RoleType.ASSISTANT.value,
-                    Message.question.isnot(None),
-                    Message.question.in_(questions),
-                )
-                .group_by(Message.question)
-                .all()
-            )
-    metrics = {row.q: row for row in agg} if agg else {}
-    latest_rows = []
-    for question, asked_at, username in base:
-        m = metrics.get(question)
-        errors = int(getattr(m, "errors", 0) or 0) if m else 0
-        success = (
-            int(getattr(m, "charts", 0) or 0)
-            + int(getattr(m, "dataframes", 0) or 0)
-            + int(getattr(m, "summaries", 0) or 0)
-        ) > 0 and errors == 0
-        latest_rows.append(
-            {
-                "User": username,
-                "Question": question,
-                "Asked At": asked_at,
-                "Status": "Success" if success else ("Error" if errors > 0 else "Unknown"),
-                "Elapsed (s)": round(float(getattr(m, "elapsed", 0) or 0.0), 3) if m else 0.0,
-            }
-        )
-    if latest_rows:
-        ldf = pd.DataFrame(latest_rows)
-        st.dataframe(ldf, width="stretch", hide_index=True)
-
-    st.divider()
-
-    # All Users Stats
-    st.subheader("All Users Stats")
     with SessionLocal() as session:
         rows = (
             session.query(
@@ -412,6 +382,196 @@ def _render_overview_tab(days_int: int):
             width="stretch",
             hide_index=True,
         )
+
+
+@st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
+def _cached_audit_filter_options(days_int: int) -> dict:
+    from orm.logging_functions import get_question_audit_filter_options
+
+    return get_question_audit_filter_options(days=days_int)
+
+
+_AUDIT_STATUS_EMOJI = {"Success": "✅ Success", "Error": "❌ Error", "Empty": "⚪ Empty"}
+
+
+def _truncate(text, length):
+    if text is None:
+        return ""
+    text = str(text)
+    return text if len(text) <= length else text[: length - 1] + "…"
+
+
+def _render_audit_trail_tab(days_int: int):
+    """Render the Question Audit Trail tab (#135)."""
+    import datetime as _dt
+
+    from orm.logging_functions import (
+        get_question_audit_export,
+        get_question_audit_page,
+    )
+    from orm.functions import get_all_users
+
+    options = _cached_audit_filter_options(days_int)
+
+    # Honour deep-link pre-filter from Manage Users -> Activity
+    pref_user_id = st.session_state.pop("audit_trail_pref_user_id", None)
+    if pref_user_id is not None and "audit_user_filter" not in st.session_state:
+        try:
+            all_users = get_all_users()
+            match = next((u for u in all_users if u["id"] == int(pref_user_id)), None)
+            if match and match["username"] in options["usernames"]:
+                st.session_state["audit_user_filter"] = [match["username"]]
+        except Exception as e:
+            logger.warning("Audit deep-link prefill failed: %s", e)
+
+    f1, f2, f3 = st.columns([0.30, 0.30, 0.40])
+    with f1:
+        usernames_sel = st.multiselect(
+            "User", options=options["usernames"], key="audit_user_filter"
+        )
+    with f2:
+        orgs_sel = st.multiselect(
+            "Organization", options=options["orgs"], key="audit_org_filter"
+        )
+    with f3:
+        search = st.text_input(
+            "Search question or SQL",
+            placeholder="Substring match (case-insensitive)",
+            key="audit_search",
+        )
+
+    filters = {
+        "usernames": usernames_sel,
+        "orgs": orgs_sel,
+        "days": int(days_int),
+        "search": search.strip() if search else None,
+    }
+
+    # Reset pagination on filter change
+    filter_signature = json.dumps({**filters, "_days": days_int}, sort_keys=True, default=str)
+    if st.session_state.get("audit_filter_signature") != filter_signature:
+        st.session_state["audit_filter_signature"] = filter_signature
+        st.session_state["audit_page_num"] = 1
+
+    # Pagination controls (top row)
+    if "audit_page_bump" in st.session_state:
+        st.session_state["audit_page_num"] = max(
+            1, int(st.session_state.get("audit_page_num", 1)) + int(st.session_state["audit_page_bump"])
+        )
+        del st.session_state["audit_page_bump"]
+    if "audit_page_num" not in st.session_state:
+        st.session_state["audit_page_num"] = 1
+
+    pc1, pc2, _spacer = st.columns([1, 1, 6])
+    with pc1:
+        page_size = st.selectbox("Page size", options=[25, 50, 100, 200], index=1, key="audit_page_size")
+    with pc2:
+        st.number_input("Page", min_value=1, step=1, key="audit_page_num")
+        page = int(st.session_state["audit_page_num"])
+
+    result = get_question_audit_page(filters, page=page, page_size=int(page_size))
+    items = result.get("items", [])
+    total = int(result.get("total", 0))
+    total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
+
+    # Table
+    if items:
+        table_rows = []
+        for it in items:
+            table_rows.append(
+                {
+                    "Asked At": it["asked_at"],
+                    "User": it["username"],
+                    "Organization": it.get("organization") or "(no org)",
+                    "Question": _truncate(it["question"], 120),
+                    "SQL": _truncate(it.get("sql_text"), 80),
+                    "Status": _AUDIT_STATUS_EMOJI.get(it["status"], it["status"]),
+                    "Elapsed (s)": round(float(it.get("elapsed_seconds") or 0.0), 3),
+                }
+            )
+        st.dataframe(pd.DataFrame(table_rows), width="stretch", hide_index=True)
+    else:
+        st.info("No audit rows match the current filters.")
+
+    # Pagination caption + Prev/Next
+    cprev, cinfo, cnext = st.columns([1, 3, 1])
+    with cprev:
+        st.button(
+            "Prev",
+            disabled=int(page) <= 1,
+            key="audit_prev_btn",
+            on_click=lambda: st.session_state.update({"audit_page_bump": -1}),
+        )
+    with cinfo:
+        st.caption(f"Page {int(page)} of {total_pages} • {total} total")
+    with cnext:
+        st.button(
+            "Next",
+            disabled=int(page) >= total_pages,
+            key="audit_next_btn",
+            on_click=lambda: st.session_state.update({"audit_page_bump": 1}),
+        )
+
+    # Row drilldown expanders
+    for it in items:
+        header = f"{it['asked_at']} • {it['username']} • {_truncate(it['question'], 80)}"
+        with st.expander(header):
+            st.markdown("**Question**")
+            st.write(it["question"] or "_(empty)_")
+            st.markdown("**Generated SQL**")
+            st.code(it.get("sql_text") or "(no SQL)", language="sql")
+            st.markdown("**Summary**")
+            summary = it.get("summary_text")
+            st.write(summary if summary else "_(no summary)_")
+            df_preview = it.get("dataframe_preview")
+            if df_preview:
+                st.markdown("**DataFrame preview (first 5 rows)**")
+                try:
+                    df_obj = pd.read_json(df_preview).head(5)
+                    st.dataframe(df_obj, width="stretch", hide_index=True)
+                except Exception:
+                    st.text(str(df_preview)[:1000])
+            err = it.get("error_text")
+            if err:
+                st.markdown("**Error**")
+                st.code(err, language="text")
+            st.caption(
+                f"Asked At {it['asked_at']} · Elapsed "
+                f"{round(float(it.get('elapsed_seconds') or 0.0), 3)}s · Message ID {it.get('user_message_id')}"
+            )
+
+    # Export CSV
+    if st.button("📥 Export filtered audit to CSV", key="audit_export_btn"):
+        try:
+            export_rows = get_question_audit_export(filters)
+            if not export_rows:
+                st.warning("No audit rows to export with current filters.")
+            else:
+                export_df = pd.DataFrame(
+                    [
+                        {
+                            "Asked At": r["asked_at"],
+                            "User": r["username"],
+                            "Organization": r.get("organization") or "(no org)",
+                            "Question": r["question"],
+                            "SQL": r.get("sql_text") or "",
+                            "Status": r["status"],
+                            "Elapsed (s)": round(float(r.get("elapsed_seconds") or 0.0), 3),
+                        }
+                        for r in export_rows
+                    ]
+                )
+                ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+                st.download_button(
+                    "Download question_audit_*.csv",
+                    data=export_df.to_csv(index=False).encode("utf-8"),
+                    file_name=f"question_audit_{ts}.csv",
+                    mime="text/csv",
+                    key="audit_export_download",
+                )
+        except Exception as e:
+            st.error(f"Export failed: {e}")
+            logger.error("Audit export failed: %s", e)
 
 
 def _render_llm_tab(days_int: int):
@@ -774,21 +934,24 @@ def main():
     # error visibility.
     from views.errors import render as render_errors_tab
 
-    tabs = st.tabs(["Overview", "LLM Performance", "User Activity", "Errors", "Admin Audit"])
+    tabs = st.tabs(["Audit Trail", "Overview", "LLM Performance", "User Activity", "Errors", "Admin Audit"])
 
     with tabs[0]:
-        _render_overview_tab(days_int)
+        _render_audit_trail_tab(days_int)
 
     with tabs[1]:
-        _render_llm_tab(days_int)
+        _render_overview_tab(days_int)
 
     with tabs[2]:
-        _render_activity_tab(days_int)
+        _render_llm_tab(days_int)
 
     with tabs[3]:
-        render_errors_tab(days_int)
+        _render_activity_tab(days_int)
 
     with tabs[4]:
+        render_errors_tab(days_int)
+
+    with tabs[5]:
         _render_audit_tab(days_int)
 
 

--- a/views/user.py
+++ b/views/user.py
@@ -13,7 +13,6 @@ from orm.functions import (
     get_all_user_roles,
     get_all_users,
     get_user_daily_stats,
-    get_user_questions_page,
     get_user_recent_questions,
     get_user_stats_for_all_users,
     get_users_for_export,
@@ -988,98 +987,13 @@ if tab3 and st.session_state.get("user_role") == RoleTypeEnum.ADMIN.value:
                         fig.update_layout(margin=dict(l=0, r=0, t=10, b=0), legend_title_text="")
                         st.plotly_chart(fig, use_container_width=True)
 
-                    with st.expander("Recent Questions"):
-                        if st.session_state.get("q_selected_user_id") != selected["id"]:
-                            st.session_state["q_selected_user_id"] = selected["id"]
-                            st.session_state["q_page_num"] = 1
-                        if "q_page_num" not in st.session_state:
-                            st.session_state["q_page_num"] = 1
-                        if "q_page_bump" in st.session_state:
-                            st.session_state["q_page_num"] = max(
-                                1,
-                                int(st.session_state.get("q_page_num", 1))
-                                + int(st.session_state["q_page_bump"]),
-                            )
-                            del st.session_state["q_page_bump"]
-
-                        colq1, colq2, colq3 = st.columns([1, 1, 6])
-                        with colq1:
-                            page_size = st.selectbox(
-                                "Page size", options=[25, 50, 100], index=1, key="q_page_size"
-                            )
-                        with colq2:
-                            st.number_input("Page", min_value=1, step=1, key="q_page_num")
-                            page = int(st.session_state["q_page_num"])
-
-                        page_data = get_user_questions_page(
-                            selected["id"], page=int(page), page_size=int(page_size)
-                        )
-                        items = page_data.get("items", [])
-                        total = page_data.get("total", 0)
-
-                        if items:
-                            qdf = pd.DataFrame(items)
-                            qdf.rename(
-                                columns={
-                                    "question": "Question",
-                                    "created_at": "Asked At",
-                                    "status": "Status",
-                                    "elapsed_seconds": "Elapsed (s)",
-                                },
-                                inplace=True,
-                            )
-                            st.dataframe(qdf, use_container_width=True, hide_index=True)
-
-                            total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
-                            cprev, cinfo, cnext = st.columns([1, 3, 1])
-                            with cprev:
-                                st.button(
-                                    "Prev",
-                                    disabled=int(page) <= 1,
-                                    on_click=lambda: st.session_state.update({"q_page_bump": -1}),
-                                )
-                            with cinfo:
-                                st.caption(f"Page {int(page)} of {total_pages} • {total} total")
-                            with cnext:
-                                st.button(
-                                    "Next",
-                                    disabled=int(page) >= total_pages,
-                                    on_click=lambda: st.session_state.update({"q_page_bump": 1}),
-                                )
-
-                            all_rows = []
-                            all_page_size = 1000
-                            remaining = total
-                            page_iter = 1
-                            while remaining > 0 and page_iter <= 100:  # safety cap
-                                p = get_user_questions_page(
-                                    selected["id"], page=page_iter, page_size=all_page_size
-                                )
-                                all_rows.extend(p.get("items", []))
-                                if len(p.get("items", [])) < all_page_size:
-                                    break
-                                remaining -= len(p.get("items", []))
-                                page_iter += 1
-                            if all_rows:
-                                all_df = pd.DataFrame(all_rows)
-                                all_df.rename(
-                                    columns={
-                                        "question": "Question",
-                                        "created_at": "Asked At",
-                                        "status": "Status",
-                                        "elapsed_seconds": "Elapsed (s)",
-                                    },
-                                    inplace=True,
-                                )
-                                csv_bytes = all_df.to_csv(index=False).encode("utf-8")
-                                st.download_button(
-                                    label="Download all questions (.csv)",
-                                    data=csv_bytes,
-                                    file_name=f"{selected['username']}_questions.csv",
-                                    mime="text/csv",
-                                )
-                        else:
-                            st.info("No questions found.")
+                    if st.button(
+                        f"View question audit for {selected['username']} →",
+                        type="primary",
+                        key="activity_audit_deeplink_btn",
+                    ):
+                        st.session_state["audit_trail_pref_user_id"] = selected["id"]
+                        st.switch_page("views/admin_analytics.py")
 
                 with danger_tab:
                     if st.button("Delete User", type="primary", key="danger_delete_user_btn"):


### PR DESCRIPTION
Closes #134, #135, and #136. Implements Epic #133 end-to-end in one combined PR (per the agreed PR strategy).

## Summary

**Backend (#134):** three new helpers in `orm/logging_functions.py` for the question audit dataset. `get_question_audit_page` (paginated), `get_question_audit_filter_options` (distinct users + orgs in range), `get_question_audit_export` (full filtered set, capped at 50k). Filter dict contract: `usernames`, `orgs` (with `(no org)` sentinel), `days`, `search` (matches either question text OR generated SQL via EXISTS subquery). 14 new unit tests in `tests/orm/test_question_audit.py`, full orm suite 157 passing.

**UI tab (#135):** `_render_audit_trail_tab` wired as the first tab. Filter row + paginated table + row drilldown expander + Export CSV button. Honors `st.session_state["audit_trail_pref_user_id"]` for deep-link entry from Manage Users (pops the key and pre-fills the User multiselect when no prior `audit_user_filter` value exists).

**Retire duplicates (#136):** Overview's "Latest Questions" trimmed to a compact 10-row preview + `View full Audit Trail →` button. Manage Users → Activity's per-user Recent Questions expander replaced with a single primary `View question audit for <username> →` button writing the pref key and navigating via `st.switch_page("views/admin_analytics.py")`. Orphaned `q_*` session-state keys removed.

## Test plan
- [x] `uv run pytest tests/orm/test_question_audit.py` — 14 passed
- [x] `uv run pytest tests/orm/` — 157 passed (143 baseline + 14 new)
- [x] `uv run ruff check orm/logging_functions.py views/admin_analytics.py tests/orm/test_question_audit.py` clean (3 pre-existing errors in `views/user.py` are out of scope)
- [x] Streamlit boots; Admin Analytics renders 6 tabs in order `[Audit Trail, Overview, LLM Performance, User Activity, Errors, Admin Audit]`
- [x] Audit Trail tab: filter row (User + Organization + Search) + paginated table with the seven specified columns + status badges (✅/❌/⚪) — verified with real dev DB data
- [x] Overview tab: "Latest Questions" is the compact 10-row preview with no legacy top-N selectbox; `View full Audit Trail →` button present
- [x] Manage Users → Activity: `View question audit for thriveai-kr →` button present; Recent Questions expander gone
- [x] Static greps for spec deletions: `"Create New User"`, `q_selected_user_id`, `q_page_num`, `q_page_bump`, `q_page_size`, `overview_limit`, `with st.expander("Recent Questions"):` all absent

## Heads-up

The deep-link pre-fill is guarded by `"audit_user_filter" not in st.session_state` so it does not clobber a user's prior selection on the audit tab. In a session where the audit tab has been visited before (so `audit_user_filter` is already `[]`), the pre-fill is skipped — that's the intended "manual filter change is not overridden" semantics from the spec. On a fresh session the deep-link pre-fills the user as expected. If you want to override even empty prior selections, that's a one-line tweak.

## Non-functional
- `git diff --name-only origin/main..HEAD` returns only `orm/logging_functions.py`, `tests/orm/test_question_audit.py`, `views/admin_analytics.py`, `views/user.py`. Matches the Epic's scope constraint.
- No backend / schema changes. No Alembic migration. No new third-party deps.
- `st.switch_page` works natively because `app.py` already uses `st.Page` + `st.navigation` with file-path-registered pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)