### PR TITLE
fix(audit-trail): View full Audit Trail button now actually switches tabs

### DIFF
--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -347,8 +347,31 @@ def _render_overview_tab(days_int: int):
         st.dataframe(pd.DataFrame(compact_rows), width="stretch", hide_index=True)
     else:
         st.info("No questions in the selected time range.")
-    if st.button("View full Audit Trail →", type="primary", key="overview_to_audit_btn"):
-        st.switch_page("views/admin_analytics.py")
+    # Streamlit's st.tabs widget has no server-side API to change the active
+    # tab and st.switch_page is a no-op on the same page, so we use a small
+    # JS shim served via components.v1.html that clicks the parent window's
+    # Audit Trail tab on link click.
+    st.components.v1.html(
+        """
+        <a href="#" id="goto-audit-link" onclick="
+          (function(){
+            try {
+              var tabs = window.parent.document.querySelectorAll('button[role=tab]');
+              for (var i = 0; i < tabs.length; i++) {
+                if (tabs[i].textContent.trim() === 'Audit Trail') { tabs[i].click(); break; }
+              }
+            } catch (e) { console.error('audit-tab nav failed', e); }
+            return false;
+          })();
+          return false;
+        " style="display:inline-block;padding:0.5rem 1rem;background:#0b5258;
+                 color:white;text-decoration:none;border-radius:0.5rem;
+                 font-weight:600;font-family:inherit;">
+          View full Audit Trail →
+        </a>
+        """,
+        height=60,
+    )
 
     st.divider()
 


### PR DESCRIPTION
Follow-up to #150. The "View full Audit Trail →" button on the Overview tab was wired to `st.switch_page("views/admin_analytics.py")`, which is a no-op when called from the page you're already on — Streamlit reruns the script but the active tab is preserved. So the button visibly did nothing.

## Why st.switch_page can't do this
`st.tabs` has no server-side API to set the active tab; selection is purely client-side React state. Calling `st.switch_page` to the same page doesn't reset that state.

## Fix
Serve a small HTML+JS shim via `st.components.v1.html` that, on click, reaches up to the parent window and programmatically clicks the `button[role="tab"]` whose label is `"Audit Trail"`. Works in-place — no page reload, no URL change.

## Test plan
- [x] From Admin Analytics → Overview tab → click `View full Audit Trail →` → confirmed via Playwright that the active tab switches to `Audit Trail`.
- [x] `uv run ruff check views/admin_analytics.py` clean.

## Non-functional
- Single-file change. `git diff --name-only` returns only `views/admin_analytics.py`.
- No backend changes, no new deps, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)