### PR TITLE
feat(audit): Admin Actions tab grid + row-click dialog (#156)

### DIFF
--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -1238,35 +1238,52 @@ def get_admin_actions_by_type(days: int = 30) -> list[dict]:
         return []
 
 
-def get_recent_admin_actions(days: int = 30, limit: int = 50) -> list[dict]:
-    """Get recent admin actions for audit log."""
+def get_admin_actions_page(days: int = 30, page: int = 1, page_size: int = 50) -> dict:
+    """Paginated admin actions audit. Returns ``{"items": [...], "total": int}``.
+
+    Mirrors the shape of :func:`get_question_audit_page` (Feature #134) so the
+    Admin Actions tab in ``views/admin_analytics.py`` can reuse the same
+    grid + dialog primitive (Feature #156, Epic #154). Unlike the Questions
+    tab, AdminAction rows have no filters today, so the signature takes
+    ``days`` directly instead of a filters dict.
+
+    Each item exposes the full ``AdminAction`` row plus the joined
+    ``admin_username`` so the UI can render without re-querying.
+    """
     try:
-        since = datetime.now() - timedelta(days=days)
+        since = datetime.now() - timedelta(days=int(days))
         with SessionLocal() as session:
             from orm.models import User
 
-            results = (
+            base_query = (
                 session.query(AdminAction, User.username.label("admin_username"))
                 .outerjoin(User, User.id == AdminAction.admin_id)
                 .filter(AdminAction.created_at >= since)
                 .order_by(AdminAction.created_at.desc())
-                .limit(limit)
-                .all()
             )
-            return [
+            total = session.query(func.count(AdminAction.id)).filter(AdminAction.created_at >= since).scalar() or 0
+            offset = max(0, (int(page) - 1) * int(page_size))
+            rows = base_query.offset(offset).limit(int(page_size)).all()
+            items = [
                 {
                     "id": r.AdminAction.id,
                     "created_at": r.AdminAction.created_at,
                     "admin_username": r.admin_username or "Unknown",
                     "action_type": r.AdminAction.action_type,
+                    "target_user_id": r.AdminAction.target_user_id,
                     "target_username": r.AdminAction.target_username,
+                    "target_entity_type": r.AdminAction.target_entity_type,
+                    "target_entity_id": r.AdminAction.target_entity_id,
                     "description": r.AdminAction.description,
-                    "success": r.AdminAction.success,
                     "old_value": r.AdminAction.old_value,
                     "new_value": r.AdminAction.new_value,
+                    "affected_count": r.AdminAction.affected_count,
+                    "success": bool(r.AdminAction.success) if r.AdminAction.success is not None else None,
+                    "error_message": r.AdminAction.error_message,
                 }
-                for r in results
+                for r in rows
             ]
+            return {"items": items, "total": int(total)}
     except Exception as e:
-        logger.warning("Failed to get recent admin actions: %s", e)
-        return []
+        logger.warning("get_admin_actions_page failed: %s", e)
+        return {"items": [], "total": 0}

--- a/tests/orm/test_admin_actions_pagination.py
+++ b/tests/orm/test_admin_actions_pagination.py
@@ -1,0 +1,316 @@
+"""Tests for ``orm.logging_functions.get_admin_actions_page`` (#156).
+
+Covers:
+  - Item shape exposes all 14 AdminAction-derived fields per spec.
+  - Page math: page out of range returns empty items + correct total.
+  - Page size variants (25 / 50 / 100 / 200).
+  - Default ordering is created_at DESC.
+  - Time-range (``days``) filtering excludes older rows.
+  - Joined admin_username falls back to "Unknown" when the admin row is missing.
+  - Error path returns ``{"items": [], "total": 0}``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import AdminAction, Base, RoleTypeEnum, User, UserRole
+
+
+# Fields the dict-shape contract guarantees per the #156 spec.
+EXPECTED_ITEM_KEYS = {
+    "id",
+    "created_at",
+    "admin_username",
+    "action_type",
+    "target_user_id",
+    "target_username",
+    "target_entity_type",
+    "target_entity_id",
+    "description",
+    "old_value",
+    "new_value",
+    "affected_count",
+    "success",
+    "error_message",
+}
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add(UserRole(id=1, role_name="Admin", description="Admin", role=RoleTypeEnum.ADMIN))
+    session.commit()
+
+
+def _seed_admin(session, *, user_id=1, username="alice_admin"):
+    session.add(
+        User(
+            id=user_id,
+            user_role_id=1,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+        )
+    )
+    session.commit()
+
+
+def _add_action(
+    session,
+    *,
+    admin_id=1,
+    action_type="user_update",
+    target_user_id=None,
+    target_username=None,
+    target_entity_type=None,
+    target_entity_id=None,
+    description="A change",
+    old_value=None,
+    new_value=None,
+    affected_count=None,
+    success=True,
+    error_message=None,
+    when=None,
+):
+    action = AdminAction(
+        admin_id=admin_id,
+        action_type=action_type,
+        target_user_id=target_user_id,
+        target_username=target_username,
+        target_entity_type=target_entity_type,
+        target_entity_id=target_entity_id,
+        description=description,
+        old_value=old_value,
+        new_value=new_value,
+        affected_count=affected_count,
+        success=success,
+        error_message=error_message,
+    )
+    session.add(action)
+    session.commit()
+    if when is not None:
+        # server_default=func.now() is applied on insert; override after so
+        # the time-range filter can be exercised deterministically.
+        last = session.query(AdminAction).order_by(AdminAction.id.desc()).first()
+        last.created_at = when
+        session.commit()
+    return action
+
+
+# ---------------------------------------------------------------------------
+# Shape & contract
+# ---------------------------------------------------------------------------
+
+
+class TestItemShape:
+    def test_item_exposes_all_fourteen_fields(self, session_factory):
+        """Each item must expose the full set of AdminAction-derived fields
+        named in the #156 spec."""
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s, user_id=1, username="alice_admin")
+            _seed_admin(s, user_id=2, username="bob_target")
+            _add_action(
+                s,
+                admin_id=1,
+                action_type="user_update",
+                target_user_id=2,
+                target_username="bob_target",
+                target_entity_type="user",
+                target_entity_id="2",
+                description="Updated bob",
+                old_value=json.dumps({"role": "Patient"}),
+                new_value=json.dumps({"role": "Doctor"}),
+                affected_count=1,
+                success=True,
+                error_message=None,
+            )
+
+        result = get_admin_actions_page(days=30, page=1, page_size=50)
+        assert result["total"] == 1
+        assert len(result["items"]) == 1
+        item = result["items"][0]
+        assert set(item.keys()) == EXPECTED_ITEM_KEYS, (
+            f"Item keys mismatch.\nMissing: {EXPECTED_ITEM_KEYS - set(item.keys())}\n"
+            f"Extra: {set(item.keys()) - EXPECTED_ITEM_KEYS}"
+        )
+        # Spot-check joined + projected values.
+        assert item["admin_username"] == "alice_admin"
+        assert item["target_user_id"] == 2
+        assert item["target_username"] == "bob_target"
+        assert item["target_entity_type"] == "user"
+        assert item["target_entity_id"] == "2"
+        assert item["affected_count"] == 1
+        assert item["success"] is True
+        assert item["error_message"] is None
+        assert item["old_value"] is not None and "Patient" in item["old_value"]
+        assert item["new_value"] is not None and "Doctor" in item["new_value"]
+
+    def test_missing_admin_falls_back_to_unknown(self, session_factory):
+        """If the AdminAction.admin_id row no longer exists (e.g. user
+        deleted), admin_username is "Unknown" via the outer join."""
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            # No User seeded — admin_id=999 won't join.
+            _add_action(s, admin_id=999, action_type="user_delete")
+
+        result = get_admin_actions_page(days=30)
+        assert result["total"] == 1
+        assert result["items"][0]["admin_username"] == "Unknown"
+
+    def test_nullable_target_fields_remain_none(self, session_factory):
+        """When the action has no target user/entity, the dict still carries
+        the keys with None values."""
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            _add_action(s, target_user_id=None, target_username=None, target_entity_type=None, target_entity_id=None)
+
+        item = get_admin_actions_page(days=30)["items"][0]
+        assert item["target_user_id"] is None
+        assert item["target_username"] is None
+        assert item["target_entity_type"] is None
+        assert item["target_entity_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Page math
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    def test_total_independent_of_page(self, session_factory):
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            for i in range(7):
+                _add_action(s, description=f"Action {i}")
+
+        assert get_admin_actions_page(days=30, page=1, page_size=3)["total"] == 7
+        assert get_admin_actions_page(days=30, page=2, page_size=3)["total"] == 7
+        assert get_admin_actions_page(days=30, page=99, page_size=3)["total"] == 7
+
+    def test_page_size_caps_returned_items(self, session_factory):
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            for i in range(12):
+                _add_action(s, description=f"Action {i}")
+
+        assert len(get_admin_actions_page(days=30, page=1, page_size=5)["items"]) == 5
+        assert len(get_admin_actions_page(days=30, page=2, page_size=5)["items"]) == 5
+        # Last page has remainder only.
+        assert len(get_admin_actions_page(days=30, page=3, page_size=5)["items"]) == 2
+
+    def test_page_out_of_range_returns_empty_items_with_correct_total(self, session_factory):
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            for i in range(3):
+                _add_action(s, description=f"Action {i}")
+
+        out = get_admin_actions_page(days=30, page=99, page_size=10)
+        assert out["items"] == []
+        assert out["total"] == 3
+
+    def test_page_size_variants_25_50_100_200(self, session_factory):
+        """Spec calls out [25, 50, 100, 200] as the selectbox options; this
+        check just confirms each is accepted without error and returns at
+        most that many items."""
+        from orm.logging_functions import get_admin_actions_page
+
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            for i in range(30):
+                _add_action(s, description=f"Action {i}")
+
+        for size in (25, 50, 100, 200):
+            out = get_admin_actions_page(days=30, page=1, page_size=size)
+            assert out["total"] == 30
+            assert len(out["items"]) == min(size, 30)
+
+
+# ---------------------------------------------------------------------------
+# Ordering & time-range filter
+# ---------------------------------------------------------------------------
+
+
+class TestOrderingAndTimeRange:
+    def test_default_order_is_created_at_desc(self, session_factory):
+        from orm.logging_functions import get_admin_actions_page
+
+        now = datetime.now()
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            _add_action(s, description="oldest", when=now - timedelta(hours=3))
+            _add_action(s, description="middle", when=now - timedelta(hours=2))
+            _add_action(s, description="newest", when=now - timedelta(hours=1))
+
+        items = get_admin_actions_page(days=30)["items"]
+        assert [i["description"] for i in items] == ["newest", "middle", "oldest"]
+
+    def test_days_window_excludes_old_rows(self, session_factory):
+        from orm.logging_functions import get_admin_actions_page
+
+        now = datetime.now()
+        with session_factory() as s:
+            _seed_roles(s)
+            _seed_admin(s)
+            _add_action(s, description="recent", when=now - timedelta(days=2))
+            _add_action(s, description="too_old", when=now - timedelta(days=45))
+
+        out = get_admin_actions_page(days=7)
+        assert out["total"] == 1
+        assert out["items"][0]["description"] == "recent"
+
+
+# ---------------------------------------------------------------------------
+# Error path
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPath:
+    def test_db_exception_returns_empty_sentinel(self, monkeypatch):
+        """When the SessionLocal raises, get_admin_actions_page must return
+        the documented sentinel ``{"items": [], "total": 0}`` and log a warning
+        (mirrors get_question_audit_page's error path)."""
+        from orm import logging_functions as lf
+
+        def _boom(*_a, **_kw):
+            raise RuntimeError("db is on fire")
+
+        monkeypatch.setattr(lf, "SessionLocal", _boom)
+        out = lf.get_admin_actions_page(days=30)
+        assert out == {"items": [], "total": 0}

--- a/tests/views/test_admin_actions_dialog.py
+++ b/tests/views/test_admin_actions_dialog.py
@@ -1,0 +1,634 @@
+"""Tests for the Admin Actions audit tab row-click dialog (#156).
+
+Covers:
+  (a) Dialog opens when row selection state changes; closes when cleared.
+  (b) Both old/new JSON columns render when both present.
+  (c) Only the populated column renders when one is null.
+  (d) Malformed JSON falls back to ``st.text`` without raising.
+  (e) Error block renders only when ``success=False`` and message present.
+  (f) Affected-count line renders only when non-null.
+  (g) Target line formatting prefers username, falls back to entity_type:entity_id.
+  (h) Pre-existing KPI / Action Distribution surface stays unchanged
+      (the per-row expander is gone — dialog is the sole detail surface).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_action(
+    *,
+    id: int = 1,
+    admin_username: str = "alice_admin",
+    action_type: str = "user_update",
+    target_user_id: int | None = 42,
+    target_username: str | None = "bob",
+    target_entity_type: str | None = "user",
+    target_entity_id: str | None = "42",
+    description: str = "Updated bob's role",
+    old_value: str | None = '{"role": "Patient"}',
+    new_value: str | None = '{"role": "Doctor"}',
+    affected_count: int | None = 1,
+    success: bool | None = True,
+    error_message: str | None = None,
+    created_at: datetime | None = None,
+) -> dict:
+    return {
+        "id": id,
+        "created_at": created_at or datetime(2026, 6, 1, 12, 0, 0),
+        "admin_username": admin_username,
+        "action_type": action_type,
+        "target_user_id": target_user_id,
+        "target_username": target_username,
+        "target_entity_type": target_entity_type,
+        "target_entity_id": target_entity_id,
+        "description": description,
+        "old_value": old_value,
+        "new_value": new_value,
+        "affected_count": affected_count,
+        "success": success,
+        "error_message": error_message,
+    }
+
+
+class _RecordingStreamlit:
+    """A minimal recording stand-in for the ``st`` module for the dialog body.
+
+    Mirrors the pattern from tests/views/test_admin_audit_dialog.py (#155).
+    Only the surface used by ``_render_admin_action_dialog_body`` is
+    implemented.
+    """
+
+    def __init__(self):
+        self.session_state: dict = {}
+        self.code_calls: list[tuple[str, str]] = []  # (content, language)
+        self.json_calls: list = []
+        self.write_calls: list = []
+        self.text_calls: list = []
+        self.markdown_calls: list[str] = []
+        self.caption_calls: list[str] = []
+        self.columns_calls: list[int] = []
+
+    # ---- Streamlit surface ------------------------------------------------
+    def markdown(self, body, **_kwargs):
+        self.markdown_calls.append(str(body))
+
+    def write(self, body, **_kwargs):
+        self.write_calls.append(body)
+
+    def code(self, body, language: str = "text", **_kwargs):
+        self.code_calls.append((str(body), language))
+
+    def json(self, body, **_kwargs):
+        self.json_calls.append(body)
+
+    def text(self, body, **_kwargs):
+        self.text_calls.append(str(body))
+
+    def caption(self, body, **_kwargs):
+        self.caption_calls.append(str(body))
+
+    def divider(self):
+        pass
+
+    def columns(self, spec):
+        n = spec if isinstance(spec, int) else len(spec)
+        self.columns_calls.append(n)
+        return [MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None) for _ in range(n)]
+
+    def dialog(self, _title):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+# ---------------------------------------------------------------------------
+# (b)(c)(d) Old / New JSON columns
+# ---------------------------------------------------------------------------
+
+
+class TestOldNewJsonColumns:
+    def test_both_columns_render_when_both_present(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(
+            old_value='{"role": "Patient"}',
+            new_value='{"role": "Doctor"}',
+        )
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert len(rec.json_calls) == 2, "Both old AND new JSON blocks must render when both are present"
+        # Order: old then new.
+        assert rec.json_calls[0] == {"role": "Patient"}
+        assert rec.json_calls[1] == {"role": "Doctor"}
+        # st.text fallback must NOT have been invoked for either column.
+        assert rec.text_calls == []
+
+    def test_only_old_renders_when_new_is_null(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value='{"k": 1}', new_value=None)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == [{"k": 1}], "Only the populated (old) JSON column should render"
+
+    def test_only_new_renders_when_old_is_null(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value=None, new_value='{"k": 2}')
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == [{"k": 2}], "Only the populated (new) JSON column should render"
+
+    def test_empty_string_is_treated_as_absent(self):
+        """``""`` should be treated the same as ``None`` — neither column
+        renders if both are empty strings."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value="", new_value="")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == []
+        assert rec.text_calls == []
+
+    def test_malformed_old_value_falls_back_to_text(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value="not-a-json {{{", new_value=None)
+        with patch.object(admin_analytics, "st", rec):
+            # Must not raise.
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == []
+        assert "not-a-json" in " ".join(rec.text_calls)
+
+    def test_malformed_new_value_falls_back_to_text(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value=None, new_value="<<garbage>>")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == []
+        assert "<<garbage>>" in " ".join(rec.text_calls)
+
+    def test_one_malformed_one_valid_each_handled_independently(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(old_value="not json", new_value='{"ok": true}')
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert rec.json_calls == [{"ok": True}]
+        assert any("not json" in t for t in rec.text_calls)
+
+
+# ---------------------------------------------------------------------------
+# (e) Error block — gated on (success=False AND message present)
+# ---------------------------------------------------------------------------
+
+
+class TestErrorBlock:
+    def test_error_block_renders_when_success_false_and_message_present(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(success=False, error_message="DB constraint violated")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        error_codes = [body for body, lang in rec.code_calls if lang == "text"]
+        assert any("DB constraint violated" in body for body in error_codes), (
+            "Expected the error_message to be rendered as a text code block"
+        )
+
+    def test_no_error_block_when_success_true_even_with_message(self):
+        """If success=True, the error_message field is meaningless and must
+        not render."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(success=True, error_message="stale warning")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        error_codes = [body for body, lang in rec.code_calls if lang == "text"]
+        assert error_codes == [], "Error block must not render when success=True"
+
+    def test_no_error_block_when_failed_but_no_message(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(success=False, error_message=None)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        error_codes = [body for body, lang in rec.code_calls if lang == "text"]
+        assert error_codes == [], "Error block requires a non-empty error_message"
+
+    def test_failed_badge_renders_when_success_false(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(success=False, error_message=None)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        badges = " ".join(rec.markdown_calls)
+        assert "FAILED" in badges and "SUCCESS" not in badges.replace("FAILED", "")
+
+    def test_success_badge_renders_when_success_true(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(success=True)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert any("SUCCESS" in m for m in rec.markdown_calls)
+
+
+# ---------------------------------------------------------------------------
+# (f) Affected-count line
+# ---------------------------------------------------------------------------
+
+
+class TestAffectedCount:
+    def test_affected_renders_when_non_null(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(affected_count=37)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert any("Affected" in m and "37" in m for m in rec.markdown_calls)
+
+    def test_affected_omitted_when_null(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(affected_count=None)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert not any("Affected" in m for m in rec.markdown_calls)
+
+    def test_affected_zero_is_treated_as_present(self):
+        """Zero is a meaningful value for bulk operations — don't drop it."""
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(affected_count=0)
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert any("Affected" in m and "0" in m for m in rec.markdown_calls)
+
+
+# ---------------------------------------------------------------------------
+# (g) Target line formatting
+# ---------------------------------------------------------------------------
+
+
+class TestTargetLine:
+    def test_username_preferred_when_present(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(target_username="bob", target_entity_type="user", target_entity_id="42")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        target_md = [m for m in rec.markdown_calls if m.startswith("**Target:**")]
+        assert target_md == ["**Target:** bob"]
+
+    def test_falls_back_to_entity_type_id_when_no_username(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(target_username=None, target_entity_type="training_data", target_entity_id="abc-123")
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        target_md = [m for m in rec.markdown_calls if m.startswith("**Target:**")]
+        assert target_md == ["**Target:** training_data:abc-123"]
+
+    def test_target_line_omitted_when_no_target_info(self):
+        from views import admin_analytics
+
+        rec = _RecordingStreamlit()
+        item = _make_action(
+            target_user_id=None,
+            target_username=None,
+            target_entity_type=None,
+            target_entity_id=None,
+        )
+        with patch.object(admin_analytics, "st", rec):
+            admin_analytics._render_admin_action_dialog_body(item)
+
+        assert not any(m.startswith("**Target:**") for m in rec.markdown_calls)
+
+
+# ---------------------------------------------------------------------------
+# (a) Selection state opens / closes the dialog
+# ---------------------------------------------------------------------------
+
+
+def _make_tab_stub():
+    """Build a stub ``st`` module sufficient for ``_render_audit_tab`` to run."""
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {}
+            self.captured_dataframe_kwargs: list[dict] = []
+            self.dialog_invocations: list[dict] = []
+
+        # Streamlit surface --------------------------------------------------
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None) for _ in range(n)]
+
+        def container(self, **_kw):
+            return MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None)
+
+        def divider(self):
+            pass
+
+        def subheader(self, *_a, **_kw):
+            pass
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def dataframe(self, _df, **kwargs):
+            self.captured_dataframe_kwargs.append(kwargs)
+            # Default: simulate the configured selection_event hook (set per test).
+            return getattr(self, "_dataframe_event", None) or MagicMock(selection={"rows": []})
+
+        def button(self, *_a, **_kw):
+            return False
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def text(self, *_a, **_kw):
+            pass
+
+        def json(self, *_a, **_kw):
+            pass
+
+        def plotly_chart(self, *_a, **_kw):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub()
+
+
+class TestSelectionStateTrigger:
+    def test_row_selection_opens_dialog_and_sets_state(self):
+        """When the dataframe event reports a selected row, _render_audit_tab
+        must set ``audit_actions_dialog_open_id`` and invoke the dialog
+        function for that row."""
+        from views import admin_analytics
+
+        item = _make_action(id=314)
+        dialog_calls: list[dict] = []
+
+        stub = _make_tab_stub()
+        ev = MagicMock()
+        ev.selection = {"rows": [0]}
+        stub._dataframe_event = ev
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_admin_action_dialog", side_effect=lambda x: dialog_calls.append(x)),
+            patch(
+                "orm.logging_functions.get_admin_actions_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch(
+                "orm.logging_functions.get_admin_action_stats",
+                return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+            ),
+            patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+        ):
+            admin_analytics._render_audit_tab(30)
+
+        assert dialog_calls == [item], "Dialog must be invoked for the selected row's item"
+        assert stub.session_state.get("audit_actions_dialog_open_id") == 314
+
+    def test_no_selection_clears_dialog_state_key(self):
+        from views import admin_analytics
+
+        item = _make_action(id=314)
+
+        stub = _make_tab_stub()
+        # Pre-existing tracking key — must be cleared when selection is empty.
+        stub.session_state["audit_actions_dialog_open_id"] = 314
+        ev = MagicMock()
+        ev.selection = {"rows": []}
+        stub._dataframe_event = ev
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_admin_action_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_admin_actions_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch(
+                "orm.logging_functions.get_admin_action_stats",
+                return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+            ),
+            patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+        ):
+            admin_analytics._render_audit_tab(30)
+
+        dialog_mock.assert_not_called()
+        assert "audit_actions_dialog_open_id" not in stub.session_state
+
+    def test_dataframe_wired_with_single_row_selection_primitive(self):
+        """The grid must always use the locked-in trigger primitive:
+        ``selection_mode='single-row'``, ``on_select='rerun'``, and a stable
+        key. Epic #154 mandates this for #156 + #157."""
+        from views import admin_analytics
+
+        item = _make_action()
+        stub = _make_tab_stub()
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_admin_action_dialog"),
+            patch(
+                "orm.logging_functions.get_admin_actions_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch(
+                "orm.logging_functions.get_admin_action_stats",
+                return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+            ),
+            patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+        ):
+            admin_analytics._render_audit_tab(30)
+
+        assert stub.captured_dataframe_kwargs, "Expected st.dataframe to be called for the grid"
+        kw = stub.captured_dataframe_kwargs[0]
+        assert kw.get("selection_mode") == "single-row"
+        assert kw.get("on_select") == "rerun"
+        assert kw.get("key") == "audit_actions_dataframe"
+
+
+# ---------------------------------------------------------------------------
+# Per-row expander removal & no get_recent_admin_actions reference
+# ---------------------------------------------------------------------------
+
+
+class TestExpanderRetired:
+    def test_admin_analytics_no_longer_imports_get_recent_admin_actions(self):
+        """The per-row expander loop is gone — `get_recent_admin_actions`
+        must not appear anywhere in admin_analytics.py."""
+        from pathlib import Path
+
+        src = Path(__file__).resolve().parents[2] / "views" / "admin_analytics.py"
+        text = src.read_text()
+        assert "get_recent_admin_actions" not in text, (
+            "Sole caller removed in #156; the import + call must be gone from views/admin_analytics.py"
+        )
+
+    def test_get_recent_admin_actions_is_removed_from_logging_functions(self):
+        """Backend function itself is retired (the spec calls for removal,
+        not deprecation, since it had a single call site)."""
+        from orm import logging_functions
+
+        assert not hasattr(logging_functions, "get_recent_admin_actions"), (
+            "get_recent_admin_actions should be removed; the dialog page reads via get_admin_actions_page"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing KPI / Action Distribution surface untouched
+# ---------------------------------------------------------------------------
+
+
+class TestKpiAndDistributionPreserved:
+    def test_kpi_cards_and_distribution_still_render_above_grid(self):
+        """The KPI row + distribution pie/table block should still call
+        ``get_admin_action_stats`` and ``get_admin_actions_by_type`` —
+        these were not touched by #156."""
+        from views import admin_analytics
+
+        stats_calls: list = []
+        by_type_calls: list = []
+
+        def _stats(days=30):
+            stats_calls.append(days)
+            return {"total": 5, "user_changes": 2, "training_actions": 1, "failed": 1}
+
+        def _by_type(days=30):
+            by_type_calls.append(days)
+            return [{"action_type": "user_update", "count": 3}, {"action_type": "user_delete", "count": 2}]
+
+        stub = _make_tab_stub()
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_admin_action_dialog"),
+            patch("orm.logging_functions.get_admin_action_stats", side_effect=_stats),
+            patch("orm.logging_functions.get_admin_actions_by_type", side_effect=_by_type),
+            patch(
+                "orm.logging_functions.get_admin_actions_page",
+                return_value={"items": [], "total": 0},
+            ),
+        ):
+            admin_analytics._render_audit_tab(7)
+
+        assert stats_calls == [7]
+        assert by_type_calls == [7]
+
+
+# ---------------------------------------------------------------------------
+# Sanity: dialog body doesn't raise on minimal item
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_item_does_not_raise():
+    """A row with nothing but id + admin_username + action_type should still
+    render cleanly (no Target line, no JSON diff, no error, no affected)."""
+    from views import admin_analytics
+
+    rec = _RecordingStreamlit()
+    item = {
+        "id": 1,
+        "created_at": None,
+        "admin_username": None,
+        "action_type": None,
+        "target_user_id": None,
+        "target_username": None,
+        "target_entity_type": None,
+        "target_entity_id": None,
+        "description": None,
+        "old_value": None,
+        "new_value": None,
+        "affected_count": None,
+        "success": None,
+        "error_message": None,
+    }
+    with patch.object(admin_analytics, "st", rec):
+        admin_analytics._render_admin_action_dialog_body(item)
+
+    # Caption with Action ID 1 should always appear at the end.
+    assert any("Action ID 1" in c for c in rec.caption_calls)

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -352,6 +352,7 @@ def _render_overview_tab(days_int: int):
         height=60,
     )
 
+
 @st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
 def _cached_audit_filter_options(days_int: int) -> dict:
     from orm.logging_functions import get_question_audit_filter_options
@@ -394,13 +395,9 @@ def _render_audit_trail_tab(days_int: int):
 
     f1, f2, f3 = st.columns([0.30, 0.30, 0.40])
     with f1:
-        usernames_sel = st.multiselect(
-            "User", options=options["usernames"], key="audit_user_filter"
-        )
+        usernames_sel = st.multiselect("User", options=options["usernames"], key="audit_user_filter")
     with f2:
-        orgs_sel = st.multiselect(
-            "Organization", options=options["orgs"], key="audit_org_filter"
-        )
+        orgs_sel = st.multiselect("Organization", options=options["orgs"], key="audit_org_filter")
     with f3:
         search = st.text_input(
             "Search question or SQL",
@@ -783,12 +780,121 @@ def _render_activity_tab(days_int: int):
         st.info("No recent activity found.")
 
 
+def _format_action_target(item: dict) -> str:
+    """Format the target column for the Admin Actions grid.
+
+    Prefers ``target_username`` (the human-readable handle, denormalised on
+    the row so deleted users still render). Falls back to
+    ``target_entity_type:target_entity_id`` when no username is set. Returns
+    empty string when neither is present.
+    """
+    username = item.get("target_username")
+    if username:
+        return str(username)
+    entity_type = item.get("target_entity_type")
+    entity_id = item.get("target_entity_id")
+    if entity_type and entity_id:
+        return f"{entity_type}:{entity_id}"
+    if entity_type:
+        return str(entity_type)
+    if entity_id:
+        return str(entity_id)
+    return ""
+
+
+def _render_admin_action_dialog_body(item: dict) -> None:
+    """Render the body of the Admin Action detail dialog (#156).
+
+    Split out from the ``@st.dialog``-decorated wrapper so tests can call
+    the body directly with a stubbed ``st`` module — mirrors the pattern
+    used by ``_render_audit_question_dialog_body`` (#155).
+    """
+    # Header line: timestamp · admin · action_type
+    created_at = item.get("created_at")
+    if hasattr(created_at, "strftime"):
+        created_str = created_at.strftime("%Y-%m-%d %H:%M:%S")
+    else:
+        created_str = str(created_at) if created_at is not None else "(unknown time)"
+    admin = item.get("admin_username") or "Unknown"
+    action_type = item.get("action_type") or "(unknown action)"
+    st.markdown(f"**{created_str}** · {admin} · {action_type}")
+
+    # Success / failure badge
+    success = item.get("success")
+    if success is False:
+        st.markdown(":red[❌ FAILED]")
+    else:
+        st.markdown(":green[✅ SUCCESS]")
+
+    # Description
+    st.markdown("**Description**")
+    st.write(item.get("description") or "_(no description)_")
+
+    # Target line — surface fields the old expander dropped on the floor.
+    target = _format_action_target(item)
+    if target:
+        st.markdown(f"**Target:** {target}")
+
+    # Affected count (bulk operations) — only when non-null.
+    affected = item.get("affected_count")
+    if affected is not None:
+        st.markdown(f"**Affected:** {int(affected)}")
+
+    # Error block — only on failure with a non-empty message.
+    error_msg = item.get("error_message")
+    if success is False and error_msg:
+        st.markdown("**Error**")
+        st.code(str(error_msg), language="text")
+
+    # Side-by-side old/new value diff.
+    old_raw = item.get("old_value")
+    new_raw = item.get("new_value")
+    has_old = old_raw is not None and old_raw != ""
+    has_new = new_raw is not None and new_raw != ""
+    if has_old or has_new:
+        col1, col2 = st.columns(2)
+        if has_old:
+            with col1:
+                st.markdown("**Previous State**")
+                try:
+                    st.json(json.loads(old_raw))
+                except Exception:
+                    st.text(str(old_raw))
+        if has_new:
+            with col2:
+                st.markdown("**New State**")
+                try:
+                    st.json(json.loads(new_raw))
+                except Exception:
+                    st.text(str(new_raw))
+
+    # Trailing metadata caption.
+    st.caption(f"Action ID {item.get('id')}")
+
+
+@st.dialog("Admin Action Detail")
+def _render_admin_action_dialog(item: dict) -> None:
+    """``@st.dialog``-decorated wrapper invoked from ``_render_audit_tab``.
+
+    Uses the same trigger primitive as the Questions tab (#155): a
+    ``st.dataframe(on_select="rerun", selection_mode="single-row")``
+    selection-state change opens this dialog. See Epic #154.
+    """
+    _render_admin_action_dialog_body(item)
+
+
 def _render_audit_tab(days_int: int):
-    """Render the Admin Audit tab."""
+    """Render the Admin Audit tab.
+
+    Grid + row-click dialog (Feature #156). The pre-existing KPI row and
+    Action Distribution pie/table at the top of the tab are unchanged from
+    #144 — only the trailing "Recent Admin Actions" expander block was
+    swapped for the paginated grid + dialog.
+    """
     from orm.logging_functions import (
         get_admin_action_stats,
         get_admin_actions_by_type,
-        get_recent_admin_actions,
+        get_admin_actions_page,
     )
 
     stats = get_admin_action_stats(days=days_int)
@@ -827,39 +933,110 @@ def _render_audit_tab(days_int: int):
 
     st.divider()
 
-    # Recent Actions Log
+    # Recent Admin Actions — paginated grid + row-click dialog (#156).
     st.subheader("Recent Admin Actions")
-    recent = get_recent_admin_actions(days=days_int, limit=50)
-    if recent:
-        for action in recent:
-            status_icon = ":green[SUCCESS]" if action["success"] else ":red[FAILED]"
-            with st.expander(
-                f"{status_icon} **{action['action_type']}** by {action['admin_username']} - {action['created_at'].strftime('%Y-%m-%d %H:%M')}",
-                expanded=False,
-            ):
-                st.markdown(f"**Description:** {action['description']}")
-                if action["target_username"]:
-                    st.markdown(f"**Target User:** {action['target_username']}")
 
-                # Show value changes if present
-                if action["old_value"] or action["new_value"]:
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        st.markdown("**Previous State:**")
-                        try:
-                            old = json.loads(action["old_value"]) if action["old_value"] else {}
-                            st.json(old)
-                        except Exception:
-                            st.text(action["old_value"] or "N/A")
-                    with col2:
-                        st.markdown("**New State:**")
-                        try:
-                            new = json.loads(action["new_value"]) if action["new_value"] else {}
-                            st.json(new)
-                        except Exception:
-                            st.text(action["new_value"] or "N/A")
+    # Reset pagination on time-range change so the page index doesn't
+    # outlive a shrunken result set.
+    if st.session_state.get("audit_actions_days_signature") != int(days_int):
+        st.session_state["audit_actions_days_signature"] = int(days_int)
+        st.session_state["audit_actions_page_num"] = 1
+
+    # Pagination controls (top row) — mirrors _render_audit_trail_tab.
+    if "audit_actions_page_bump" in st.session_state:
+        st.session_state["audit_actions_page_num"] = max(
+            1,
+            int(st.session_state.get("audit_actions_page_num", 1)) + int(st.session_state["audit_actions_page_bump"]),
+        )
+        del st.session_state["audit_actions_page_bump"]
+    if "audit_actions_page_num" not in st.session_state:
+        st.session_state["audit_actions_page_num"] = 1
+
+    pc1, pc2, _spacer = st.columns([1, 1, 6])
+    with pc1:
+        page_size = st.selectbox(
+            "Page size",
+            options=[25, 50, 100, 200],
+            index=1,
+            key="audit_actions_page_size",
+        )
+    with pc2:
+        st.number_input("Page", min_value=1, step=1, key="audit_actions_page_num")
+        page = int(st.session_state["audit_actions_page_num"])
+
+    result = get_admin_actions_page(days=int(days_int), page=page, page_size=int(page_size))
+    items = result.get("items", [])
+    total = int(result.get("total", 0))
+    total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
+
+    if items:
+        table_rows = []
+        for it in items:
+            ts = it.get("created_at")
+            ts_str = ts.strftime("%Y-%m-%d %H:%M:%S") if hasattr(ts, "strftime") else str(ts or "")
+            table_rows.append(
+                {
+                    "Time": ts_str,
+                    "Admin": it.get("admin_username") or "Unknown",
+                    "Action Type": it.get("action_type") or "",
+                    "Target": _format_action_target(it),
+                    "Description": _truncate(it.get("description"), 120),
+                    "Status": "✅ Success" if it.get("success") else "❌ Failed",
+                }
+            )
+
+        event = st.dataframe(
+            pd.DataFrame(table_rows),
+            width="stretch",
+            hide_index=True,
+            on_select="rerun",
+            selection_mode="single-row",
+            key="audit_actions_dataframe",
+        )
+
+        selected_rows = []
+        try:
+            selected_rows = (event.selection or {}).get("rows", []) if event else []
+        except AttributeError:
+            try:
+                selected_rows = (event or {}).get("selection", {}).get("rows", [])
+            except Exception:
+                selected_rows = []
+
+        if selected_rows:
+            row_idx = int(selected_rows[0])
+            if 0 <= row_idx < len(items):
+                selected_item = items[row_idx]
+                open_id = st.session_state.get("audit_actions_dialog_open_id")
+                if open_id != selected_item["id"]:
+                    st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
+                _render_admin_action_dialog(selected_item)
+        else:
+            # Selection cleared — drop the tracking key so re-selecting the
+            # same row reopens the dialog.
+            if "audit_actions_dialog_open_id" in st.session_state:
+                del st.session_state["audit_actions_dialog_open_id"]
     else:
-        st.info("No recent admin actions found.")
+        st.info("No admin actions in the selected time range.")
+
+    # Pagination caption + Prev/Next.
+    cprev, cinfo, cnext = st.columns([1, 3, 1])
+    with cprev:
+        st.button(
+            "Prev",
+            disabled=int(page) <= 1,
+            key="audit_actions_prev_btn",
+            on_click=lambda: st.session_state.update({"audit_actions_page_bump": -1}),
+        )
+    with cinfo:
+        st.caption(f"Page {int(page)} of {total_pages} • {total} total")
+    with cnext:
+        st.button(
+            "Next",
+            disabled=int(page) >= total_pages,
+            key="audit_actions_next_btn",
+            on_click=lambda: st.session_state.update({"audit_actions_page_bump": 1}),
+        )
 
 
 # ============== Main Entry Point ==============
@@ -884,6 +1061,7 @@ def main():
         if st.button("Refresh Data", help="Clear cached data and reload metrics"):
             _read_metrics.clear()
             from views.errors import _load as _errors_load, _load_aggregates as _errors_load_aggregates
+
             _errors_load.clear()
             _errors_load_aggregates.clear()
             st.rerun()


### PR DESCRIPTION
Closes #156 (Epic #154).

## Summary

Restructures the Admin Audit tab in `views/admin_analytics.py` from the existing
expander-only layout into a paginated grid that opens an `st.dialog` modal on
single-row selection — the same trigger primitive locked in by #155 across the
three Audit sub-tabs per Epic #154.

The dialog surfaces fields the old expander dropped on the floor:
`target_user_id`, `target_entity_type`, `target_entity_id`, `affected_count`,
and `error_message`.

## Changes

### Backend
- **Add** `get_admin_actions_page(days, page, page_size) -> {items, total}` in
  `orm/logging_functions.py`. Mirrors `get_question_audit_page`'s shape and
  error-path contract. Each item exposes all 14 AdminAction-derived fields:
  `id`, `created_at`, `admin_username` (joined), `action_type`,
  `target_user_id`, `target_username`, `target_entity_type`, `target_entity_id`,
  `description`, `old_value`, `new_value`, `affected_count`, `success`,
  `error_message`.
- **Remove** `get_recent_admin_actions` (sole caller was `_render_audit_tab`).

### UI
- **Restructure** `_render_audit_tab` (`views/admin_analytics.py:_render_audit_tab`):
  - Pre-existing KPI row + Action Distribution pie/table at the top stay
    unchanged.
  - Replace the per-row expander loop with: page-size selectbox
    `[25, 50, 100, 200]`, page-number input, Prev/Next buttons, and a
    pagination caption (`Page X of N • Y total`).
  - Single-row selection grid (`st.dataframe(on_select="rerun",
    selection_mode="single-row", key="audit_actions_dataframe")`) with columns
    Time / Admin / Action Type / Target / Description (truncated) / Status.
  - New session-state keys all prefixed `audit_actions_*` to keep them clearly
    separate from `_render_audit_trail_tab`'s `audit_*` keys.
- **Add** `_render_admin_action_dialog` (`@st.dialog`-decorated) and its
  testable body `_render_admin_action_dialog_body`. Renders header line,
  success/failure badge, description, optional Target line (prefers
  `target_username`; falls back to `target_entity_type:target_entity_id`),
  optional `Affected:` line, error block (gated on `success=False` AND
  non-empty message), side-by-side old/new JSON diff with `st.text` fallback
  on parse failure, and an `Action ID <id>` caption.

### Tests
- **New** `tests/orm/test_admin_actions_pagination.py` (10 tests):
  - Item shape exposes all 14 fields.
  - Page math: out-of-range page returns empty items + correct total.
  - Page-size variants (25/50/100/200) all work.
  - Default ordering is `created_at DESC`.
  - Time-range filter excludes old rows.
  - Missing admin falls back to `"Unknown"` via the outer join.
  - DB exception returns `{"items": [], "total": 0}` sentinel.
- **New** `tests/views/test_admin_actions_dialog.py` (25 tests):
  - Both / only-old / only-new JSON columns render correctly.
  - Empty string treated as absent.
  - Malformed JSON (each column independently) falls back to `st.text`.
  - Error block gated on `success=False` AND non-empty `error_message`.
  - Affected-count line renders only when non-null; zero is preserved.
  - Target line prefers username, falls back to entity_type:entity_id,
    omitted when both null.
  - Row selection sets `audit_actions_dialog_open_id` and invokes the dialog.
  - Empty selection clears the tracking key (so re-selecting reopens).
  - Grid is wired with `selection_mode="single-row"`, `on_select="rerun"`,
    `key="audit_actions_dataframe"`.
  - `get_recent_admin_actions` removed from both module attribute and source.
  - KPI / distribution surface untouched.

## Design decisions

- **Trigger primitive locked in by #155.** Same `st.dataframe(on_select=...)`
  pattern — Epic #154 explicitly rules out per-row `st.button` columns to avoid
  the 200-widgets-at-page_size=200 perf pitfall.
- **No role gate, no `agent_logging.mode` interaction.** AdminAction rows don't
  carry PHI or generated SQL — `_guard_admin()` at the page level is
  sufficient. Per spec, no `role_can_see_query_details` or `[agent_logging].mode`
  defense-in-depth was added.
- **No outbound deep-link.** Epic #154 scopes the "View target user in Manage
  Users →" deep-link to the Questions tab (#155) only. A future PR can wire it
  on cheaply since `manage_users_pref_user_id` was added by #155.
- **`get_recent_admin_actions` removed, not deprecated.** Sole call site
  swapped, so the tidy thing is to delete it rather than leave a dead shim.

## Self-review findings

- Initial test stub for `_render_audit_tab` lacked `st.container`, which the
  `_kpi_card` helper uses. Fixed by adding a `MagicMock`-returning
  `container(**_kw)` to the stub.
- Removed unused `pandas` / `pytest` top-level imports from the dialog test
  file to satisfy ruff.
- `success` is normalised in `get_admin_actions_page` so SQLite's `0/1`
  representation reads back as a proper `bool` (or `None`), which keeps the
  badge logic simple in the dialog body.
- `affected_count=0` is deliberately rendered (zero is meaningful for bulk
  ops); the code uses `is not None` rather than truthiness — covered by a
  dedicated test.

## Test plan

- [x] `uv sync`
- [x] `uv run pytest tests/orm/test_admin_actions_pagination.py tests/views/test_admin_actions_dialog.py` — **35 / 35 passing**
- [x] `uv run pytest -m "not milvus" tests/views tests/orm` — 270 passing,
      3 known-failing tests on `main` (`tests/views/test_agent_analytics.py`,
      `tests/views/test_user_import.py`) import retired views — unrelated to
      this change.
- [x] `uv run ruff check views/admin_analytics.py orm/logging_functions.py tests/orm/test_admin_actions_pagination.py tests/views/test_admin_actions_dialog.py`
- [x] `uv run ruff format --check views/admin_analytics.py orm/logging_functions.py tests/orm/test_admin_actions_pagination.py tests/views/test_admin_actions_dialog.py`

## Files Modified

- `orm/logging_functions.py` — add `get_admin_actions_page`, remove
  `get_recent_admin_actions`
- `views/admin_analytics.py` — add `_format_action_target`,
  `_render_admin_action_dialog_body`, `_render_admin_action_dialog`;
  restructure `_render_audit_tab` from expander loop to paginated grid + dialog
- `tests/orm/test_admin_actions_pagination.py` — new (10 tests)
- `tests/views/test_admin_actions_dialog.py` — new (25 tests)

## Out of scope (per Epic #154)

- Keyboard nav, URL-encoded shareable links per row, filter controls
  (user / action type / target), deep-link to Manage Users.