### PR TITLE
feat(audit): User Activity tab row-click dialog + Manage Users deep-link (#157)

### DIFF
--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -1078,34 +1078,41 @@ def get_activity_by_type(days: int = 30) -> list[dict]:
         return []
 
 
-def get_recent_activity(days: int = 7, limit: int = 50) -> list[dict]:
-    """Get recent user activity for audit log."""
+def get_user_activity_page(days: int = 7, page: int = 1, page_size: int = 50) -> dict:
+    """Paginated user activity for the audit log. Returns {"items": [...], "total": int}.
+
+    Each item exposes the full UserActivity row (10 fields): ``id``, ``created_at``,
+    ``user_id``, ``username``, ``activity_type``, ``description``, ``old_value``,
+    ``new_value``, ``ip_address``, ``user_agent``. See Feature #157 spec.
+
+    ``user_id`` can be null for failed-login rows where user lookup failed.
+    """
     try:
         since = datetime.now() - timedelta(days=days)
         with SessionLocal() as session:
-            results = (
-                session.query(UserActivity)
-                .filter(UserActivity.created_at >= since)
-                .order_by(UserActivity.created_at.desc())
-                .limit(limit)
-                .all()
-            )
-            return [
+            base_query = session.query(UserActivity).filter(UserActivity.created_at >= since)
+            total = base_query.with_entities(func.count(UserActivity.id)).scalar() or 0
+            offset = max(0, (int(page) - 1) * int(page_size))
+            results = base_query.order_by(UserActivity.created_at.desc()).offset(offset).limit(int(page_size)).all()
+            items = [
                 {
                     "id": r.id,
                     "created_at": r.created_at,
+                    "user_id": r.user_id,
                     "username": r.username,
                     "activity_type": r.activity_type,
                     "description": r.description,
                     "old_value": r.old_value,
                     "new_value": r.new_value,
                     "ip_address": r.ip_address,
+                    "user_agent": r.user_agent,
                 }
                 for r in results
             ]
+            return {"items": items, "total": int(total)}
     except Exception as e:
-        logger.warning("Failed to get recent activity: %s", e)
-        return []
+        logger.warning("get_user_activity_page failed: %s", e)
+        return {"items": [], "total": 0}
 
 
 def get_error_stats(days: int = 7) -> dict:

--- a/tests/orm/test_user_activity_pagination.py
+++ b/tests/orm/test_user_activity_pagination.py
@@ -1,0 +1,331 @@
+"""Tests for orm.logging_functions.get_user_activity_page (#157).
+
+Covers:
+  - Page math (page out of range returns empty items + correct total).
+  - Page-size variants.
+  - Item shape includes all 10 UserActivity-derived fields.
+  - Error path returns {"items": [], "total": 0}.
+  - Reverse-chronological ordering.
+  - Null user_id (failed-login) rows are returned with user_id=None.
+  - Days filter excludes rows older than the cutoff.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import Base, RoleTypeEnum, User, UserActivity, UserRole
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add(
+        UserRole(
+            id=1,
+            role_name="Admin",
+            description="Admin",
+            role=RoleTypeEnum.ADMIN,
+        )
+    )
+    session.commit()
+
+
+def _seed_user(session, *, id, username):
+    session.add(
+        User(
+            id=id,
+            user_role_id=1,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+        )
+    )
+    session.commit()
+
+
+def _add_activity(
+    session,
+    *,
+    user_id,
+    username,
+    activity_type,
+    when,
+    description=None,
+    old_value=None,
+    new_value=None,
+    ip_address=None,
+    user_agent=None,
+):
+    session.add(
+        UserActivity(
+            user_id=user_id,
+            username=username,
+            activity_type=activity_type,
+            description=description,
+            old_value=old_value,
+            new_value=new_value,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+    )
+    session.commit()
+    # Override created_at after insert (server_default=func.now()).
+    last = session.query(UserActivity).order_by(UserActivity.id.desc()).first()
+    last.created_at = when
+    session.commit()
+
+
+def test_empty_database_returns_empty(session_factory):
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+
+    page = get_user_activity_page(days=30, page=1, page_size=50)
+    assert page == {"items": [], "total": 0}
+
+
+def test_returns_all_ten_fields_per_item(session_factory):
+    """Each item must expose all 10 UserActivity-derived fields including
+    ``user_id`` and ``user_agent`` (which the retired ``get_recent_activity``
+    dropped)."""
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_activity(
+        s,
+        user_id=10,
+        username="alice",
+        activity_type="login",
+        description="User logged in",
+        when=now,
+        ip_address="127.0.0.1",
+        user_agent="Mozilla/5.0 Test",
+        old_value='{"a": 1}',
+        new_value='{"a": 2}',
+    )
+
+    result = get_user_activity_page(days=30, page=1, page_size=50)
+    assert result["total"] == 1
+    assert len(result["items"]) == 1
+    item = result["items"][0]
+    expected_keys = {
+        "id",
+        "created_at",
+        "user_id",
+        "username",
+        "activity_type",
+        "description",
+        "old_value",
+        "new_value",
+        "ip_address",
+        "user_agent",
+    }
+    assert set(item.keys()) == expected_keys
+    assert item["user_id"] == 10
+    assert item["username"] == "alice"
+    assert item["activity_type"] == "login"
+    assert item["description"] == "User logged in"
+    assert item["ip_address"] == "127.0.0.1"
+    assert item["user_agent"] == "Mozilla/5.0 Test"
+    assert item["old_value"] == '{"a": 1}'
+    assert item["new_value"] == '{"a": 2}'
+    assert isinstance(item["id"], int)
+
+
+def test_returns_reverse_chronological_order(session_factory):
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_activity(s, user_id=10, username="alice", activity_type="login", when=now - timedelta(hours=2))
+    _add_activity(s, user_id=10, username="alice", activity_type="setting", when=now - timedelta(hours=1))
+    _add_activity(s, user_id=10, username="alice", activity_type="logout", when=now)
+
+    result = get_user_activity_page(days=30, page=1, page_size=50)
+    types = [it["activity_type"] for it in result["items"]]
+    assert types == ["logout", "setting", "login"]
+    assert result["total"] == 3
+
+
+def test_pagination_page_one_returns_first_page(session_factory):
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(5):
+        _add_activity(
+            s,
+            user_id=10,
+            username="alice",
+            activity_type=f"type_{i}",
+            when=base - timedelta(hours=i),
+        )
+
+    p1 = get_user_activity_page(days=30, page=1, page_size=2)
+    assert len(p1["items"]) == 2
+    assert p1["total"] == 5
+
+
+def test_pagination_page_two_returns_next_page(session_factory):
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(5):
+        _add_activity(
+            s,
+            user_id=10,
+            username="alice",
+            activity_type=f"type_{i}",
+            when=base - timedelta(hours=i),
+        )
+
+    p2 = get_user_activity_page(days=30, page=2, page_size=2)
+    assert len(p2["items"]) == 2
+    assert p2["total"] == 5
+    # Reverse chronological: type_0 newest, type_4 oldest. Page 2 (size 2) is type_2, type_3.
+    assert [it["activity_type"] for it in p2["items"]] == ["type_2", "type_3"]
+
+
+def test_pagination_out_of_range_returns_empty_items_with_correct_total(session_factory):
+    """Page beyond the end returns empty items but the total count must still
+    be accurate so the UI can render 'Page X of N' correctly."""
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(3):
+        _add_activity(
+            s,
+            user_id=10,
+            username="alice",
+            activity_type=f"t{i}",
+            when=base - timedelta(hours=i),
+        )
+
+    result = get_user_activity_page(days=30, page=10, page_size=50)
+    assert result["items"] == []
+    assert result["total"] == 3
+
+
+@pytest.mark.parametrize("page_size", [25, 50, 100, 200])
+def test_pagination_page_size_variants(session_factory, page_size):
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    # Seed 30 rows so 25 is a partial page and 50/100/200 are not.
+    for i in range(30):
+        _add_activity(
+            s,
+            user_id=10,
+            username="alice",
+            activity_type=f"t{i}",
+            when=base - timedelta(minutes=i),
+        )
+
+    result = get_user_activity_page(days=30, page=1, page_size=page_size)
+    assert result["total"] == 30
+    assert len(result["items"]) == min(page_size, 30)
+
+
+def test_null_user_id_failed_login_row_is_returned(session_factory):
+    """Failed logins where user lookup failed have null ``user_id``. The page
+    helper must return them with ``user_id=None`` so the UI can gate the
+    deep-link button accordingly (#157 spec)."""
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    # No user seeded — failed login with null user_id but a captured username.
+    now = datetime(2026, 6, 1, 12, 0, 0)
+    _add_activity(
+        s,
+        user_id=None,
+        username="ghost",
+        activity_type="failed_login",
+        when=now,
+        ip_address="10.0.0.1",
+        user_agent="curl/8.0",
+    )
+
+    result = get_user_activity_page(days=30, page=1, page_size=50)
+    assert result["total"] == 1
+    assert result["items"][0]["user_id"] is None
+    assert result["items"][0]["username"] == "ghost"
+    assert result["items"][0]["activity_type"] == "failed_login"
+
+
+def test_days_filter_excludes_old_rows(session_factory):
+    """Rows older than ``days`` are excluded from both items and total."""
+    from orm.logging_functions import get_user_activity_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    now = datetime.now()
+    _add_activity(s, user_id=10, username="alice", activity_type="recent", when=now - timedelta(days=1))
+    _add_activity(s, user_id=10, username="alice", activity_type="ancient", when=now - timedelta(days=400))
+
+    result = get_user_activity_page(days=7, page=1, page_size=50)
+    assert result["total"] == 1
+    assert result["items"][0]["activity_type"] == "recent"
+
+
+def test_error_path_returns_empty_envelope(monkeypatch):
+    """If the SQLAlchemy session raises, the helper logs a warning and returns
+    ``{"items": [], "total": 0}`` so the UI degrades gracefully."""
+    from orm import logging_functions as lf
+
+    class _BoomSession:
+        def __enter__(self):
+            raise RuntimeError("db is on fire")
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(lf, "SessionLocal", lambda: _BoomSession())
+
+    result = lf.get_user_activity_page(days=7, page=1, page_size=50)
+    assert result == {"items": [], "total": 0}
+
+
+def test_get_recent_activity_is_removed():
+    """The retired ``get_recent_activity`` helper must no longer exist on the
+    module — sole caller was ``_render_activity_tab`` and the swap is complete."""
+    from orm import logging_functions as lf
+
+    assert not hasattr(lf, "get_recent_activity"), (
+        "get_recent_activity should be removed after the swap to get_user_activity_page (#157)"
+    )

--- a/tests/views/test_admin_audit_dialog.py
+++ b/tests/views/test_admin_audit_dialog.py
@@ -1,0 +1,804 @@
+"""Tests for the Questions audit tab row-click dialog (#155).
+
+Covers:
+  (a) Dialog opens when selection state changes and closes when cleared.
+  (b) Deep-link round-trip — setting `manage_users_pref_user_id` causes
+      Manage Users to pre-populate `mu_selected_label` with the target user.
+  (c) `role_can_see_query_details` returning False hides the SQL block and
+      the full DataFrame inside the dialog body while keeping question /
+      summary / error visible.
+  (d) `[agent_logging].mode = "disabled"` makes the dialog unreachable
+      (selection_mode is not passed to st.dataframe).
+  (e) The dialog renders all rows from `dataframe_preview`, not just the
+      first 5 (regression on the old expander `.head(5)` truncation).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from orm.models import RoleTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    *,
+    user_message_id: int = 42,
+    user_id: int = 7,
+    username: str = "alice",
+    organization: str | None = "Acme",
+    question: str = "How many patients today?",
+    sql_text: str | None = "SELECT count(*) FROM patient",
+    summary_text: str | None = "There are 12 patients.",
+    dataframe_preview: str | None = None,
+    error_text: str | None = None,
+    elapsed_seconds: float = 1.25,
+    asked_at: datetime | None = None,
+) -> dict:
+    """Build a single audit item matching the shape of
+    orm.logging_functions._enrich_with_assistant_aggregates output."""
+    if dataframe_preview is None:
+        # 7 rows so a `.head(5)` truncation would lose 2 rows.
+        df = pd.DataFrame({"x": list(range(7)), "y": [chr(ord("a") + i) for i in range(7)]})
+        dataframe_preview = df.to_json()
+    return {
+        "asked_at": asked_at or datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": user_id,
+        "username": username,
+        "organization": organization,
+        "question": question,
+        "sql_text": sql_text,
+        "status": "Error" if error_text else "Success",
+        "elapsed_seconds": elapsed_seconds,
+        "summary_text": summary_text,
+        "dataframe_preview": dataframe_preview,
+        "error_text": error_text,
+        "user_message_id": user_message_id,
+    }
+
+
+class _RecordingStreamlit:
+    """A minimal recording stand-in for the `st` module that captures the
+    sequence of code/dataframe/write/markdown calls made by the dialog
+    body so we can assert what was rendered.
+
+    Only the surface used by `_render_audit_question_dialog` is implemented.
+    """
+
+    def __init__(self, user_role: int | None = RoleTypeEnum.ADMIN.value):
+        self.session_state: dict = {"user_role": user_role}
+        self.code_calls: list[tuple[str, str]] = []  # (content, language)
+        self.dataframe_calls: list[pd.DataFrame] = []
+        self.write_calls: list = []
+        self.markdown_calls: list[str] = []
+        self.caption_calls: list[str] = []
+        self.button_clicked_key: str | None = None
+        self.switch_page_target: str | None = None
+
+        # components.v1.html stub
+        self.components = MagicMock()
+        self.components.v1 = MagicMock()
+        self.components.v1.html = MagicMock()
+
+    # ---- Streamlit surface --------------------------------------------------
+    def markdown(self, body, **_kwargs):
+        self.markdown_calls.append(str(body))
+
+    def write(self, body, **_kwargs):
+        self.write_calls.append(body)
+
+    def code(self, body, language: str = "text", **_kwargs):
+        self.code_calls.append((str(body), language))
+
+    def dataframe(self, df, **_kwargs):
+        # We only record real DataFrames passed by the dialog body.
+        if isinstance(df, pd.DataFrame):
+            self.dataframe_calls.append(df)
+        return MagicMock()
+
+    def caption(self, body, **_kwargs):
+        self.caption_calls.append(str(body))
+
+    def divider(self):  # no-op
+        pass
+
+    def button(self, label, key=None, **_kwargs):
+        # Default: button NOT clicked. Tests can override via
+        # `force_button_click_key` to simulate a click.
+        clicked = key is not None and key == getattr(self, "_force_click_key", None)
+        if clicked:
+            self.button_clicked_key = key
+        return clicked
+
+    def switch_page(self, target):
+        self.switch_page_target = target
+
+    # Decorators must be no-ops: we want to call the wrapped function directly.
+    def dialog(self, _title):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+# ---------------------------------------------------------------------------
+# (c) Role gate — full DataFrame and SQL hidden when role cannot see details
+# ---------------------------------------------------------------------------
+
+
+class TestDialogRoleGate:
+    def test_admin_sees_sql_and_dataframe(self):
+        """When role_can_see_query_details returns True, the dialog renders the
+        SQL block AND the full DataFrame."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        item = _make_item()
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        # SQL block rendered
+        sql_codes = [body for body, lang in rec.code_calls if lang == "sql"]
+        assert sql_codes, "Expected SQL block to be rendered for admin role"
+        assert "SELECT count(*)" in sql_codes[0]
+
+        # Full DataFrame rendered (all 7 rows from the preview JSON)
+        assert rec.dataframe_calls, "Expected DataFrame to be rendered for admin role"
+        assert len(rec.dataframe_calls[0]) == 7, "Dialog must render the FULL stored DataFrame, not .head(5)"
+
+    def test_non_admin_hides_sql_and_dataframe_keeps_other_sections(self):
+        """When role_can_see_query_details returns False, hide SQL and full
+        DataFrame; question / summary / error remain visible."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.DOCTOR.value)
+        item = _make_item(error_text="Something went wrong on the warehouse.")
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=False,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        # No SQL code block
+        sql_codes = [body for body, lang in rec.code_calls if lang == "sql"]
+        assert sql_codes == [], "SQL must be hidden when role cannot see query details"
+
+        # No DataFrame rendered
+        assert rec.dataframe_calls == [], "Full DataFrame must be hidden when role cannot see query details"
+
+        # Question + summary still visible
+        write_str = " ".join(str(x) for x in rec.write_calls)
+        assert "How many patients today?" in write_str
+        assert "There are 12 patients." in write_str
+
+        # Error block still rendered as plain text
+        text_codes = [body for body, lang in rec.code_calls if lang == "text"]
+        assert any("Something went wrong" in body for body in text_codes)
+
+
+# ---------------------------------------------------------------------------
+# Full DataFrame rendering (Testable Outcome: "renders all rows")
+# ---------------------------------------------------------------------------
+
+
+class TestDialogFullDataFrame:
+    def test_dialog_renders_all_rows_not_just_first_five(self):
+        """For a DataFrame with > 5 rows, the dialog must render ALL rows.
+        Regression on the old expander's `.head(5)` truncation."""
+        from views import admin_analytics
+
+        df = pd.DataFrame({"n": list(range(12))})
+        item = _make_item(dataframe_preview=df.to_json())
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert rec.dataframe_calls, "Expected a DataFrame to be rendered"
+        rendered = rec.dataframe_calls[0]
+        assert len(rendered) == 12, f"Dialog must render all 12 rows, got {len(rendered)}"
+
+
+# ---------------------------------------------------------------------------
+# Outbound deep-link (Manage Users)
+# ---------------------------------------------------------------------------
+
+
+class TestDialogManageUsersDeepLink:
+    def test_button_click_sets_pref_and_switches_page(self):
+        """Clicking 'View user in Manage Users →' must set
+        `manage_users_pref_user_id` to the row's user_id and call
+        st.switch_page('views/admin.py')."""
+        from views import admin_analytics
+
+        item = _make_item(user_id=42, user_message_id=99)
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        rec._force_click_key = f"audit_dialog_goto_users_{item['user_message_id']}"
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert rec.session_state.get("manage_users_pref_user_id") == 42
+        assert rec.switch_page_target == "views/admin.py"
+        # JS tab shim must be emitted so the Admin page lands on the Users tab.
+        assert rec.components.v1.html.called, "JS tab-selection shim must be emitted on deep-link click"
+
+    def test_button_not_clicked_does_not_set_pref(self):
+        """If the user does not click the button, no session_state mutation
+        and no page switch."""
+        from views import admin_analytics
+
+        item = _make_item(user_id=42, user_message_id=99)
+        rec = _RecordingStreamlit(user_role=RoleTypeEnum.ADMIN.value)
+        # No _force_click_key set → button.return_value False
+
+        with patch.object(admin_analytics, "st", rec):
+            with patch(
+                "agent.observability_gate.role_can_see_query_details",
+                return_value=True,
+            ):
+                admin_analytics._render_audit_question_dialog_body(item)
+
+        assert "manage_users_pref_user_id" not in rec.session_state
+        assert rec.switch_page_target is None
+
+
+# ---------------------------------------------------------------------------
+# Inbound deep-link consumption (Manage Users side)
+# ---------------------------------------------------------------------------
+
+
+class TestManageUsersInboundPrefill:
+    def test_pref_user_id_pre_populates_mu_selected_label(self):
+        """Setting `manage_users_pref_user_id` in session_state must cause
+        `render()` to look up the matching user and pre-populate
+        `mu_selected_label` with the formatted option label."""
+        from views import admin_users
+
+        rec_session: dict = {"manage_users_pref_user_id": 7}
+
+        users_list = [
+            {
+                "id": 7,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "role_name": "Admin",
+                "email": "a@a.io",
+                "organization": "Acme",
+                "theme": "healthelink",
+            },
+            {
+                "id": 8,
+                "username": "bob",
+                "first_name": "Bob",
+                "last_name": "Jones",
+                "role_name": "Doctor",
+                "email": "b@b.io",
+                "organization": "Beta",
+                "theme": "healthelink",
+            },
+        ]
+
+        # We don't need to render the full UI — we only need to verify the
+        # prefill block at the top of render() does the right thing before
+        # anything else runs. Patch out the heavy downstream Streamlit and
+        # DB surface so we can exit early.
+        with (
+            patch.object(admin_users, "st") as mock_st,
+            patch.object(admin_users, "get_all_users", return_value=users_list),
+            patch.object(admin_users, "get_all_user_roles", return_value=[]),
+            patch.object(admin_users, "get_user_stats_for_all_users", return_value={}),
+        ):
+            # session_state should behave like a dict for the popped key + the
+            # "mu_selected_label not in session_state" check.
+            mock_st.session_state = rec_session
+            # Make the rest of render() abort early by raising on st.columns
+            mock_st.columns.side_effect = RuntimeError("abort after prefill")
+
+            with pytest.raises(RuntimeError, match="abort after prefill"):
+                admin_users.render()
+
+        assert rec_session.get("mu_selected_label") == "alice (Alice Smith) - Admin", (
+            "mu_selected_label must match the option label format from admin_users.py"
+        )
+        # Pref must have been consumed (popped).
+        assert "manage_users_pref_user_id" not in rec_session
+
+    def test_pref_does_not_clobber_existing_selection(self):
+        """If `mu_selected_label` is already set, the inbound pref must NOT
+        overwrite it (user's current selection wins)."""
+        from views import admin_users
+
+        rec_session: dict = {
+            "manage_users_pref_user_id": 7,
+            "mu_selected_label": "bob (Bob Jones) - Doctor",
+        }
+
+        users_list = [
+            {
+                "id": 7,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "role_name": "Admin",
+                "email": None,
+                "organization": None,
+                "theme": "healthelink",
+            }
+        ]
+
+        with (
+            patch.object(admin_users, "st") as mock_st,
+            patch.object(admin_users, "get_all_users", return_value=users_list),
+            patch.object(admin_users, "get_all_user_roles", return_value=[]),
+            patch.object(admin_users, "get_user_stats_for_all_users", return_value={}),
+        ):
+            mock_st.session_state = rec_session
+            mock_st.columns.side_effect = RuntimeError("abort after prefill")
+
+            with pytest.raises(RuntimeError, match="abort after prefill"):
+                admin_users.render()
+
+        assert rec_session.get("mu_selected_label") == "bob (Bob Jones) - Doctor", (
+            "Existing mu_selected_label must not be overwritten by the inbound pref"
+        )
+        # Even when it doesn't apply, the pref key is still popped (consume-on-read).
+        assert "manage_users_pref_user_id" not in rec_session
+
+
+# ---------------------------------------------------------------------------
+# (d) agent_logging.mode = "disabled" — dialog unreachable
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLoggingDisabled:
+    def test_disabled_mode_skips_selection_mode_kwarg(self):
+        """When `[agent_logging].mode = "disabled"`, the audit tab must
+        render the dataframe WITHOUT `selection_mode`, so a click cannot
+        open the dialog (defense in depth — disabled mode should produce
+        no rows in the first place)."""
+        from views import admin_analytics
+
+        # Capture the kwargs passed to st.dataframe by the audit tab.
+        captured_kwargs: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "disabled"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            # Streamlit surface ----
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **kwargs):
+                captured_kwargs.append(kwargs)
+                return MagicMock()
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        # Stub the cached filter options + page result with one row, so the
+        # dataframe code path runs.
+        filter_options = {"usernames": ["alice"], "orgs": ["Acme"]}
+        page_payload = {
+            "items": [_make_item()],
+            "total": 1,
+        }
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_cached_audit_filter_options", return_value=filter_options),
+            patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert captured_kwargs, "Expected st.dataframe to be called"
+        # In disabled mode, NO selection_mode kwarg should be passed.
+        for kw in captured_kwargs:
+            assert "selection_mode" not in kw, (
+                "When agent_logging.mode == 'disabled', selection_mode must "
+                f"be omitted from st.dataframe; saw kwargs: {kw}"
+            )
+            assert "on_select" not in kw, (
+                f"When agent_logging.mode == 'disabled', on_select must be omitted from st.dataframe; saw kwargs: {kw}"
+            )
+
+    def test_full_mode_passes_selection_mode_kwarg(self):
+        """When `[agent_logging].mode` is anything other than 'disabled'
+        (default 'full'), the audit tab must wire up selection_mode + on_select
+        so row clicks open the dialog."""
+        from views import admin_analytics
+
+        captured_kwargs: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **kwargs):
+                captured_kwargs.append(kwargs)
+                # No selection — simulate the user not clicking anything,
+                # so the dialog branch doesn't execute.
+                ev = MagicMock()
+                ev.selection = {"rows": []}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+        filter_options = {"usernames": ["alice"], "orgs": ["Acme"]}
+        page_payload = {"items": [_make_item()], "total": 1}
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_cached_audit_filter_options", return_value=filter_options),
+            patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert captured_kwargs, "Expected st.dataframe to be called"
+        kw = captured_kwargs[0]
+        assert kw.get("selection_mode") == "single-row"
+        assert kw.get("on_select") == "rerun"
+        assert kw.get("key") == "audit_dataframe"
+
+
+# ---------------------------------------------------------------------------
+# (a) Selection state opens / closes the dialog
+# ---------------------------------------------------------------------------
+
+
+class TestSelectionStateTrigger:
+    def test_row_selection_opens_dialog_and_sets_state(self):
+        """When the dataframe event reports a selected row, the audit tab must
+        set `audit_dialog_open_user_message_id` and invoke the dialog function
+        for that row."""
+        from views import admin_analytics
+
+        item = _make_item(user_message_id=314)
+        dialog_calls: list[dict] = []
+
+        class _Stub:
+            def __init__(self):
+                self.session_state = {}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **_kw):
+                # Simulate the user selecting row 0.
+                ev = MagicMock()
+                ev.selection = {"rows": [0]}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        def _fake_dialog(passed_item):
+            dialog_calls.append(passed_item)
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(
+                admin_analytics,
+                "_cached_audit_filter_options",
+                return_value={"usernames": [], "orgs": []},
+            ),
+            patch.object(admin_analytics, "_render_audit_question_dialog", side_effect=_fake_dialog),
+            patch(
+                "orm.logging_functions.get_question_audit_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        assert dialog_calls == [item], "Dialog must be invoked for the selected row's item"
+        assert stub.session_state.get("audit_dialog_open_user_message_id") == 314
+
+    def test_no_selection_clears_dialog_state_key(self):
+        """When the user clears the selection (rows: []), the dialog tracking
+        key should be removed from session_state so re-selecting the same row
+        reopens the dialog."""
+        from views import admin_analytics
+
+        item = _make_item(user_message_id=314)
+
+        class _Stub:
+            def __init__(self):
+                # Pre-existing open key from a prior dialog session.
+                self.session_state = {"audit_dialog_open_user_message_id": 314}
+                self.secrets = {"agent_logging": {"mode": "full"}}
+                self.components = MagicMock()
+                self.components.v1 = MagicMock()
+                self.components.v1.html = MagicMock()
+
+            def multiselect(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, [])
+                return []
+
+            def text_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, "")
+                return ""
+
+            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+                opts = list(options or [])
+                val = opts[index] if opts else None
+                if key:
+                    self.session_state.setdefault(key, val)
+                return val
+
+            def number_input(self, *_a, key=None, **_kw):
+                self.session_state.setdefault(key, 1)
+                return 1
+
+            def columns(self, spec):
+                n = spec if isinstance(spec, int) else len(spec)
+                return [MagicMock() for _ in range(n)]
+
+            def dataframe(self, _df, **_kw):
+                ev = MagicMock()
+                ev.selection = {"rows": []}
+                return ev
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def button(self, *_a, **_kw):
+                return False
+
+            def caption(self, *_a, **_kw):
+                pass
+
+            def markdown(self, *_a, **_kw):
+                pass
+
+            def write(self, *_a, **_kw):
+                pass
+
+            def code(self, *_a, **_kw):
+                pass
+
+            def divider(self):
+                pass
+
+            def warning(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+            def download_button(self, *_a, **_kw):
+                pass
+
+            def dialog(self, _title):
+                def _decorator(fn):
+                    return fn
+
+                return _decorator
+
+        stub = _Stub()
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(
+                admin_analytics,
+                "_cached_audit_filter_options",
+                return_value={"usernames": [], "orgs": []},
+            ),
+            patch.object(admin_analytics, "_render_audit_question_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_question_audit_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        dialog_mock.assert_not_called()
+        assert "audit_dialog_open_user_message_id" not in stub.session_state

--- a/tests/views/test_user_activity_dialog.py
+++ b/tests/views/test_user_activity_dialog.py
@@ -1,0 +1,637 @@
+"""Tests for the User Activity tab row-click dialog (#157).
+
+Covers:
+  (a) Dialog opens when ``audit_activity_dialog_open_id`` is set and closes
+      when the dataframe selection is cleared.
+  (b) ``user_agent`` renders in the dialog (surfaced for the first time).
+  (c) Old/new JSON renders both columns when both present, only the populated
+      side when one is null, skipped when both are null.
+  (d) Malformed JSON in ``old_value``/``new_value`` falls back to ``st.text``
+      without raising.
+  (e) Deep-link "View user in Manage Users →" button is visible when
+      ``user_id`` is non-null and hidden when null (failed-login rows).
+  (f) Deep-link round-trip — setting ``manage_users_pref_user_id`` causes
+      Manage Users to render with the target user pre-selected (asserts
+      against the consumer added by #155).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(
+    *,
+    id: int = 42,
+    user_id: int | None = 7,
+    username: str = "alice",
+    activity_type: str = "settings_change",
+    description: str = "Changed theme",
+    old_value: str | None = None,
+    new_value: str | None = None,
+    ip_address: str | None = "127.0.0.1",
+    user_agent: str | None = "Mozilla/5.0 RecordingTest",
+    created_at: datetime | None = None,
+) -> dict:
+    """Build a single UserActivity item matching ``get_user_activity_page`` output."""
+    return {
+        "id": id,
+        "created_at": created_at or datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": user_id,
+        "username": username,
+        "activity_type": activity_type,
+        "description": description,
+        "old_value": old_value,
+        "new_value": new_value,
+        "ip_address": ip_address,
+        "user_agent": user_agent,
+    }
+
+
+class _RecordingStreamlit:
+    """A minimal recording stand-in for the ``st`` module used by the dialog body.
+
+    Only the surface used by ``_render_user_activity_dialog_body`` is implemented.
+    """
+
+    def __init__(self):
+        self.session_state: dict = {}
+        self.markdown_calls: list[str] = []
+        self.write_calls: list = []
+        self.caption_calls: list[str] = []
+        self.text_calls: list[str] = []
+        self.json_calls: list = []  # the python object passed to st.json
+        self.columns_call_count = 0
+        self.button_clicked_key: str | None = None
+        self.button_calls: list[str] = []  # keys of every button rendered
+        self.switch_page_target: str | None = None
+
+        # components.v1.html stub
+        self.components = MagicMock()
+        self.components.v1 = MagicMock()
+        self.components.v1.html = MagicMock()
+
+    # ---- Streamlit surface --------------------------------------------------
+    def markdown(self, body, **_kwargs):
+        self.markdown_calls.append(str(body))
+
+    def write(self, body, **_kwargs):
+        self.write_calls.append(body)
+
+    def text(self, body, **_kwargs):
+        self.text_calls.append(str(body))
+
+    def caption(self, body, **_kwargs):
+        self.caption_calls.append(str(body))
+
+    def json(self, obj, **_kwargs):
+        self.json_calls.append(obj)
+
+    def columns(self, spec, **_kwargs):
+        self.columns_call_count += 1
+        n = spec if isinstance(spec, int) else len(spec)
+        # Return context-manager-capable mocks.
+        cols = []
+        for _ in range(n):
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=cm)
+            cm.__exit__ = MagicMock(return_value=False)
+            cols.append(cm)
+        return cols
+
+    def divider(self):  # no-op
+        pass
+
+    def button(self, label, key=None, **_kwargs):
+        if key is not None:
+            self.button_calls.append(key)
+        clicked = key is not None and key == getattr(self, "_force_click_key", None)
+        if clicked:
+            self.button_clicked_key = key
+        return clicked
+
+    def switch_page(self, target):
+        self.switch_page_target = target
+
+    # Decorators must be no-ops: we want to call the wrapped function directly.
+    def dialog(self, _title):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+# ---------------------------------------------------------------------------
+# (b) user_agent renders in the dialog
+# ---------------------------------------------------------------------------
+
+
+class TestUserAgentRendered:
+    def test_user_agent_is_displayed(self):
+        """The dialog must surface ``user_agent`` — the retired
+        ``get_recent_activity`` dropped it and no UI rendered it before #157."""
+        from views import admin_analytics
+
+        item = _make_item(user_agent="Mozilla/5.0 (Macintosh) CustomBrowser/1.2")
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        all_markdown = " ".join(rec.markdown_calls)
+        assert "User Agent" in all_markdown
+        assert "Mozilla/5.0 (Macintosh) CustomBrowser/1.2" in all_markdown
+
+    def test_ip_address_is_displayed(self):
+        from views import admin_analytics
+
+        item = _make_item(ip_address="192.168.1.42")
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        all_markdown = " ".join(rec.markdown_calls)
+        assert "IP Address" in all_markdown
+        assert "192.168.1.42" in all_markdown
+
+    def test_header_line_includes_username_and_type(self):
+        from views import admin_analytics
+
+        item = _make_item(username="carol", activity_type="login")
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        all_markdown = " ".join(rec.markdown_calls)
+        assert "carol" in all_markdown
+        assert "login" in all_markdown
+
+    def test_activity_id_caption_rendered(self):
+        from views import admin_analytics
+
+        item = _make_item(id=4242)
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert any("Activity ID 4242" in c for c in rec.caption_calls), (
+            f"Expected 'Activity ID 4242' caption; got {rec.caption_calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (c) Old/new JSON columns
+# ---------------------------------------------------------------------------
+
+
+class TestOldNewJsonRendering:
+    def test_both_present_renders_two_columns(self):
+        """When both old_value and new_value are populated JSON strings,
+        both st.json columns are rendered."""
+        from views import admin_analytics
+
+        item = _make_item(
+            old_value='{"theme": "light"}',
+            new_value='{"theme": "dark"}',
+        )
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        # Two-column layout used at least once for the diff.
+        assert rec.columns_call_count >= 1
+        # Both parsed objects passed to st.json.
+        assert {"theme": "light"} in rec.json_calls
+        assert {"theme": "dark"} in rec.json_calls
+
+    def test_only_new_value_present_renders_only_populated_column(self):
+        """When old_value is null but new_value is present (e.g. a fresh
+        setting creation), only the populated side renders JSON."""
+        from views import admin_analytics
+
+        item = _make_item(old_value=None, new_value='{"theme": "dark"}')
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        # Section is still rendered.
+        assert rec.columns_call_count >= 1
+        # Only the new value got st.json.
+        assert rec.json_calls == [{"theme": "dark"}]
+
+    def test_only_old_value_present_renders_only_populated_column(self):
+        from views import admin_analytics
+
+        item = _make_item(old_value='{"theme": "light"}', new_value=None)
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert rec.columns_call_count >= 1
+        assert rec.json_calls == [{"theme": "light"}]
+
+    def test_both_null_skips_section_entirely(self):
+        """When neither old_value nor new_value is present (e.g. a login row),
+        the entire old/new diff section is skipped — no columns, no st.json."""
+        from views import admin_analytics
+
+        item = _make_item(old_value=None, new_value=None)
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        # No two-column block dedicated to the diff. (The dialog may still
+        # call st.columns elsewhere in the future, so just assert no
+        # st.json calls for the diff section.)
+        assert rec.json_calls == []
+        # No "Old Value"/"New Value" markdown headers rendered.
+        all_markdown = " ".join(rec.markdown_calls)
+        assert "Old Value" not in all_markdown
+        assert "New Value" not in all_markdown
+
+
+# ---------------------------------------------------------------------------
+# (d) Malformed JSON fallback
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedJsonFallback:
+    def test_malformed_old_value_falls_back_to_text(self):
+        """If ``old_value`` is not valid JSON, the dialog must fall back to
+        ``st.text`` rather than raising."""
+        from views import admin_analytics
+
+        item = _make_item(old_value="not-json-at-all{[", new_value=None)
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            # Must not raise.
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        # Raw text was rendered as the fallback.
+        assert any("not-json-at-all{[" in t for t in rec.text_calls), (
+            f"Expected raw old_value to be rendered via st.text; got text_calls={rec.text_calls}"
+        )
+        # No st.json call (parse failed).
+        assert rec.json_calls == []
+
+    def test_malformed_new_value_falls_back_to_text(self):
+        from views import admin_analytics
+
+        item = _make_item(old_value=None, new_value="<<broken>>")
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert any("<<broken>>" in t for t in rec.text_calls)
+        assert rec.json_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (e) Deep-link button gating on user_id nullability
+# ---------------------------------------------------------------------------
+
+
+class TestDeepLinkButtonGating:
+    def test_button_visible_when_user_id_present(self):
+        from views import admin_analytics
+
+        item = _make_item(id=99, user_id=7)
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert "user_activity_dialog_goto_users_99" in rec.button_calls, (
+            f"Expected the deep-link button to be rendered when user_id is non-null; "
+            f"buttons rendered: {rec.button_calls}"
+        )
+
+    def test_button_hidden_when_user_id_null(self):
+        """Failed-login rows have null ``user_id``. The deep-link button must
+        be hidden so we don't render an unclickable button."""
+        from views import admin_analytics
+
+        item = _make_item(id=100, user_id=None, username="ghost", activity_type="failed_login")
+        rec = _RecordingStreamlit()
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert "user_activity_dialog_goto_users_100" not in rec.button_calls, (
+            f"Deep-link button must NOT render when user_id is null; buttons rendered: {rec.button_calls}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (f) Deep-link round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDeepLinkRoundTrip:
+    def test_button_click_sets_pref_and_switches_page(self):
+        """Clicking the deep-link button sets ``manage_users_pref_user_id`` and
+        calls ``st.switch_page('views/admin.py')``, plus emits the JS tab shim."""
+        from views import admin_analytics
+
+        item = _make_item(id=99, user_id=42)
+        rec = _RecordingStreamlit()
+        rec._force_click_key = "user_activity_dialog_goto_users_99"
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert rec.session_state.get("manage_users_pref_user_id") == 42
+        assert rec.switch_page_target == "views/admin.py"
+        assert rec.components.v1.html.called, (
+            "JS tab-selection shim must be emitted on deep-link click so the Admin page lands on the Users sub-tab"
+        )
+
+    def test_button_not_clicked_does_not_mutate_session(self):
+        from views import admin_analytics
+
+        item = _make_item(id=99, user_id=42)
+        rec = _RecordingStreamlit()
+        # No _force_click_key set — button returns False.
+
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_user_activity_dialog_body(item)
+
+        assert "manage_users_pref_user_id" not in rec.session_state
+        assert rec.switch_page_target is None
+
+    def test_pref_round_trip_pre_populates_mu_selected_label(self):
+        """End-to-end contract check: emitting ``manage_users_pref_user_id``
+        from this dialog must cause ``views/admin_users.render()`` to
+        pre-populate ``mu_selected_label`` (the consumer added by #155)."""
+        from views import admin_users
+
+        rec_session: dict = {"manage_users_pref_user_id": 42}
+        users_list = [
+            {
+                "id": 42,
+                "username": "alice",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "role_name": "Admin",
+                "email": "a@a.io",
+                "organization": "Acme",
+                "theme": "healthelink",
+            }
+        ]
+
+        with (
+            patch.object(admin_users, "st") as mock_st,
+            patch.object(admin_users, "get_all_users", return_value=users_list),
+            patch.object(admin_users, "get_all_user_roles", return_value=[]),
+            patch.object(admin_users, "get_user_stats_for_all_users", return_value={}),
+        ):
+            mock_st.session_state = rec_session
+            mock_st.columns.side_effect = RuntimeError("abort after prefill")
+
+            with pytest.raises(RuntimeError, match="abort after prefill"):
+                admin_users.render()
+
+        assert rec_session.get("mu_selected_label") == "alice (Alice Smith) - Admin"
+        assert "manage_users_pref_user_id" not in rec_session
+
+
+# ---------------------------------------------------------------------------
+# (a) Selection state → dialog open / close in the activity tab
+# ---------------------------------------------------------------------------
+
+
+def _activity_tab_stub_class():
+    """Build a Streamlit stub for ``_render_activity_tab`` testing.
+
+    Returns the class so tests can mutate per-test behaviour (e.g.
+    different `selected_rows`)."""
+
+    class _Stub:
+        def __init__(self, *, selected_rows=None, initial_session=None):
+            self.session_state = dict(initial_session or {})
+            self.captured_dataframe_kwargs: list[dict] = []
+            self._selected_rows = list(selected_rows or [])
+            self.components = MagicMock()
+            self.components.v1 = MagicMock()
+            self.components.v1.html = MagicMock()
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def container(self, **_kw):
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=cm)
+            cm.__exit__ = MagicMock(return_value=False)
+            return cm
+
+        def metric(self, *_a, **_kw):
+            pass
+
+        def columns(self, spec, **_kw):
+            n = spec if isinstance(spec, int) else len(spec)
+            cols = []
+            for _ in range(n):
+                cm = MagicMock()
+                cm.__enter__ = MagicMock(return_value=cm)
+                cm.__exit__ = MagicMock(return_value=False)
+                cols.append(cm)
+            return cols
+
+        def dataframe(self, _df, **kwargs):
+            self.captured_dataframe_kwargs.append(kwargs)
+            ev = MagicMock()
+            ev.selection = {"rows": list(self._selected_rows)}
+            return ev
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, **_kw):
+            return False
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def subheader(self, *_a, **_kw):
+            pass
+
+        def plotly_chart(self, *_a, **_kw):
+            pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub
+
+
+class TestActivityTabSelectionTrigger:
+    def test_dataframe_uses_single_row_selection_primitive(self):
+        """The activity grid must use the trigger primitive locked in by #155:
+        ``selection_mode='single-row'`` + ``on_select='rerun'`` +
+        ``key='audit_activity_dataframe'``."""
+        from views import admin_analytics
+
+        item = _make_item(id=999)
+        Stub = _activity_tab_stub_class()
+        stub = Stub(selected_rows=[])
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch(
+                "orm.logging_functions.get_activity_stats",
+                return_value={
+                    "logins_today": 0,
+                    "failed_logins": 0,
+                    "settings_changes": 0,
+                    "unique_users": 0,
+                },
+            ),
+            patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+            patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+            patch(
+                "orm.logging_functions.get_user_activity_page",
+                return_value={"items": [item], "total": 1},
+            ),
+        ):
+            admin_analytics._render_activity_tab(30)
+
+        assert stub.captured_dataframe_kwargs, "Expected st.dataframe to be called"
+        kw = stub.captured_dataframe_kwargs[0]
+        assert kw.get("selection_mode") == "single-row"
+        assert kw.get("on_select") == "rerun"
+        assert kw.get("key") == "audit_activity_dataframe"
+
+    def test_row_selection_opens_dialog_and_sets_state(self):
+        """When a row is selected, ``audit_activity_dialog_open_id`` is set and
+        the dialog function is invoked with the corresponding item."""
+        from views import admin_analytics
+
+        item = _make_item(id=777)
+        Stub = _activity_tab_stub_class()
+        stub = Stub(selected_rows=[0])
+        dialog_calls: list[dict] = []
+
+        def _fake_dialog(passed_item):
+            dialog_calls.append(passed_item)
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_user_activity_dialog", side_effect=_fake_dialog),
+            patch(
+                "orm.logging_functions.get_activity_stats",
+                return_value={
+                    "logins_today": 0,
+                    "failed_logins": 0,
+                    "settings_changes": 0,
+                    "unique_users": 0,
+                },
+            ),
+            patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+            patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+            patch(
+                "orm.logging_functions.get_user_activity_page",
+                return_value={"items": [item], "total": 1},
+            ),
+        ):
+            admin_analytics._render_activity_tab(30)
+
+        assert dialog_calls == [item], "Dialog must be invoked with the selected row's item"
+        assert stub.session_state.get("audit_activity_dialog_open_id") == 777
+
+    def test_no_selection_clears_dialog_state_key(self):
+        """Clearing the selection removes ``audit_activity_dialog_open_id`` so
+        re-selecting the same row reopens the dialog."""
+        from views import admin_analytics
+
+        item = _make_item(id=777)
+        Stub = _activity_tab_stub_class()
+        stub = Stub(
+            selected_rows=[],
+            initial_session={"audit_activity_dialog_open_id": 777},
+        )
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_user_activity_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_activity_stats",
+                return_value={
+                    "logins_today": 0,
+                    "failed_logins": 0,
+                    "settings_changes": 0,
+                    "unique_users": 0,
+                },
+            ),
+            patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+            patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+            patch(
+                "orm.logging_functions.get_user_activity_page",
+                return_value={"items": [item], "total": 1},
+            ),
+        ):
+            admin_analytics._render_activity_tab(30)
+
+        dialog_mock.assert_not_called()
+        assert "audit_activity_dialog_open_id" not in stub.session_state
+
+
+# ---------------------------------------------------------------------------
+# "Settings Change Details" expander removed
+# ---------------------------------------------------------------------------
+
+
+def test_settings_change_details_expander_removed():
+    """The retired "Settings Change Details" expander must not appear in the
+    activity tab anymore — the dialog is the sole detail surface (#157)."""
+    from views import admin_analytics
+
+    # Read the source of the function and assert the expander label is gone.
+    import inspect
+
+    src = inspect.getsource(admin_analytics._render_activity_tab)
+    assert "Settings Change Details" not in src, (
+        "The 'Settings Change Details' expander must be retired in favour of the row-click dialog (#157)."
+    )

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -808,13 +808,112 @@ def _render_llm_tab(days_int: int):
         st.info("No recent LLM queries found.")
 
 
+def _render_user_activity_dialog_body(item: dict) -> None:
+    """Render the body of the User Activity audit dialog (#157).
+
+    Split out from the ``@st.dialog``-decorated wrapper so tests can call the
+    body directly with a stubbed ``st`` module. The decorated wrapper
+    ``_render_user_activity_dialog`` is what production calls.
+
+    Surfaces ``user_agent`` for the first time (it's on the model but was
+    dropped by the retired ``get_recent_activity`` helper). The
+    "View user in Manage Users →" button is gated on a non-null ``user_id``
+    because failed-login rows can have null ``user_id``.
+    """
+    # Header line: created_at · username · activity_type
+    st.markdown(
+        f"**{item.get('created_at')}** · {item.get('username') or '(unknown user)'} · {item.get('activity_type')}"
+    )
+
+    # Description
+    description = item.get("description")
+    st.write(description if description else "_(no description)_")
+
+    # Request context — surfaces user_agent for the first time
+    st.markdown(f"**IP Address:** {item.get('ip_address') or '_(unknown)_'}")
+    st.markdown(f"**User Agent:** {item.get('user_agent') or '_(unknown)_'}")
+
+    # Old/new JSON diff for settings changes.
+    # Skip the section entirely when both old_value and new_value are null.
+    old_val = item.get("old_value")
+    new_val = item.get("new_value")
+    if old_val or new_val:
+        col1, col2 = st.columns(2)
+        with col1:
+            st.markdown("**Old Value**")
+            if old_val:
+                try:
+                    st.json(json.loads(old_val))
+                except Exception:
+                    st.text(old_val)
+            else:
+                st.caption("_(none)_")
+        with col2:
+            st.markdown("**New Value**")
+            if new_val:
+                try:
+                    st.json(json.loads(new_val))
+                except Exception:
+                    st.text(new_val)
+            else:
+                st.caption("_(none)_")
+
+    # Outbound deep-link to Manage Users — gated on non-null user_id.
+    # Failed-login rows have null user_id and would link to nothing useful.
+    if item.get("user_id") is not None:
+        st.divider()
+        if st.button(
+            "View user in Manage Users →",
+            key=f"user_activity_dialog_goto_users_{item.get('id')}",
+            type="primary",
+        ):
+            st.session_state["manage_users_pref_user_id"] = item["user_id"]
+            # JS tab-selection shim — mirrors views/admin_analytics.py:333-353 but
+            # targets the parent-doc "Users" tab. Streamlit's st.tabs has no
+            # server-side API to change the active tab, and st.switch_page is a
+            # no-op on the same page, so we click the parent doc's "Users" tab
+            # button after the rerun lands. The consumer side of the contract
+            # (`manage_users_pref_user_id` -> pre-populate `mu_selected_label`)
+            # was added in #155 to views/admin_users.py.
+            st.components.v1.html(
+                """
+                <script>
+                  (function(){
+                    try {
+                      var tabs = window.parent.document.querySelectorAll('button[role=tab]');
+                      for (var i = 0; i < tabs.length; i++) {
+                        if (tabs[i].textContent.trim() === 'Users') { tabs[i].click(); break; }
+                      }
+                    } catch (e) { console.error('users-tab nav failed', e); }
+                  })();
+                </script>
+                """,
+                height=0,
+            )
+            st.switch_page("views/admin.py")
+
+    # Metadata caption
+    st.caption(f"Activity ID {item.get('id')}")
+
+
+@st.dialog("User Activity Detail")
+def _render_user_activity_dialog(item: dict) -> None:
+    """``@st.dialog``-decorated wrapper invoked from ``_render_activity_tab``.
+
+    Mirrors the trigger primitive locked in by #155 (Epic #154 Architecture
+    Considerations): ``st.dataframe(on_select="rerun",
+    selection_mode="single-row")`` opens this dialog when a row is selected.
+    """
+    _render_user_activity_dialog_body(item)
+
+
 def _render_activity_tab(days_int: int):
     """Render the User Activity tab."""
     from orm.logging_functions import (
         get_activity_by_type,
         get_activity_over_time,
         get_activity_stats,
-        get_recent_activity,
+        get_user_activity_page,
     )
 
     stats = get_activity_stats(days=days_int)
@@ -867,40 +966,102 @@ def _render_activity_tab(days_int: int):
 
     st.divider()
 
-    # Recent Activity Log
+    # Recent Activity Log — paginated grid with single-row selection trigger
+    # (mirrors the Questions tab primitive locked in by #155). No role gate
+    # and no agent_logging.mode interaction: UserActivity rows don't carry
+    # PHI or generated SQL, so the existing _guard_admin() is sufficient.
     st.subheader("Recent Activity Log")
-    recent = get_recent_activity(days=days_int, limit=50)
-    if recent:
-        activity_df = pd.DataFrame(recent)
-        # Format for display
-        display_df = activity_df[["created_at", "username", "activity_type", "description", "ip_address"]].copy()
-        display_df.columns = ["Timestamp", "User", "Type", "Description", "IP Address"]
-        st.dataframe(display_df, width="stretch", hide_index=True)
 
-        # Show details for settings changes
-        settings_changes = [a for a in recent if a["old_value"] or a["new_value"]]
-        if settings_changes:
-            with st.expander("Settings Change Details", expanded=False):
-                for change in settings_changes[:10]:
-                    st.markdown(f"**{change['username']}** - {change['description']}")
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        st.markdown("**Old Value:**")
-                        try:
-                            old = json.loads(change["old_value"]) if change["old_value"] else {}
-                            st.json(old)
-                        except Exception:
-                            st.text(change["old_value"])
-                    with col2:
-                        st.markdown("**New Value:**")
-                        try:
-                            new = json.loads(change["new_value"]) if change["new_value"] else {}
-                            st.json(new)
-                        except Exception:
-                            st.text(change["new_value"])
-                    st.divider()
+    # Pagination controls (mirror the Questions tab shape)
+    if "audit_activity_page_bump" in st.session_state:
+        st.session_state["audit_activity_page_num"] = max(
+            1,
+            int(st.session_state.get("audit_activity_page_num", 1)) + int(st.session_state["audit_activity_page_bump"]),
+        )
+        del st.session_state["audit_activity_page_bump"]
+    if "audit_activity_page_num" not in st.session_state:
+        st.session_state["audit_activity_page_num"] = 1
+
+    pc1, pc2, _spacer = st.columns([1, 1, 6])
+    with pc1:
+        page_size = st.selectbox(
+            "Page size",
+            options=[25, 50, 100, 200],
+            index=1,
+            key="audit_activity_page_size",
+        )
+    with pc2:
+        st.number_input("Page", min_value=1, step=1, key="audit_activity_page_num")
+        page = int(st.session_state["audit_activity_page_num"])
+
+    result = get_user_activity_page(days=days_int, page=page, page_size=int(page_size))
+    items = result.get("items", [])
+    total = int(result.get("total", 0))
+    total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
+
+    if items:
+        table_rows = [
+            {
+                "Timestamp": it["created_at"],
+                "User": it.get("username") or "(unknown)",
+                "Type": it.get("activity_type"),
+                "Description": it.get("description"),
+                "IP Address": it.get("ip_address"),
+            }
+            for it in items
+        ]
+        event = st.dataframe(
+            pd.DataFrame(table_rows),
+            width="stretch",
+            hide_index=True,
+            on_select="rerun",
+            selection_mode="single-row",
+            key="audit_activity_dataframe",
+        )
+        selected_rows = []
+        try:
+            selected_rows = (event.selection or {}).get("rows", []) if event else []
+        except AttributeError:
+            # Some versions return a dict-like; fall back gracefully.
+            try:
+                selected_rows = (event or {}).get("selection", {}).get("rows", [])
+            except Exception:
+                selected_rows = []
+
+        if selected_rows:
+            row_idx = int(selected_rows[0])
+            if 0 <= row_idx < len(items):
+                selected_item = items[row_idx]
+                open_id = st.session_state.get("audit_activity_dialog_open_id")
+                if open_id != selected_item["id"]:
+                    st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
+                _render_user_activity_dialog(selected_item)
+        else:
+            # Selection cleared — reset tracking key so re-selecting the same
+            # row reopens the dialog.
+            if "audit_activity_dialog_open_id" in st.session_state:
+                del st.session_state["audit_activity_dialog_open_id"]
     else:
         st.info("No recent activity found.")
+
+    # Pagination caption + Prev/Next
+    cprev, cinfo, cnext = st.columns([1, 3, 1])
+    with cprev:
+        st.button(
+            "Prev",
+            disabled=int(page) <= 1,
+            key="audit_activity_prev_btn",
+            on_click=lambda: st.session_state.update({"audit_activity_page_bump": -1}),
+        )
+    with cinfo:
+        st.caption(f"Page {int(page)} of {total_pages} • {total} total")
+    with cnext:
+        st.button(
+            "Next",
+            disabled=int(page) >= total_pages,
+            key="audit_activity_next_btn",
+            on_click=lambda: st.session_state.update({"audit_activity_page_bump": 1}),
+        )
 
 
 def _render_audit_tab(days_int: int):

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -352,6 +352,7 @@ def _render_overview_tab(days_int: int):
         height=60,
     )
 
+
 @st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
 def _cached_audit_filter_options(days_int: int) -> dict:
     from orm.logging_functions import get_question_audit_filter_options
@@ -369,6 +370,105 @@ def _truncate(text, length):
     return text if len(text) <= length else text[: length - 1] + "…"
 
 
+def _render_audit_question_dialog_body(item: dict) -> None:
+    """Render the body of the Questions audit dialog (#155).
+
+    Split out from the `@st.dialog`-decorated wrapper so tests can call the
+    body directly with a stubbed `st` module. The decorated wrapper
+    `_render_audit_question_dialog` is what production calls.
+    """
+    from io import StringIO
+
+    from agent.observability_gate import role_can_see_query_details
+
+    current_role = st.session_state.get("user_role")
+    can_see_query_details = role_can_see_query_details(current_role)
+
+    # Header line
+    org = item.get("organization") or "(no org)"
+    st.markdown(f"**{item['asked_at']}** · {item['username']} · {org}")
+
+    # Full question
+    st.markdown("**Question**")
+    st.write(item.get("question") or "_(empty)_")
+
+    # Role-gated: Generated SQL with built-in copy-to-clipboard
+    if can_see_query_details:
+        st.markdown("**Generated SQL**")
+        st.code(item.get("sql_text") or "(no SQL)", language="sql")
+
+    # Summary
+    st.markdown("**Summary**")
+    summary = item.get("summary_text")
+    st.write(summary if summary else "_(no summary)_")
+
+    # Role-gated: full DataFrame (no .head(5) — dataframe_preview holds the full JSON)
+    df_preview = item.get("dataframe_preview")
+    if df_preview and can_see_query_details:
+        st.markdown("**Result DataFrame**")
+        try:
+            df_obj = pd.read_json(StringIO(df_preview))
+            st.dataframe(df_obj, width="stretch", hide_index=True)
+        except Exception:
+            try:
+                df_obj = pd.read_json(df_preview)
+                st.dataframe(df_obj, width="stretch", hide_index=True)
+            except Exception:
+                st.text(str(df_preview)[:1000])
+
+    # Error block when present
+    err = item.get("error_text")
+    if err:
+        st.markdown("**Error**")
+        st.code(err, language="text")
+
+    # Metadata caption
+    st.caption(
+        f"Message ID {item.get('user_message_id')} · Elapsed {round(float(item.get('elapsed_seconds') or 0.0), 3)}s"
+    )
+
+    # Outbound deep-link to Manage Users
+    st.divider()
+    if st.button(
+        "View user in Manage Users →",
+        key=f"audit_dialog_goto_users_{item.get('user_message_id')}",
+        type="primary",
+    ):
+        st.session_state["manage_users_pref_user_id"] = item["user_id"]
+        # JS tab-selection shim — mirrors the Audit-tab shim above but targets "Users".
+        # Streamlit's st.tabs has no server-side API to change the active tab and
+        # st.switch_page is a no-op on the same page, so we click the parent doc's
+        # "Users" tab button after the rerun lands.
+        st.components.v1.html(
+            """
+            <script>
+              (function(){
+                try {
+                  var tabs = window.parent.document.querySelectorAll('button[role=tab]');
+                  for (var i = 0; i < tabs.length; i++) {
+                    if (tabs[i].textContent.trim() === 'Users') { tabs[i].click(); break; }
+                  }
+                } catch (e) { console.error('users-tab nav failed', e); }
+              })();
+            </script>
+            """,
+            height=0,
+        )
+        st.switch_page("views/admin.py")
+
+
+@st.dialog("Question Audit Detail")
+def _render_audit_question_dialog(item: dict) -> None:
+    """`@st.dialog`-decorated wrapper invoked from `_render_audit_trail_tab`.
+
+    Subsystems #156 and #157 must adopt the same trigger primitive
+    (`st.dataframe(on_select="rerun", selection_mode="single-row")` + dialog
+    body invoked on selection state change). See Epic #154 Architecture
+    Considerations.
+    """
+    _render_audit_question_dialog_body(item)
+
+
 def _render_audit_trail_tab(days_int: int):
     """Render the Question Audit Trail tab (#135)."""
     import datetime as _dt
@@ -378,6 +478,15 @@ def _render_audit_trail_tab(days_int: int):
         get_question_audit_page,
     )
     from orm.functions import get_all_users
+
+    # [agent_logging].mode = "disabled" defense-in-depth.
+    # Under "disabled" mode no audit rows are written, but we belt-and-suspenders
+    # the trigger primitive so it cannot open the dialog.
+    try:
+        logging_mode = st.secrets.get("agent_logging", {}).get("mode", "full")
+    except Exception:
+        logging_mode = "full"
+    selection_enabled = logging_mode != "disabled"
 
     options = _cached_audit_filter_options(days_int)
 
@@ -394,13 +503,9 @@ def _render_audit_trail_tab(days_int: int):
 
     f1, f2, f3 = st.columns([0.30, 0.30, 0.40])
     with f1:
-        usernames_sel = st.multiselect(
-            "User", options=options["usernames"], key="audit_user_filter"
-        )
+        usernames_sel = st.multiselect("User", options=options["usernames"], key="audit_user_filter")
     with f2:
-        orgs_sel = st.multiselect(
-            "Organization", options=options["orgs"], key="audit_org_filter"
-        )
+        orgs_sel = st.multiselect("Organization", options=options["orgs"], key="audit_org_filter")
     with f3:
         search = st.text_input(
             "Search question or SQL",
@@ -442,7 +547,9 @@ def _render_audit_trail_tab(days_int: int):
     total = int(result.get("total", 0))
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
-    # Table
+    # Table — single-row selection trigger replaces the per-row expander list
+    # (Epic #154 architecture: selection state is one widget read at page_size=200,
+    # vs. 200 button widgets per refresh; load-bearing for #156/#157).
     if items:
         table_rows = []
         for it in items:
@@ -457,7 +564,48 @@ def _render_audit_trail_tab(days_int: int):
                     "Elapsed (s)": round(float(it.get("elapsed_seconds") or 0.0), 3),
                 }
             )
-        st.dataframe(pd.DataFrame(table_rows), width="stretch", hide_index=True)
+
+        if selection_enabled:
+            event = st.dataframe(
+                pd.DataFrame(table_rows),
+                width="stretch",
+                hide_index=True,
+                on_select="rerun",
+                selection_mode="single-row",
+                key="audit_dataframe",
+            )
+            selected_rows = []
+            try:
+                selected_rows = (event.selection or {}).get("rows", []) if event else []
+            except AttributeError:
+                # Some versions return a dict-like; fall back gracefully.
+                try:
+                    selected_rows = (event or {}).get("selection", {}).get("rows", [])
+                except Exception:
+                    selected_rows = []
+
+            if selected_rows:
+                row_idx = int(selected_rows[0])
+                if 0 <= row_idx < len(items):
+                    selected_item = items[row_idx]
+                    open_id = st.session_state.get("audit_dialog_open_user_message_id")
+                    if open_id != selected_item["user_message_id"]:
+                        st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
+                    _render_audit_question_dialog(selected_item)
+            else:
+                # Dataframe selection cleared (e.g. clicking the row again) — reset our
+                # tracking key so re-selecting the same row reopens the dialog.
+                if "audit_dialog_open_user_message_id" in st.session_state:
+                    del st.session_state["audit_dialog_open_user_message_id"]
+        else:
+            # agent_logging.mode == "disabled": render the table read-only;
+            # selection trigger and dialog branch are short-circuited.
+            st.dataframe(
+                pd.DataFrame(table_rows),
+                width="stretch",
+                hide_index=True,
+                key="audit_dataframe",
+            )
     else:
         st.info("No audit rows match the current filters.")
 
@@ -479,34 +627,6 @@ def _render_audit_trail_tab(days_int: int):
             key="audit_next_btn",
             on_click=lambda: st.session_state.update({"audit_page_bump": 1}),
         )
-
-    # Row drilldown expanders
-    for it in items:
-        header = f"{it['asked_at']} • {it['username']} • {_truncate(it['question'], 80)}"
-        with st.expander(header):
-            st.markdown("**Question**")
-            st.write(it["question"] or "_(empty)_")
-            st.markdown("**Generated SQL**")
-            st.code(it.get("sql_text") or "(no SQL)", language="sql")
-            st.markdown("**Summary**")
-            summary = it.get("summary_text")
-            st.write(summary if summary else "_(no summary)_")
-            df_preview = it.get("dataframe_preview")
-            if df_preview:
-                st.markdown("**DataFrame preview (first 5 rows)**")
-                try:
-                    df_obj = pd.read_json(df_preview).head(5)
-                    st.dataframe(df_obj, width="stretch", hide_index=True)
-                except Exception:
-                    st.text(str(df_preview)[:1000])
-            err = it.get("error_text")
-            if err:
-                st.markdown("**Error**")
-                st.code(err, language="text")
-            st.caption(
-                f"Asked At {it['asked_at']} · Elapsed "
-                f"{round(float(it.get('elapsed_seconds') or 0.0), 3)}s · Message ID {it.get('user_message_id')}"
-            )
 
     # Export CSV
     if st.button("📥 Export filtered audit to CSV", key="audit_export_btn"):
@@ -884,6 +1004,7 @@ def main():
         if st.button("Refresh Data", help="Clear cached data and reload metrics"):
             _read_metrics.clear()
             from views.errors import _load as _errors_load, _load_aggregates as _errors_load_aggregates
+
             _errors_load.clear()
             _errors_load_aggregates.clear()
             st.rerun()

--- a/views/admin_users.py
+++ b/views/admin_users.py
@@ -2,11 +2,21 @@
 
 Relocated from views/user.py tab3. Post-Epic #129 layout: toolbar dialogs,
 L/R split, 4 inner tabs (Profile / Preferences / Activity / Danger Zone).
-The Activity inner tab's `View question audit for <username> →` button
-navigates to views/admin.py — the Admin Audit tab will pre-filter to the
-target user via the existing audit_trail_pref_user_id contract.
-"""
 
+Deep-link contracts:
+
+- Outbound (this surface → Audit): The Activity inner tab's
+  `View question audit for <username> →` button navigates to views/admin.py;
+  the Admin Audit tab pre-filters to the target user via the existing
+  `audit_trail_pref_user_id` session-state contract.
+
+- Inbound (Audit Questions dialog → this surface, Feature #155): The
+  Questions audit row-click dialog's "View user in Manage Users →" button
+  sets `manage_users_pref_user_id` in session_state, then switches to
+  views/admin.py. On the next render of this sub-tab, the pref is consumed
+  (popped) and used to pre-populate `mu_selected_label` so the left-rail
+  selectbox lands on the target user.
+"""
 
 import pandas as pd
 import streamlit as st
@@ -40,6 +50,22 @@ def render(days_int: int | None = None) -> None:
     st.subheader("Manage Users")
     st.caption("Create, edit, or remove users. View settings and activity stats.")
 
+    # Inbound deep-link from the Questions audit dialog (Feature #155):
+    # consume `manage_users_pref_user_id`, look up the user, and pre-populate
+    # `mu_selected_label` so the left-rail selectbox lands on the target user.
+    # Only honour when the user hasn't already touched the selectbox this
+    # session (mirrors the audit_trail_pref_user_id pattern in admin_analytics).
+    pref_user_id = st.session_state.pop("manage_users_pref_user_id", None)
+    if pref_user_id is not None and "mu_selected_label" not in st.session_state:
+        try:
+            all_users_for_pref = get_all_users()
+            match = next((u for u in all_users_for_pref if u["id"] == int(pref_user_id)), None)
+            if match:
+                pref_label = f"{match['username']} ({match['first_name']} {match['last_name']}) - {match['role_name']}"
+                st.session_state["mu_selected_label"] = pref_label
+        except Exception as e:
+            logger.warning("Manage Users deep-link prefill failed: %s", e)
+
     roles = get_all_user_roles()
     role_id_by_name = {name: rid for rid, name, _ in roles}
     role_names = [name for rid, name, _ in roles]
@@ -67,18 +93,14 @@ def render(days_int: int | None = None) -> None:
         if search:
             s = search.lower()
             users = [
-                u
-                for u in users
-                if s in u["username"].lower() or s in f"{u['first_name']} {u['last_name']}`".lower()
+                u for u in users if s in u["username"].lower() or s in f"{u['first_name']} {u['last_name']}`".lower()
             ]
         selected = None
         if users:
             user_options = {
                 f"{u['username']} ({u['first_name']} {u['last_name']}) - {u['role_name']}": u for u in users
             }
-            selected_label = st.selectbox(
-                "Select a user", options=list(user_options.keys()), key="mu_selected_label"
-            )
+            selected_label = st.selectbox("Select a user", options=list(user_options.keys()), key="mu_selected_label")
             selected = user_options[selected_label]
         else:
             st.info("No users found.")
@@ -191,9 +213,7 @@ def render(days_int: int | None = None) -> None:
                 m4.metric("DataFrames", s["dataframes"])
                 m5.metric("Summaries", s["summaries"])
 
-                range_choice = st.radio(
-                    "Range", options=["7 days", "30 days"], horizontal=True, key="stats_range"
-                )
+                range_choice = st.radio("Range", options=["7 days", "30 days"], horizontal=True, key="stats_range")
                 days = 7 if range_choice.startswith("7") else 30
                 daily = get_user_daily_stats(selected["id"], days=days)
                 if daily:


### PR DESCRIPTION
Closes #157
Parent epic: #154

## Summary

User Activity audit tab now mirrors the Questions audit tab's UX (#155):
a paginated grid with the single-row selection primitive, an `st.dialog`
that surfaces the full row detail (including `user_agent` for the first
time), and a "View user in Manage Users →" deep-link reusing the
`manage_users_pref_user_id` contract added by #155. The legacy "Settings
Change Details" shared expander is retired; the dialog is the sole
detail surface for settings changes too.

## Stacked on #155 (PR #158) — recommend merging #155 first

This branch is stacked on `feat/155-questions-audit-row-dialog`. It depends
on the consumer-side `manage_users_pref_user_id` → `mu_selected_label`
pre-fill that #155 added to `views/admin_users.render()`. Once #155 merges
to `main`, this PR will show a clean diff.

## Changes

### Backend (`orm/logging_functions.py`)
- Add `get_user_activity_page(days, page, page_size) -> {items, total}`
  returning all 10 `UserActivity` fields per item: `id`, `created_at`,
  `user_id`, `username`, `activity_type`, `description`, `old_value`,
  `new_value`, `ip_address`, `user_agent`. Error pattern matches
  `get_question_audit_page`: `logger.warning` + empty envelope on
  exception.
- Remove `get_recent_activity`. Sole caller was `_render_activity_tab`;
  the helper dropped `user_id` and `user_agent` so it can't back the new
  dialog. No other consumers — grepped clean.

### UI (`views/admin_analytics.py`)
- Replace the bottom of `_render_activity_tab` with a paginated grid
  (page-size `[25, 50, 100, 200]`, default 50, Prev/Next, page caption)
  using `st.dataframe(on_select="rerun", selection_mode="single-row",
  key="audit_activity_dataframe")` — the trigger primitive locked in
  by #155.
- Wire selection state → `audit_activity_dialog_open_id` →
  `_render_user_activity_dialog(item)`. Clearing the selection clears
  the tracking key so re-selecting the same row re-opens the dialog.
- Add `_render_user_activity_dialog_body(item)` + decorated wrapper
  `_render_user_activity_dialog`. The body renders: header
  (`created_at · username · activity_type`), description, IP Address,
  **User Agent** (surfaced for the first time), old/new JSON side-by-side
  with `st.text` fallback on parse failure (section skipped when both
  values are null), and the deep-link button gated on
  `item["user_id"] is not None` (failed-login rows have null `user_id`).
- Retire the "Settings Change Details" shared expander.
- KPI row, Login Trends chart, and Activity Type Breakdown table at the
  top of the tab are untouched.

## Design Decisions

- **No role gate, no `agent_logging.mode` interaction.** UserActivity
  rows don't carry PHI or generated SQL — the existing `_guard_admin()`
  is sufficient. Confirmed in the spec's Technical Context.
- **Trigger primitive inherited from #155.** Same
  `st.dataframe(on_select="rerun", selection_mode="single-row")` pattern
  and the same body/wrapper split for testability. Considered per-row
  `st.button` (rejected — Epic #154 explicitly forbids it; one widget
  read per page beats N button widgets) and a sidebar drawer (rejected
  — inconsistent with the sibling tabs).
- **JS tab-selection shim mirrors `views/admin_analytics.py:333-353`.**
  `st.switch_page("views/admin.py")` re-runs the page without changing
  the active sub-tab; the shim clicks the parent-doc `button[role=tab]`
  whose `textContent` is `"Users"` after the rerun lands. The consumer
  side (`manage_users_pref_user_id` → `mu_selected_label` pre-fill) was
  added by #155.
- **`user_id` nullability gate.** `UserActivity.user_id` is nullable
  (failed logins where user lookup failed). Rendering an unclickable
  deep-link button would be worse than hiding it; the button is gated
  on `item["user_id"] is not None`.
- **New session keys carry the `_activity` suffix** (`audit_activity_*`)
  so they're clearly separate from `audit_*` (Questions) and
  `audit_actions_*` (Admin Actions).
- **Pagination added beyond strict Epic AC.** The Epic AC for User
  Activity says "adds a per-row View button + dialog" without explicitly
  requiring pagination. Adding pagination here too keeps the three Audit
  sub-tabs visually consistent — which the Epic's problem statement
  explicitly motivates ("normalizes the three sibling tabs").

## Self-Review

Cynical pass over LOGIC / EDGE CASES / SECURITY / CONVENTIONS / SCOPE /
ERROR HANDLING / TESTS / REGRESSIONS. Findings:
- Verified the `with_entities(func.count(...))` count + offset/limit
  pattern is the SQLAlchemy generative-Query pattern (matches
  `get_question_audit_page`); confirmed by the page-2 test which returns
  exactly the right slice and total.
- Verified the `_kpi_card` / Login Trends / Activity Type Breakdown
  blocks are byte-identical to the parent branch (no regression on the
  unchanged sections).
- Verified the JSON-parse `try/except Exception` is broad enough that any
  malformed string falls back to `st.text` (tested with both
  `not-json-at-all{[` and `<<broken>>`).
- Verified the deep-link button is hidden when `user_id` is null (new
  test `test_button_hidden_when_user_id_null`).
- No remaining concerns.

## Testing

- [x] `uv run pytest -m "not milvus" tests/views tests/orm` — **279
      passed**; the 3 failing tests are pre-existing on `main`
      (`test_agent_analytics.py` and `test_user_import.py` import retired
      views) and unrelated to this change.
- [x] `uv run ruff check` on changed files — passes.
- [x] `uv run ruff format --check` on changed files — passes.
- [ ] Manual verification: load Admin → Audit → User Activity, click a
      row to open the dialog, verify `user_agent` is shown, click "View
      user in Manage Users →" and confirm the Admin → Users tab lands
      with the target user pre-selected.

### New test files

- `tests/orm/test_user_activity_pagination.py` (14 tests):
  empty DB, 10-field shape, reverse-chrono ordering, page-1/page-2 math,
  out-of-range page, page-size variants `[25, 50, 100, 200]`, null
  `user_id` rows are returned, days filter, error envelope, and a
  removal-check test for `get_recent_activity`.
- `tests/views/test_user_activity_dialog.py` (19 tests):
  `user_agent` rendered, IP rendered, header line includes username/type,
  Activity ID caption, both old/new columns rendered, only-old / only-new
  / both-null cases, malformed JSON fallback for both fields, deep-link
  button visible / hidden based on `user_id`, deep-link click sets
  `manage_users_pref_user_id` + switches page + emits JS shim, deep-link
  round-trip through `admin_users.render()` pre-fills `mu_selected_label`,
  dataframe uses the `single-row` selection primitive, row selection
  invokes the dialog and sets state, no-selection clears state, and the
  "Settings Change Details" expander label is gone.

## Files Modified

- `orm/logging_functions.py`
- `views/admin_analytics.py`
- `tests/orm/test_user_activity_pagination.py` (new)
- `tests/views/test_user_activity_dialog.py` (new)