### PR TITLE
feat(audit): Questions tab row-click dialog + Manage Users deep-link (#155)

### DIFF
--- a/tests/views/test_admin_audit_dialog.py
+++ b/tests/views/test_admin_audit_dialog.py
@@ -1,0 +1,804 @@
+"""Tests for the Questions audit tab row-click dialog (#155).
+
+Covers:
+  (a) Dialog opens when selection state changes and closes when cleared.
+  (b) Deep-link round-trip — setting `manage_users_pref_user_id` causes
+      Manage Users to pre-populate `mu_selected_label` with the target user.
+  (c) `role_can_see_query_details` returning False hides the SQL block and
+      the full DataFrame inside the dialog body while keeping question /
+      summary / error visible.
+  (d) `[agent_logging].mode = "disabled"` makes the dialog unreachable
+      (selection_mode is not passed to st.dataframe).
+  (e) The dialog renders all rows from `dataframe_preview`, not just the
+      first 5 (regression on the old expander `.head(5)` truncation).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from orm.models import RoleTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    *,
+    user_message_id: int = 42,
+    user_id: int = 7,
+    username: str = "alice",
+    organization: str | None = "Acme",
+    question: str = "How many patients today?",
+    sql_text: str | None = "SELECT count(*) FROM patient",
+    summary_text: str | None = "There are 12 patients.",
+    dataframe_preview: str | None = None,
+    error_text: str | None = None,
+    elapsed_seconds: float = 1.25,
+    asked_at: datetime | None = None,
+) -> dict:
+    """Build a single audit item matching the shape of
+    orm.logging_functions._enrich_with_assistant_aggregates output."""
+    if dataframe_preview is None:
+        # 7 rows so a `.head(5)` truncation would lose 2 rows.
+        df = pd.DataFrame({"x": list(range(7)), "y": [chr(ord("a") + i) for i in range(7)]})
+        dataframe_preview = df.to_json()
+    return {
+        "asked_at": asked_at or datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": user_id,
+        "username": username,
+        "organization": organization,
+        "question": question,
+        "sql_text": sql_text,
+        "status": "Error" if error_text else "Success",
+        "elapsed_seconds": elapsed_seconds,
+        "summary_text": summary_text,
+        "dataframe_preview": dataframe_preview,
+        "error_text": error_text,
+        "user_message_id": user_message_id,
+    }
+
+
+class _RecordingStreamlit:
+    """A minimal recording stand-in for the `st` module that captures the
+    sequence of code/dataframe/write/markdown calls made by the dialog
+    body so we can assert what was rendered.
+
+    Only the surface used by `_render_audit_question_dialog` is implemented.
+    """
+
+    def __init__(self, user_role: int | None = RoleTypeEnum.ADMIN.value):
+        self.session_state: dict = {"user_role": user_role}
+        self.code_calls: list[tuple[str, str]] = []  # (content, language)
+        self.dataframe_calls: list[pd.DataFrame] = []
+        self.write_calls: list = []
+        self.markdown_calls: list[str] = []
+        self.caption_calls: list[str] = []
+        self.button_clicked_key: str | None = None
+        self.switch_page_target: str | None = None
+
+        # components.v1.html stub
+        self.components = MagicMock()
+        self.components.v1 = MagicMock()
+        self.components.v1.html = MagicMock()
+
+    # ---- Streamlit surface --------------------------------------------------
+    def markdown(self, body, **_kwargs):
+        self.markdown_calls.append(str(body))
+
+    def write(self, body, **_kwargs):
+        self.write_calls.append(body)
+
+    def code(self, body, language: str = "text", **_kwargs):
+        self.code_calls.append((str(body), language))
+
+    def dataframe(self, df, **_kwargs):
+        # We only record real DataFrames passed by the dialog body.
+        if isinstance(df, pd.DataFrame):
+            self.dataframe_calls.append(df)
+        return MagicMock()
+
+    def caption(self, body, **_kwargs):
+        self.caption_calls.append(str(body))
+
+    def divider(self):  # no-op
+        pass
+
+    def button(self, label, key=None, **_kwargs):
+        # Default: button NOT clicked. Tests can override via
+        # `force_button_click_key` to simulate a click.
+        clicked = key is not None and key == getattr(self, "_force_click_key", None)
+        if clicked:
+            self.button_clicked_key = key
+        return clicked
+
+    def switch_page(self, target):
+        self.switch_page_target = target
+
+    # Decorators must be no-ops: we want to call the wrapped function directly.
+    def dialog(self, _title):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+# ---------------------------------------------------------------------------
+# (c) Role gate — full DataFrame and SQL hidden when role cannot see details
+# ---------------------------------------------------------------------------
+
+
+class TestDialogRoleGate:
+    def test_admin_sees_sql_and_dataframe(self):
+        """When role_can_see_query_details returns True, the dialog renders the
+        SQL block AND the full DataFrame."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        item = _make_item()
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        # SQL block rendered
+        sql_codes = [body for body, lang in rec.code_calls if lang == "sql"]
+        assert sql_codes, "Expected SQL block to be rendered for admin role"
+        assert "SELECT count(*)" in sql_codes[0]
+
+        # Full DataFrame rendered (all 7 rows from the preview JSON)
+        assert rec.dataframe_calls, "Expected DataFrame to be rendered for admin role"
+        assert len(rec.dataframe_calls[0]) == 7, "Dialog must render the FULL stored DataFrame, not .head(5)"
+
+    def test_non_admin_hides_sql_and_dataframe_keeps_other_sections(self):
+        """When role_can_see_query_details returns False, hide SQL and full
+        DataFrame; question / summary / error remain visible."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.DOCTOR.value)
+        item = _make_item(error_text="Something went wrong on the warehouse.")
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=False,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        # No SQL code block
+        sql_codes = [body for body, lang in rec.code_calls if lang == "sql"]
+        assert sql_codes == [], "SQL must be hidden when role cannot see query details"
+
+        # No DataFrame rendered
+        assert rec.dataframe_calls == [], "Full DataFrame must be hidden when role cannot see query details"
+
+        # Question + summary still visible
+        write_str = " ".join(str(x) for x in rec.write_calls)
+        assert "How many patients today?" in write_str
+        assert "There are 12 patients." in write_str
+
+        # Error block still rendered as plain text
+        text_codes = [body for body, lang in rec.code_calls if lang == "text"]
+        assert any("Something went wrong" in body for body in text_codes)
+
+
+# ---------------------------------------------------------------------------
+# Full DataFrame rendering (Testable Outcome: "renders all rows")
+# ---------------------------------------------------------------------------
+
+
+class TestDialogFullDataFrame:
+    def test_dialog_renders_all_rows_not_just_first_five(self):
+        """For a DataFrame with > 5 rows, the dialog must render ALL rows.
+        Regression on the old expander's `.head(5)` truncation."""
+        from views import admin_analytics
+
+        df = pd.DataFrame({"n": list(range(12))})
+        item = _make_item(dataframe_preview=df.to_json())
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert rec.dataframe_calls, "Expected a DataFrame to be rendered"
+        rendered = rec.dataframe_calls[0]
+        assert len(rendered) == 12, f"Dialog must render all 12 rows, got {len(rendered)}"
+
+
+# ---------------------------------------------------------------------------
+# Outbound deep-link (Manage Users)
+# ---------------------------------------------------------------------------
+
+
+class TestDialogManageUsersDeepLink:
+    def test_button_click_sets_pref_and_switches_page(self):
+        """Clicking 'View user in Manage Users →' must set
+        `manage_users_pref_user_id` to the row's user_id and call
+        st.switch_page('views/admin.py')."""
+        from views import admin_analytics
+
+        item = _make_item(user_id=42, user_message_id=99)
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        rec._force_click_key = f"audit_dialog_goto_users_{item['user_message_id']}"
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert rec.session_state.get("manage_users_pref_user_id") == 42
+        assert rec.switch_page_target == "views/admin.py"
+        # JS tab shim must be emitted so the Admin page lands on the Users tab.
+        assert rec.components.v1.html.called, "JS tab-selection shim must be emitted on deep-link click"
+
+    def test_button_not_clicked_does_not_set_pref(self):
+        """If the user does not click the button, no session_state mutation
+        and no page switch."""
+        from views import admin_analytics
+
+        item = _make_item(user_id=42, user_message_id=99)
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        # No _force_click_key set → button.return_value False
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert "manage_users_pref_user_id" not in rec.session_state
+        assert rec.switch_page_target is None
+
+
+# ---------------------------------------------------------------------------
+# Inbound deep-link consumption (Manage Users side)
+# ---------------------------------------------------------------------------
+
+
+class TestManageUsersInboundPrefill:
+    def test_pref_user_id_pre_populates_mu_selected_label(self):
+        """Setting `manage_users_pref_user_id` in session_state must cause
+        `render()` to look up the matching user and pre-populate
+        `mu_selected_label` with the formatted option label."""
+        from views import admin_users
+
+        rec_session: dict = {"manage_users_pref_user_id": 7}
+
+        users_list = [
+            {
+                "id": 7,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "role_name": "Admin",
+                "email": "a@a.io",
+                "organization": "Acme",
+                "theme": "healthelink",
+            },
+            {
+                "id": 8,
+                "username": "bob",
+                "first_name": "Bob",
+                "last_name": "Jones",
+                "role_name": "Doctor",
+                "email": "b@b.io",
+                "organization": "Beta",
+                "theme": "healthelink",
+            },
+        ]
+
+        # We don't need to render the full UI — we only need to verify the
+        # prefill block at the top of render() does the right thing before
+        # anything else runs. Patch out the heavy downstream Streamlit and
+        # DB surface so we can exit early.
+        with (
+            patch.object(admin_users, "st") as mock_st,
+            patch.object(admin_users, "get_all_users", return_value=users_list),
+            patch.object(admin_users, "get_all_user_roles", return_value=[]),
+            patch.object(admin_users, "get_user_stats_for_all_users", return_value={}),
+        ):
+            # session_state should behave like a dict for the popped key + the
+            # "mu_selected_label not in session_state" check.
+            mock_st.session_state = rec_session
+            # Make the rest of render() abort early by raising on st.columns
+            mock_st.columns.side_effect = RuntimeError("abort after prefill")
+
+            with pytest.raises(RuntimeError, match="abort after prefill"):
+                admin_users.render()
+
+        assert rec_session.get("mu_selected_label") == "alice (Alice Smith) - Admin", (
+            "mu_selected_label must match the option label format from admin_users.py"
+        )
+        # Pref must have been consumed (popped).
+        assert "manage_users_pref_user_id" not in rec_session
+
+    def test_pref_does_not_clobber_existing_selection(self):
+        """If `mu_selected_label` is already set, the inbound pref must NOT
+        overwrite it (user's current selection wins)."""
+        from views import admin_users
+
+        rec_session: dict = {
+            "manage_users_pref_user_id": 7,
+            "mu_selected_label": "bob (Bob Jones) - Doctor",
+        }
+
+        users_list = [
+            {
+                "id": 7,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "role_name": "Admin",
+                "email": None,
+                "organization": None,
+                "theme": "healthelink",
+            }
+        ]
+
+        with (
+            patch.object(admin_users, "st") as mock_st,
+            patch.object(admin_users, "get_all_users", return_value=users_list),
+            patch.object(admin_users, "get_all_user_roles", return_value=[]),
+            patch.object(admin_users, "get_user_stats_for_all_users", return_value={}),
+        ):
+            mock_st.session_state = rec_session
+            mock_st.columns.side_effect = RuntimeError("abort after prefill")
+
+            with pytest.raises(RuntimeError, match="abort after prefill"):
+                admin_users.render()
+
+        assert rec_session.get("mu_selected_label") == "bob (Bob Jones) - Doctor", (
+            "Existing mu_selected_label must not be overwritten by the inbound pref"
+        )
+        # Even when it doesn't apply, the pref key is still popped (consume-on-read).
+        assert "manage_users_pref_user_id" not in rec_session
+
+
+# ---------------------------------------------------------------------------
+# (d) agent_logging.mode = "disabled" — dialog unreachable
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLoggingDisabled:
+    def test_disabled_mode_skips_selection_mode_kwarg(self):
+        """When `[agent_logging].mode = "disabled"`, the audit tab must
+        render the dataframe WITHOUT `selection_mode`, so a click cannot
+        open the dialog (defense in depth — disabled mode should produce
+        no rows in the first place)."""
+        from views import admin_analytics
+
+        # Capture the kwargs passed to st.dataframe by the audit tab.
+        captured_kwargs: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "disabled"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            # Streamlit surface ----
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **kwargs):
+                captured_kwargs.append(kwargs)
+                return MagicMock()
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        # Stub the cached filter options + page result with one row, so the
+        # dataframe code path runs.
+        filter_options = {"usernames": ["alice"], "orgs": ["Acme"]}
+        page_payload = {
+            "items": [_make_item()],
+            "total": 1,
+        }
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_cached_audit_filter_options", return_value=filter_options),
+            patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert captured_kwargs, "Expected st.dataframe to be called"
+        # In disabled mode, NO selection_mode kwarg should be passed.
+        for kw in captured_kwargs:
+            assert "selection_mode" not in kw, (
+                "When agent_logging.mode == 'disabled', selection_mode must "
+                f"be omitted from st.dataframe; saw kwargs: {kw}"
+            )
+            assert "on_select" not in kw, (
+                f"When agent_logging.mode == 'disabled', on_select must be omitted from st.dataframe; saw kwargs: {kw}"
+            )
+
+    def test_full_mode_passes_selection_mode_kwarg(self):
+        """When `[agent_logging].mode` is anything other than 'disabled'
+        (default 'full'), the audit tab must wire up selection_mode + on_select
+        so row clicks open the dialog."""
+        from views import admin_analytics
+
+        captured_kwargs: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **kwargs):
+                captured_kwargs.append(kwargs)
+                # No selection — simulate the user not clicking anything,
+                # so the dialog branch doesn't execute.
+                ev = MagicMock()
+                ev.selection = {"rows": []}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+        filter_options = {"usernames": ["alice"], "orgs": ["Acme"]}
+        page_payload = {"items": [_make_item()], "total": 1}
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_cached_audit_filter_options", return_value=filter_options),
+            patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert captured_kwargs, "Expected st.dataframe to be called"
+        kw = captured_kwargs[0]
+        assert kw.get("selection_mode") == "single-row"
+        assert kw.get("on_select") == "rerun"
+        assert kw.get("key") == "audit_dataframe"
+
+
+# ---------------------------------------------------------------------------
+# (a) Selection state opens / closes the dialog
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionStateTrigger:
+    def test_row_selection_opens_dialog_and_sets_state(self):
+        """When the dataframe event reports a selected row, the audit tab must
+        set `audit_dialog_open_user_message_id` and invoke the dialog function
+        for that row."""
+        from views import admin_analytics
+
+        item = _make_item(user_message_id=314)
+        dialog_calls: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **_kw):
+                # Simulate the user selecting row 0.
+                ev = MagicMock()
+                ev.selection = {"rows": [0]}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        def _fake_dialog(passed_item):
+            dialog_calls.append(passed_item)
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(
+                admin_analytics,
+                "_cached_audit_filter_options",
+                return_value={"usernames": [], "orgs": []},
+            ),
+            patch.object(admin_analytics, "_render_audit_question_dialog", side_effect=_fake_dialog),
+            patch(
+                "orm.logging_functions.get_question_audit_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert dialog_calls == [item], "Dialog must be invoked for the selected row's item"
+        assert stub.session_state.get("audit_dialog_open_user_message_id") == 314
+
+    def test_no_selection_clears_dialog_state_key(self):
+        """When the user clears the selection (rows: []), the dialog tracking
+        key should be removed from session_state so re-selecting the same row
+        reopens the dialog."""
+        from views import admin_analytics
+
+        item = _make_item(user_message_id=314)
+
+        class _Stub:
+            def __init__(self):
+                # Pre-existing open key from a prior dialog session.
+                self.session_state = {"audit_dialog_open_user_message_id": 314}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **_kw):
+                ev = MagicMock()
+                ev.selection = {"rows": []}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(
+                admin_analytics,
+                "_cached_audit_filter_options",
+                return_value={"usernames": [], "orgs": []},
+            ),
+            patch.object(admin_analytics, "_render_audit_question_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_question_audit_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        dialog_mock.assert_not_called()
+        assert "audit_dialog_open_user_message_id" not in stub.session_state

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -352,6 +352,7 @@ def _render_overview_tab(days_int: int):
         height=60,
     )
 
+
 @st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
 def _cached_audit_filter_options(days_int: int) -> dict:
     from orm.logging_functions import get_question_audit_filter_options
@@ -369,6 +370,105 @@ def _truncate(text, length):
     return text if len(text) <= length else text[: length - 1] + "…"
 
 
+def _render_audit_question_dialog_body(item: dict) -> None:
+    """Render the body of the Questions audit dialog (#155).
+
+    Split out from the `@st.dialog`-decorated wrapper so tests can call the
+    body directly with a stubbed `st` module. The decorated wrapper
+    `_render_audit_question_dialog` is what production calls.
+    """
+    from io import StringIO
+
+    from agent.observability_gate import role_can_see_query_details
+
+    current_role = st.session_state.get("user_role")
+    can_see_query_details = role_can_see_query_details(current_role)
+
+    # Header line
+    org = item.get("organization") or "(no org)"
+    st.markdown(f"**{item['asked_at']}** · {item['username']} · {org}")
+
+    # Full question
+    st.markdown("**Question**")
+    st.write(item.get("question") or "_(empty)_")
+
+    # Role-gated: Generated SQL with built-in copy-to-clipboard
+    if can_see_query_details:
+        st.markdown("**Generated SQL**")
+        st.code(item.get("sql_text") or "(no SQL)", language="sql")
+
+    # Summary
+    st.markdown("**Summary**")
+    summary = item.get("summary_text")
+    st.write(summary if summary else "_(no summary)_")
+
+    # Role-gated: full DataFrame (no .head(5) — dataframe_preview holds the full JSON)
+    df_preview = item.get("dataframe_preview")
+    if df_preview and can_see_query_details:
+        st.markdown("**Result DataFrame**")
+        try:
+            df_obj = pd.read_json(StringIO(df_preview))
+            st.dataframe(df_obj, width="stretch", hide_index=True)
+        except Exception:
+            try:
+                df_obj = pd.read_json(df_preview)
+                st.dataframe(df_obj, width="stretch", hide_index=True)
+            except Exception:
+                st.text(str(df_preview)[:1000])
+
+    # Error block when present
+    err = item.get("error_text")
+    if err:
+        st.markdown("**Error**")
+        st.code(err, language="text")
+
+    # Metadata caption
+    st.caption(
+        f"Message ID {item.get('user_message_id')} · Elapsed {round(float(item.get('elapsed_seconds') or 0.0), 3)}s"
+    )
+
+    # Outbound deep-link to Manage Users
+    st.divider()
+    if st.button(
+        "View user in Manage Users →",
+        key=f"audit_dialog_goto_users_{item.get('user_message_id')}",
+        type="primary",
+    ):
+        st.session_state["manage_users_pref_user_id"] = item["user_id"]
+        # JS tab-selection shim — mirrors the Audit-tab shim above but targets "Users".
+        # Streamlit's st.tabs has no server-side API to change the active tab and
+        # st.switch_page is a no-op on the same page, so we click the parent doc's
+        # "Users" tab button after the rerun lands.
+        st.components.v1.html(
+            """
+            <script>
+              (function(){
+                try {
+                  var tabs = window.parent.document.querySelectorAll('button[role=tab]');
+                  for (var i = 0; i < tabs.length; i++) {
+                    if (tabs[i].textContent.trim() === 'Users') { tabs[i].click(); break; }
+                  }
+                } catch (e) { console.error('users-tab nav failed', e); }
+              })();
+            </script>
+            """,
+            height=0,
+        )
+        st.switch_page("views/admin.py")
+
+
+@st.dialog("Question Audit Detail")
+def _render_audit_question_dialog(item: dict) -> None:
+    """`@st.dialog`-decorated wrapper invoked from `_render_audit_trail_tab`.
+
+    Subsystems #156 and #157 must adopt the same trigger primitive
+    (`st.dataframe(on_select="rerun", selection_mode="single-row")` + dialog
+    body invoked on selection state change). See Epic #154 Architecture
+    Considerations.
+    """
+    _render_audit_question_dialog_body(item)
+
+
 def _render_audit_trail_tab(days_int: int):
     """Render the Question Audit Trail tab (#135)."""
     import datetime as _dt
@@ -378,6 +478,15 @@ def _render_audit_trail_tab(days_int: int):
         get_question_audit_page,
     )
     from orm.functions import get_all_users
+
+    # [agent_logging].mode = "disabled" defense-in-depth.
+    # Under "disabled" mode no audit rows are written, but we belt-and-suspenders
+    # the trigger primitive so it cannot open the dialog.
+    try:
+        logging_mode = st.secrets.get("agent_logging", {}).get("mode", "full")
+    except Exception:
+        logging_mode = "full"
+    selection_enabled = logging_mode != "disabled"
 
     options = _cached_audit_filter_options(days_int)
 
@@ -394,13 +503,9 @@ def _render_audit_trail_tab(days_int: int):
 
     f1, f2, f3 = st.columns([0.30, 0.30, 0.40])
     with f1:
-        usernames_sel = st.multiselect(
-            "User", options=options["usernames"], key="audit_user_filter"
-        )
+        usernames_sel = st.multiselect("User", options=options["usernames"], key="audit_user_filter")
     with f2:
-        orgs_sel = st.multiselect(
-            "Organization", options=options["orgs"], key="audit_org_filter"
-        )
+        orgs_sel = st.multiselect("Organization", options=options["orgs"], key="audit_org_filter")
     with f3:
         search = st.text_input(
             "Search question or SQL",
@@ -442,7 +547,9 @@ def _render_audit_trail_tab(days_int: int):
     total = int(result.get("total", 0))
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
-    # Table
+    # Table — single-row selection trigger replaces the per-row expander list
+    # (Epic #154 architecture: selection state is one widget read at page_size=200,
+    # vs. 200 button widgets per refresh; load-bearing for #156/#157).
     if items:
         table_rows = []
         for it in items:
@@ -457,7 +564,48 @@ def _render_audit_trail_tab(days_int: int):
                     "Elapsed (s)": round(float(it.get("elapsed_seconds") or 0.0), 3),
                 }
             )
-        st.dataframe(pd.DataFrame(table_rows), width="stretch", hide_index=True)
+
+        if selection_enabled:
+            event = st.dataframe(
+                pd.DataFrame(table_rows),
+                width="stretch",
+                hide_index=True,
+                on_select="rerun",
+                selection_mode="single-row",
+                key="audit_dataframe",
+            )
+            selected_rows = []
+            try:
+                selected_rows = (event.selection or {}).get("rows", []) if event else []
+            except AttributeError:
+                # Some versions return a dict-like; fall back gracefully.
+                try:
+                    selected_rows = (event or {}).get("selection", {}).get("rows", [])
+                except Exception:
+                    selected_rows = []
+
+            if selected_rows:
+                row_idx = int(selected_rows[0])
+                if 0 <= row_idx < len(items):
+                    selected_item = items[row_idx]
+                    open_id = st.session_state.get("audit_dialog_open_user_message_id")
+                    if open_id != selected_item["user_message_id"]:
+                        st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
+                    _render_audit_question_dialog(selected_item)
+            else:
+                # Dataframe selection cleared (e.g. clicking the row again) — reset our
+                # tracking key so re-selecting the same row reopens the dialog.
+                if "audit_dialog_open_user_message_id" in st.session_state:
+                    del st.session_state["audit_dialog_open_user_message_id"]
+        else:
+            # agent_logging.mode == "disabled": render the table read-only;
+            # selection trigger and dialog branch are short-circuited.
+            st.dataframe(
+                pd.DataFrame(table_rows),
+                width="stretch",
+                hide_index=True,
+                key="audit_dataframe",
+            )
     else:
         st.info("No audit rows match the current filters.")
 
@@ -479,34 +627,6 @@ def _render_audit_trail_tab(days_int: int):
             key="audit_next_btn",
             on_click=lambda: st.session_state.update({"audit_page_bump": 1}),
         )
-
-    # Row drilldown expanders
-    for it in items:
-        header = f"{it['asked_at']} • {it['username']} • {_truncate(it['question'], 80)}"
-        with st.expander(header):
-            st.markdown("**Question**")
-            st.write(it["question"] or "_(empty)_")
-            st.markdown("**Generated SQL**")
-            st.code(it.get("sql_text") or "(no SQL)", language="sql")
-            st.markdown("**Summary**")
-            summary = it.get("summary_text")
-            st.write(summary if summary else "_(no summary)_")
-            df_preview = it.get("dataframe_preview")
-            if df_preview:
-                st.markdown("**DataFrame preview (first 5 rows)**")
-                try:
-                    df_obj = pd.read_json(df_preview).head(5)
-                    st.dataframe(df_obj, width="stretch", hide_index=True)
-                except Exception:
-                    st.text(str(df_preview)[:1000])
-            err = it.get("error_text")
-            if err:
-                st.markdown("**Error**")
-                st.code(err, language="text")
-            st.caption(
-                f"Asked At {it['asked_at']} · Elapsed "
-                f"{round(float(it.get('elapsed_seconds') or 0.0), 3)}s · Message ID {it.get('user_message_id')}"
-            )
 
     # Export CSV
     if st.button("📥 Export filtered audit to CSV", key="audit_export_btn"):
@@ -884,6 +1004,7 @@ def main():
         if st.button("Refresh Data", help="Clear cached data and reload metrics"):
             _read_metrics.clear()
             from views.errors import _load as _errors_load, _load_aggregates as _errors_load_aggregates
+
             _errors_load.clear()
             _errors_load_aggregates.clear()
             st.rerun()

--- a/views/admin_users.py
+++ b/views/admin_users.py
@@ -2,11 +2,21 @@
 
 Relocated from views/user.py tab3. Post-Epic #129 layout: toolbar dialogs,
 L/R split, 4 inner tabs (Profile / Preferences / Activity / Danger Zone).
-The Activity inner tab's `View question audit for <username> →` button
-navigates to views/admin.py — the Admin Audit tab will pre-filter to the
-target user via the existing audit_trail_pref_user_id contract.
-"""
 
+Deep-link contracts:
+
+- Outbound (this surface → Audit): The Activity inner tab's
+  `View question audit for <username> →` button navigates to views/admin.py;
+  the Admin Audit tab pre-filters to the target user via the existing
+  `audit_trail_pref_user_id` session-state contract.
+
+- Inbound (Audit Questions dialog → this surface, Feature #155): The
+  Questions audit row-click dialog's "View user in Manage Users →" button
+  sets `manage_users_pref_user_id` in session_state, then switches to
+  views/admin.py. On the next render of this sub-tab, the pref is consumed
+  (popped) and used to pre-populate `mu_selected_label` so the left-rail
+  selectbox lands on the target user.
+"""
 
 import pandas as pd
 import streamlit as st
@@ -40,6 +50,22 @@ def render(days_int: int | None = None) -> None:
     st.subheader("Manage Users")
     st.caption("Create, edit, or remove users. View settings and activity stats.")
 
+    # Inbound deep-link from the Questions audit dialog (Feature #155):
+    # consume `manage_users_pref_user_id`, look up the user, and pre-populate
+    # `mu_selected_label` so the left-rail selectbox lands on the target user.
+    # Only honour when the user hasn't already touched the selectbox this
+    # session (mirrors the audit_trail_pref_user_id pattern in admin_analytics).
+    pref_user_id = st.session_state.pop("manage_users_pref_user_id", None)
+    if pref_user_id is not None and "mu_selected_label" not in st.session_state:
+        try:
+            all_users_for_pref = get_all_users()
+            match = next((u for u in all_users_for_pref if u["id"] == int(pref_user_id)), None)
+            if match:
+                pref_label = f"{match['username']} ({match['first_name']} {match['last_name']}) - {match['role_name']}"
+                st.session_state["mu_selected_label"] = pref_label
+        except Exception as e:
+            logger.warning("Manage Users deep-link prefill failed: %s", e)
+
     roles = get_all_user_roles()
     role_id_by_name = {name: rid for rid, name, _ in roles}
     role_names = [name for rid, name, _ in roles]
@@ -67,18 +93,14 @@ def render(days_int: int | None = None) -> None:
         if search:
             s = search.lower()
             users = [
-                u
-                for u in users
-                if s in u["username"].lower() or s in f"{u['first_name']} {u['last_name']}`".lower()
+                u for u in users if s in u["username"].lower() or s in f"{u['first_name']} {u['last_name']}`".lower()
             ]
         selected = None
         if users:
             user_options = {
                 f"{u['username']} ({u['first_name']} {u['last_name']}) - {u['role_name']}": u for u in users
             }
-            selected_label = st.selectbox(
-                "Select a user", options=list(user_options.keys()), key="mu_selected_label"
-            )
+            selected_label = st.selectbox("Select a user", options=list(user_options.keys()), key="mu_selected_label")
             selected = user_options[selected_label]
         else:
             st.info("No users found.")
@@ -191,9 +213,7 @@ def render(days_int: int | None = None) -> None:
                 m4.metric("DataFrames", s["dataframes"])
                 m5.metric("Summaries", s["summaries"])
 
-                range_choice = st.radio(
-                    "Range", options=["7 days", "30 days"], horizontal=True, key="stats_range"
-                )
+                range_choice = st.radio("Range", options=["7 days", "30 days"], horizontal=True, key="stats_range")
                 days = 7 if range_choice.startswith("7") else 30
                 daily = get_user_daily_stats(selected["id"], days=days)
                 if daily:


### PR DESCRIPTION
## Summary

Replaces the per-row expander list under the Questions audit tab with a single-row selection trigger on the existing `st.dataframe`, opening an `@st.dialog` modal with the full row detail (question, generated SQL with built-in copy button, summary, **full** result DataFrame, error, metadata). Adds an outbound "View user in Manage Users →" button inside the dialog plus the inbound `manage_users_pref_user_id` prefill contract on `views/admin_users.py`. Reuses `agent.observability_gate.role_can_see_query_details` to gate SQL + full DataFrame; honours `[agent_logging].mode = "disabled"` as defense in depth.

This subsystem establishes the trigger primitive (`st.dataframe(on_select="rerun", selection_mode="single-row")` + dialog) that Subsystems #156 and #157 must adopt per Epic #154.

## Issues Resolved
Closes #155
Parent Epic: #154

## Changes Made

### `views/admin_analytics.py`
- New `_render_audit_question_dialog_body(item)` — dialog body, split out from the decorator wrapper so unit tests can call it with a stubbed `st`.
- New `@st.dialog("Question Audit Detail") _render_audit_question_dialog(item)` — production entry point invoked from the audit tab on row selection.
- `_render_audit_trail_tab` now:
  - Reads `st.secrets.get("agent_logging", {}).get("mode", "full")`; when `"disabled"` it omits `selection_mode` / `on_select` from `st.dataframe` and short-circuits the dialog branch.
  - Wires the existing `st.dataframe(...)` with `on_select="rerun"`, `selection_mode="single-row"`, `key="audit_dataframe"`. On selection, sets `audit_dialog_open_user_message_id` and invokes the dialog. Clears the tracking key when the selection is cleared so re-clicking the same row reopens.
  - Removes the per-row expander loop (lines 484–509). Dialog is the sole detail surface.

### `views/admin_users.py`
- `render()` now consumes `manage_users_pref_user_id` at the top: pops the key, looks up the user via `get_all_users()`, and pre-populates `mu_selected_label` with the formatted label (`"{username} ({first_name} {last_name}) - {role_name}"`). Honours user precedence: skips when `mu_selected_label` is already set.
- Module docstring updated to document the new inbound contract alongside the existing outbound (`audit_trail_pref_user_id`) link.

### `tests/views/test_admin_audit_dialog.py` (new)
- `TestDialogRoleGate` — admin sees SQL + full DataFrame; non-admin hides both while keeping question / summary / error.
- `TestDialogFullDataFrame` — 12-row DataFrame renders all 12 rows (regression on the old expander `.head(5)`).
- `TestDialogManageUsersDeepLink` — button click sets `manage_users_pref_user_id` and calls `switch_page`; emits the JS tab shim. No mutation when not clicked.
- `TestManageUsersInboundPrefill` — `manage_users_pref_user_id` → `mu_selected_label = "alice (Alice Smith) - Admin"`. Existing selection is not clobbered.
- `TestAgentLoggingDisabled` — `"disabled"` mode strips `selection_mode` / `on_select` kwargs from `st.dataframe`; `"full"` mode wires them.
- `TestSelectionStateTrigger` — selecting row 0 invokes the dialog with the right item; empty selection clears the tracking key.

## Design Decisions

- **Trigger primitive: row selection on the grid, not per-row buttons.** Per spec, at `page_size=200` per-row `st.button` would create 200 widgets per refresh — the documented Streamlit perf pitfall Epic #154 explicitly flagged. Selection state is a single widget read. Locked in for #156/#157.
- **Body / wrapper split.** `_render_audit_question_dialog_body` is callable directly with a stubbed `st`; the `@st.dialog`-decorated wrapper delegates to it. This keeps production behaviour unchanged while making the dialog testable without spinning up a Streamlit runtime.
- **`dataframe_preview` is misleadingly named.** It already stores the full DataFrame JSON; truncation lived only in the old expander's `.head(5)` call. Dropping `.head(5)` is sufficient. No DB / schema / query change.
- **`pd.read_json(StringIO(...))`** fallback to plain `pd.read_json(...)` then plain text. Defends against the pandas FutureWarning for string-input + bad JSON.
- **JS tab shim** mirrors the existing one in `_render_overview_tab` but targets `button[role=tab]` with `textContent === "Users"`. Required because `st.switch_page("views/admin.py")` doesn't change the active sub-tab on its own.

## Self-Review

- Confirmed all three pre-existing inbound deep-links to the Audit tab (`audit_trail_pref_user_id`, `View question audit for <username> →`, `View all in audit →`) still funnel through `_render_audit_trail_tab` unchanged — only the per-row expander render and the selection trigger were modified.
- Tightened the deep-link pop: even when an existing `mu_selected_label` blocks the prefill from taking effect, the pref key is still popped (consume-on-read) so it doesn't leak across reruns.
- Selection-cleared branch resets `audit_dialog_open_user_message_id` so re-clicking the same row reopens the dialog (otherwise the dialog would be dismissed and never re-open without a different row click).
- Verified `dict(st.secrets.get("agent_logging", {}))` pattern matches `agent/logging_config.py:53`. Same shape, same defaults.
- Wrapped the `st.secrets` read in `try/except` to keep the audit tab resilient in test environments where `st.secrets` may not be initialized.

## Testing

- [x] `uv run pytest -m "not milvus" tests/views/test_admin_audit_dialog.py` — 11 passed
- [x] `uv run pytest -m "not milvus" tests/orm/test_question_audit.py` — 14 passed (regression on existing audit helpers)
- [x] `uv run pytest -m "not milvus" tests/views tests/orm` — 246 passed, 3 pre-existing failures unrelated to this change (the failing tests reference `views.user` and `views.agent_analytics` modules that were retired in commit `15e5c14 (feat(nav): 3-route IA)`)
- [x] `uv run ruff check views/admin_analytics.py views/admin_users.py tests/views/test_admin_audit_dialog.py` — clean
- [x] `uv run ruff format --check views/admin_analytics.py views/admin_users.py tests/views/test_admin_audit_dialog.py` — clean
- [ ] Manual smoke test: click a row in the Questions tab, confirm dialog opens with all sections, click "View user in Manage Users →", confirm the Users sub-tab opens with the user pre-selected
- [ ] Manual smoke test under `[agent_logging].mode = "disabled"`: confirm row clicks no longer open the dialog

## Files Modified
- `views/admin_analytics.py` — new dialog body + wrapper; selection trigger; defense-in-depth check; per-row expander loop removed
- `views/admin_users.py` — inbound `manage_users_pref_user_id` consumption; docstring update
- `tests/views/test_admin_audit_dialog.py` — new (11 tests across 5 classes)