### PR TITLE
feat(errors): disambiguate error counts — two ledgers, additive visuals (Epic #161)

### DIFF
--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -1115,57 +1115,6 @@ def get_user_activity_page(days: int = 7, page: int = 1, page_size: int = 50) ->
         return {"items": [], "total": 0}
 
 
-def get_error_stats(days: int = 7) -> dict:
-    """Get error statistics for analytics."""
-    try:
-        since = datetime.now() - timedelta(days=days)
-        with SessionLocal() as session:
-            from sqlalchemy import func as sqla_func
-
-            total = session.query(sqla_func.count(ErrorLog.id)).filter(ErrorLog.created_at >= since).scalar() or 0
-            critical = (
-                session.query(sqla_func.count(ErrorLog.id))
-                .filter(
-                    ErrorLog.created_at >= since,
-                    ErrorLog.severity == ErrorSeverity.CRITICAL.value,
-                )
-                .scalar()
-                or 0
-            )
-            sql_errors = (
-                session.query(sqla_func.count(ErrorLog.id))
-                .filter(
-                    ErrorLog.created_at >= since,
-                    ErrorLog.category.in_([ErrorCategory.SQL_GENERATION.value, ErrorCategory.SQL_EXECUTION.value]),
-                )
-                .scalar()
-                or 0
-            )
-            retry_attempted = (
-                session.query(sqla_func.count(ErrorLog.id))
-                .filter(ErrorLog.created_at >= since, ErrorLog.auto_retry_attempted == True)  # noqa: E712
-                .scalar()
-                or 0
-            )
-            retry_successful = (
-                session.query(sqla_func.count(ErrorLog.id))
-                .filter(ErrorLog.created_at >= since, ErrorLog.retry_successful == True)  # noqa: E712
-                .scalar()
-                or 0
-            )
-            retry_rate = (retry_successful / retry_attempted * 100) if retry_attempted > 0 else 0
-
-            return {
-                "total": total,
-                "critical": critical,
-                "sql_errors": sql_errors,
-                "retry_success_rate": round(retry_rate, 1),
-            }
-    except Exception as e:
-        logger.warning("Failed to get error stats: %s", e)
-        return {"total": 0, "critical": 0, "sql_errors": 0, "retry_success_rate": 0}
-
-
 def get_admin_action_stats(days: int = 30) -> dict:
     """Get admin action statistics."""
     try:

--- a/tests/views/test_admin_overview_error_kpis.py
+++ b/tests/views/test_admin_overview_error_kpis.py
@@ -1,0 +1,461 @@
+"""Tests for the Admin Overview error-count KPIs after the two-ledger
+disambiguation (Epic #161, Feature Spec #162).
+
+Asserts:
+
+- The KPI labels are renamed to "Chat Errors" and "Critical System
+  Errors" (the old "Errors" / "Critical Errors" labels are gone).
+- "Critical System Errors" is fed by ``views.errors._load_aggregates``
+  (the 3-source union via :func:`query_aggregates`) — NOT by the legacy
+  ``orm.logging_functions.get_error_stats`` ErrorLog-only counter.
+- The shared cache is honoured: rendering both the Errors tab and the
+  Admin Overview within one session calls ``query_aggregates`` exactly
+  once per ``days_int`` (because ``_load_aggregates`` is
+  ``@st.cache_data``-decorated and shared across modules).
+- Module-level two-ledger contract docstrings exist on both
+  ``views.admin_analytics`` and ``views.errors``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Streamlit recorder — mirrors the pattern in test_admin_actions_dialog.py
+# ---------------------------------------------------------------------------
+
+
+class _Column:
+    """Streamlit ``st.columns(...)`` element with a ``with`` context."""
+
+    def __init__(self, recorder, idx):
+        self._recorder = recorder
+        self._idx = idx
+
+    def __enter__(self):
+        self._recorder.current_column = self._idx
+        return self
+
+    def __exit__(self, exc_type, exc_val, tb):
+        self._recorder.current_column = None
+        return False
+
+
+class _Container:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, tb):
+        return False
+
+
+class _RecordingStreamlit:
+    """A minimal stand-in for the ``streamlit`` module for KPI-row rendering.
+
+    Records every ``_kpi_card(...)`` invocation by intercepting the
+    streamlit primitives it calls — ``container`` (for the bordered
+    box), ``markdown`` (for the label + value), and ``caption`` (for
+    the help text).
+    """
+
+    def __init__(self):
+        self.session_state: dict = {}
+        self.current_column: int | None = None
+        # Per-column markdown / caption text, in the order each was called.
+        self.markdown_calls: list[tuple[int | None, str]] = []
+        self.caption_calls: list[tuple[int | None, str]] = []
+        self.divider_count = 0
+
+    def container(self, *_a, **_kw):
+        return _Container(self)
+
+    def columns(self, n, **_kw):
+        if isinstance(n, list):
+            return [_Column(self, i) for i in range(len(n))]
+        return [_Column(self, i) for i in range(int(n))]
+
+    def markdown(self, body, **_kwargs):
+        self.markdown_calls.append((self.current_column, str(body)))
+
+    def caption(self, body, **_kwargs):
+        self.caption_calls.append((self.current_column, str(body)))
+
+    def divider(self):
+        self.divider_count += 1
+
+    # Surface stubs — the test never asserts on these but the
+    # production code calls into them.
+    def plotly_chart(self, *_a, **_kw):
+        pass
+
+    def dataframe(self, *_a, **_kw):
+        pass
+
+    def info(self, *_a, **_kw):
+        pass
+
+    def subheader(self, *_a, **_kw):
+        pass
+
+    def write(self, *_a, **_kw):
+        pass
+
+    def expander(self, *_a, **_kw):
+        return _Container(self)
+
+    def button(self, *_a, **_kw):
+        return False
+
+    def success(self, *_a, **_kw):
+        pass
+
+    def error(self, *_a, **_kw):
+        pass
+
+    def text_input(self, _label, value="", **_kw):
+        return value
+
+    def multiselect(self, _label, options, default=None, **_kw):
+        return list(default) if default else list(options)
+
+    def download_button(self, *_a, **_kw):
+        return False
+
+    def code(self, *_a, **_kw):
+        pass
+
+    def page_link(self, *_a, **_kw):
+        pass
+
+    def rerun(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _read_metrics stub — production code unpacks a 6-tuple
+# ---------------------------------------------------------------------------
+
+
+def _stub_read_metrics(days=30):  # noqa: ARG001 — production code calls with kw
+    _ = days
+    Row = SimpleNamespace
+    rows = [
+        Row(
+            d=dt.date.today().strftime("%Y-%m-%d"),
+            questions=2,
+            charts=1,
+            summaries=1,
+            sql=2,
+            errors=3,
+        ),
+    ]
+    result_rows = [Row(d=rows[0].d, questions=2, results=2)]
+    overall_stats = {"avg": 0.0, "min": 0.0, "max": 0.0, "stddev": 0.0, "median": 0.0, "n": 0}
+    perf_types = {
+        "sql": overall_stats,
+        "summary": overall_stats,
+        "chart": overall_stats,
+        "dataframe": overall_stats,
+    }
+    return (5, 2, rows, result_rows, overall_stats, perf_types)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOverviewErrorKpiLabels:
+    """The label rename — old labels are gone, new labels are present."""
+
+    def _render(self, monkeypatch, *, aggregates_critical=4):
+        from views import admin_analytics, errors
+
+        rec = _RecordingStreamlit()
+        monkeypatch.setattr(admin_analytics, "st", rec)
+        monkeypatch.setattr(errors, "st", rec)
+        monkeypatch.setattr(admin_analytics, "_read_metrics", _stub_read_metrics)
+        # Strip the @st.cache_data wrapper from _load_aggregates so the
+        # function-level patch on query_aggregates flows through.
+        agg_dict = {
+            "total": 47,
+            "critical": aggregates_critical,
+            "sql_errors": 8,
+            "retry_success_rate": 75.0,
+            "over_time_by_category": [],
+            "by_category": {},
+            "by_severity": [],
+        }
+
+        def _fake_load_aggregates(days):
+            return agg_dict
+
+        monkeypatch.setattr(errors, "_load_aggregates", _fake_load_aggregates)
+
+        with patch("orm.logging_functions.get_llm_stats", return_value={"total": 10, "avg_latency_ms": 250.0}):
+            with patch("orm.logging_functions.get_activity_stats", return_value={"logins_today": 3}):
+                # _render_overview_tab does substantial DB work AFTER the
+                # KPI row (latency distribution + question audit preview).
+                # We only care about the KPI markdown calls; suppress
+                # downstream DB failures so the assertion can run.
+                try:
+                    admin_analytics._render_overview_tab(30)
+                except Exception:
+                    pass
+        return rec
+
+    def test_chat_errors_label_present(self, monkeypatch):
+        rec = self._render(monkeypatch)
+        labels = [text for (_, text) in rec.markdown_calls]
+        # Bold KPI label markup is `**<label>**`
+        assert any("**Chat Errors**" == t for t in labels), (
+            f"Expected exactly '**Chat Errors**' KPI label among markdown calls: {labels}"
+        )
+
+    def test_old_errors_label_absent(self, monkeypatch):
+        rec = self._render(monkeypatch)
+        labels = [text for (_, text) in rec.markdown_calls]
+        # The exact-match old label is gone (matches "**Errors**" but not "**Chat Errors**").
+        assert not any(t == "**Errors**" for t in labels), (
+            f"Old label '**Errors**' should be retired but appears in markdown calls: {labels}"
+        )
+
+    def test_critical_system_errors_label_present(self, monkeypatch):
+        rec = self._render(monkeypatch)
+        labels = [text for (_, text) in rec.markdown_calls]
+        assert any("**Critical System Errors**" == t for t in labels), (
+            f"Expected exactly '**Critical System Errors**' label: {labels}"
+        )
+
+    def test_old_critical_errors_label_absent(self, monkeypatch):
+        rec = self._render(monkeypatch)
+        labels = [text for (_, text) in rec.markdown_calls]
+        assert not any(t == "**Critical Errors**" for t in labels), (
+            f"Old label '**Critical Errors**' should be retired: {labels}"
+        )
+
+
+class TestCriticalSystemErrorsValue:
+    """Counter rewire — value comes from _load_aggregates['critical']."""
+
+    def test_critical_system_errors_value_matches_aggregates(self, monkeypatch):
+        from views import admin_analytics, errors
+
+        rec = _RecordingStreamlit()
+        monkeypatch.setattr(admin_analytics, "st", rec)
+        monkeypatch.setattr(errors, "st", rec)
+        monkeypatch.setattr(admin_analytics, "_read_metrics", _stub_read_metrics)
+
+        # The seeded aggregates result — critical=12 should bubble through.
+        monkeypatch.setattr(
+            errors,
+            "_load_aggregates",
+            lambda days: {
+                "total": 47,
+                "critical": 12,
+                "sql_errors": 8,
+                "retry_success_rate": 75.0,
+                "over_time_by_category": [],
+                "by_category": {},
+                "by_severity": [],
+            },
+        )
+
+        with patch("orm.logging_functions.get_llm_stats", return_value={"total": 10, "avg_latency_ms": 250.0}):
+            with patch("orm.logging_functions.get_activity_stats", return_value={"logins_today": 3}):
+                try:
+                    admin_analytics._render_overview_tab(30)
+                except Exception:
+                    pass
+
+        # Find the markdown call for the value rendered immediately after
+        # the "**Critical System Errors**" label.
+        idxs = [i for i, (_, t) in enumerate(rec.markdown_calls) if t == "**Critical System Errors**"]
+        assert idxs, "Critical System Errors label was not rendered"
+        value_text = rec.markdown_calls[idxs[0] + 1][1]
+        # _kpi_card renders the value as: <h3 style='margin-top:0'>12</h3>
+        assert ">12<" in value_text, f"Expected critical=12 in value markup, got: {value_text}"
+
+
+class TestCriticalSystemErrorsIndependentOfGetErrorStats:
+    """If something still imported get_error_stats and returned a wildly
+    different number, the KPI must NOT pick it up. The rewire severs the
+    coupling — get_error_stats is gone, but if someone re-adds it, this
+    test catches the leak.
+    """
+
+    def test_kpi_ignores_get_error_stats_returns(self, monkeypatch):
+        from views import admin_analytics, errors
+
+        rec = _RecordingStreamlit()
+        monkeypatch.setattr(admin_analytics, "st", rec)
+        monkeypatch.setattr(errors, "st", rec)
+        monkeypatch.setattr(admin_analytics, "_read_metrics", _stub_read_metrics)
+        monkeypatch.setattr(
+            errors,
+            "_load_aggregates",
+            lambda days: {
+                "total": 1,
+                "critical": 7,
+                "sql_errors": 0,
+                "retry_success_rate": 0.0,
+                "over_time_by_category": [],
+                "by_category": {},
+                "by_severity": [],
+            },
+        )
+
+        # If a stray get_error_stats exists, mock it to a clearly distinct value.
+        with patch("orm.logging_functions.get_llm_stats", return_value={"total": 0, "avg_latency_ms": 0.0}):
+            with patch("orm.logging_functions.get_activity_stats", return_value={"logins_today": 0}):
+                # get_error_stats is no longer imported by admin_analytics, but
+                # we add the patch to confirm the KPI doesn't read from it.
+                if hasattr(
+                    importlib.import_module("orm.logging_functions"),
+                    "get_error_stats",
+                ):
+                    with patch(
+                        "orm.logging_functions.get_error_stats",
+                        return_value={
+                            "total": 99999,
+                            "critical": 99999,
+                            "sql_errors": 99999,
+                            "retry_success_rate": 0.0,
+                        },
+                    ):
+                        try:
+                            admin_analytics._render_overview_tab(30)
+                        except Exception:
+                            pass
+                else:
+                    try:
+                        admin_analytics._render_overview_tab(30)
+                    except Exception:
+                        pass
+
+        idxs = [i for i, (_, t) in enumerate(rec.markdown_calls) if t == "**Critical System Errors**"]
+        assert idxs, "Critical System Errors label was not rendered"
+        value_text = rec.markdown_calls[idxs[0] + 1][1]
+        assert ">7<" in value_text, (
+            f"KPI should reflect _load_aggregates['critical']=7, not get_error_stats; got: {value_text}"
+        )
+
+
+class TestGetErrorStatsRetired:
+    """The legacy ErrorLog-only counter no longer powers any production
+    code path. Per the spec, since no tests pin it and no production code
+    references it, it is deleted from orm/logging_functions.py."""
+
+    def test_get_error_stats_no_longer_exported(self):
+        import orm.logging_functions as lf
+
+        # The function is deleted entirely.
+        assert not hasattr(lf, "get_error_stats"), (
+            "get_error_stats should be deleted from orm.logging_functions "
+            "after Feature Spec #162 retires the legacy ErrorLog-only counter."
+        )
+
+    def test_get_error_stats_not_referenced_by_admin_analytics(self):
+        import inspect
+
+        from views import admin_analytics
+
+        src = inspect.getsource(admin_analytics)
+        assert "get_error_stats" not in src, (
+            "views.admin_analytics must not reference get_error_stats — "
+            "the Critical System Errors KPI routes via _load_aggregates instead."
+        )
+
+
+class TestSharedCacheAcrossOverviewAndErrorsTab:
+    """Cross-surface invariant: rendering both surfaces in one session
+    only calls ``query_aggregates`` once per ``days_int``.
+
+    This is the load-bearing contract that the Overview KPI and the
+    Errors-tab Critical card always agree under the same time range.
+    """
+
+    def test_overview_imports_shared_load_aggregates(self):
+        """Overview must reach Ledger B via the shared cache (the same
+        ``_load_aggregates`` the Errors tab uses) — not via a sibling
+        loader. The structural defense for cross-surface agreement.
+        """
+        import inspect
+
+        from views import admin_analytics
+
+        src = inspect.getsource(admin_analytics._render_overview_tab)
+        assert "from views.errors import _load_aggregates" in src, (
+            "Overview must import _load_aggregates from views.errors so the "
+            "Critical System Errors KPI shares the cache with the Errors tab. "
+            "See views/admin_analytics.py:1347 for precedent."
+        )
+
+    def test_query_aggregates_called_once_per_days_int(self, monkeypatch):
+        """Two consecutive calls to ``_load_aggregates(30)`` (one from
+        each surface in production) result in exactly one call to the
+        underlying ``query_aggregates`` — the second call hits the
+        ``@st.cache_data`` store. This is the shared-cache contract.
+        """
+        from views import errors
+
+        # Spy on the underlying query_aggregates call.
+        from orm.error_read_model import ErrorAggregates
+
+        fake_agg = ErrorAggregates(
+            total=10,
+            critical=2,
+            sql_errors=1,
+            retry_attempted=0,
+            retry_successful=0,
+            retry_success_rate=0.0,
+            over_time_by_category=[],
+            by_category={},
+            by_severity=[],
+        )
+        call_counter = MagicMock(return_value=fake_agg)
+        monkeypatch.setattr(errors, "query_aggregates", call_counter)
+
+        # Clear any pre-existing cache so the baseline is deterministic.
+        errors._load_aggregates.clear()
+
+        # Simulate the two surfaces (Overview + Errors tab) loading
+        # aggregates under the same days_int. The Streamlit cache is
+        # process-wide and persists across module imports.
+        first = errors._load_aggregates(30)
+        second = errors._load_aggregates(30)
+
+        assert first == second
+        assert call_counter.call_count == 1, (
+            f"Expected query_aggregates to be called exactly once for "
+            f"days_int=30 across both surfaces (shared cache); got "
+            f"{call_counter.call_count} calls. Shared-cache contract is broken."
+        )
+
+        errors._load_aggregates.clear()
+
+
+class TestModuleDocstringTwoLedgerContract:
+    """Both module docstrings must declare the two-ledger contract."""
+
+    @pytest.mark.parametrize(
+        "module_name",
+        ["views.admin_analytics", "views.errors"],
+    )
+    def test_module_docstring_documents_two_ledger_contract(self, module_name):
+        mod = importlib.import_module(module_name)
+        doc = mod.__doc__ or ""
+        assert "Ledger A" in doc, f"{module_name} must document Ledger A (chat-flow errors)."
+        assert "Ledger B" in doc, f"{module_name} must document Ledger B (system errors)."

--- a/tests/views/test_errors_sources_equation.py
+++ b/tests/views/test_errors_sources_equation.py
@@ -1,0 +1,273 @@
+"""Tests for the Sources-row additivity equation on the Errors tab
+(Epic #161, Feature Spec #163).
+
+The equation renders immediately below the three Source KPI cards as::
+
+    Total: X = Error Log (A) + Agent Runs (B) + Fallback File (C)
+
+When a Source chip is deselected, that source's term wraps in markdown
+strike-through (``~~term~~``) but Total is unchanged from the unfiltered
+cross-source sum. This preserves the invariant
+*Sources equation Total == Analytics row Total Errors KPI* — the
+load-bearing Epic-level guarantee.
+
+All assertions exercise the pure-format helper
+:func:`views.errors._sources_equation_markdown` so the tests run without
+a Streamlit script context.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from orm.error_read_model import ErrorSource
+from views.errors import _sources_equation_markdown
+
+
+# Convenience aliases for readability inside individual assertions.
+EL = ErrorSource.ERROR_LOG.value
+AR = ErrorSource.AGENT_RUN.value
+FS = ErrorSource.FALLBACK_SINK.value
+
+
+class TestEquationShape:
+    """The textual format itself."""
+
+    def test_all_selected_no_strikethrough(self):
+        md = _sources_equation_markdown(
+            {EL: 32, AR: 12, FS: 3},
+            [EL, AR, FS],
+        )
+        assert md == "Total: 47 = Error Log (32) + Agent Runs (12) + Fallback File (3)"
+        assert "~~" not in md
+
+    def test_order_is_error_log_then_agent_runs_then_fallback(self):
+        # Order is canonical regardless of how the selected list is sorted —
+        # matches the Source KPI card order at views/errors.py:200-221.
+        md = _sources_equation_markdown(
+            {FS: 1, AR: 2, EL: 4},
+            [FS, AR, EL],
+        )
+        assert md == "Total: 7 = Error Log (4) + Agent Runs (2) + Fallback File (1)"
+
+    def test_uses_summed_total_not_max(self):
+        md = _sources_equation_markdown(
+            {EL: 10, AR: 10, FS: 10},
+            [EL, AR, FS],
+        )
+        assert md.startswith("Total: 30 =")
+
+
+class TestStrikethroughOnDeselect:
+    """A deselected source strikes through its term; Total is unchanged."""
+
+    def test_single_source_deselected_only_that_term_struck(self):
+        md = _sources_equation_markdown(
+            {EL: 32, AR: 12, FS: 3},
+            [EL, AR],  # FS deselected
+        )
+        # Total still 47 (unfiltered)
+        assert "Total: 47" in md
+        # FS struck
+        assert "~~Fallback File (3)~~" in md
+        # Other terms NOT struck
+        assert "Error Log (32)" in md and "~~Error Log (32)~~" not in md
+        assert "Agent Runs (12)" in md and "~~Agent Runs (12)~~" not in md
+
+    def test_two_sources_deselected_both_struck(self):
+        md = _sources_equation_markdown(
+            {EL: 32, AR: 12, FS: 3},
+            [EL],  # AR + FS deselected
+        )
+        assert "Total: 47" in md
+        assert "~~Agent Runs (12)~~" in md
+        assert "~~Fallback File (3)~~" in md
+        assert "Error Log (32)" in md and "~~Error Log (32)~~" not in md
+
+    def test_all_three_deselected_all_struck_total_unchanged(self):
+        md = _sources_equation_markdown(
+            {EL: 32, AR: 12, FS: 3},
+            [],  # nothing selected
+        )
+        # Total stays at the unfiltered cross-source sum (load-bearing invariant).
+        assert "Total: 47" in md
+        assert "~~Error Log (32)~~" in md
+        assert "~~Agent Runs (12)~~" in md
+        assert "~~Fallback File (3)~~" in md
+
+
+class TestEdgeCases:
+    """Empty / missing / partial-failure paths."""
+
+    def test_empty_counts_renders_zeros(self):
+        md = _sources_equation_markdown({}, [EL, AR, FS])
+        assert md == "Total: 0 = Error Log (0) + Agent Runs (0) + Fallback File (0)"
+
+    def test_one_key_missing_treated_as_zero(self):
+        md = _sources_equation_markdown(
+            {EL: 5, FS: 2},  # AR missing
+            [EL, AR, FS],
+        )
+        assert "Total: 7" in md
+        assert "Agent Runs (0)" in md
+
+    def test_empty_counts_and_nothing_selected(self):
+        md = _sources_equation_markdown({}, [])
+        # All terms struck, Total still 0 (no raising).
+        assert "Total: 0" in md
+        assert "~~Error Log (0)~~" in md
+        assert "~~Agent Runs (0)~~" in md
+        assert "~~Fallback File (0)~~" in md
+
+    def test_unknown_keys_in_counts_are_ignored(self):
+        # A bogus source value (e.g. from a stale cache key) doesn't crash
+        # and isn't added to Total.
+        md = _sources_equation_markdown(
+            {EL: 5, AR: 3, FS: 2, "unknown_source": 99},
+            [EL, AR, FS],
+        )
+        assert "Total: 10" in md
+        assert "unknown_source" not in md
+
+
+class TestCardConsistencyInvariant:
+    """For each source, the equation term is struck through iff the
+    corresponding Source KPI card is dimmed (``dim=True``). Both
+    observe ``selected_source_values`` identically.
+    """
+
+    @pytest.mark.parametrize(
+        "src",
+        [EL, AR, FS],
+    )
+    def test_strikethrough_matches_card_dim(self, src):
+        counts = {EL: 10, AR: 20, FS: 30}
+        # Deselect ONLY this source.
+        selected = [s for s in (EL, AR, FS) if s != src]
+        md = _sources_equation_markdown(counts, selected)
+        # The Source KPI card for `src` would render with dim=True
+        # (label struck through) because `src not in selected`.
+        # The equation must also strike through this source's term.
+        label = {EL: "Error Log", AR: "Agent Runs", FS: "Fallback File"}[src]
+        n = counts[src]
+        assert f"~~{label} ({n})~~" in md
+        # The other two sources are selected → NOT struck through.
+        for other in (EL, AR, FS):
+            if other == src:
+                continue
+            other_label = {EL: "Error Log", AR: "Agent Runs", FS: "Fallback File"}[other]
+            other_n = counts[other]
+            assert f"{other_label} ({other_n})" in md
+            assert f"~~{other_label} ({other_n})~~" not in md
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface invariant: equation Total == Analytics row Total Errors KPI
+# ---------------------------------------------------------------------------
+
+
+class TestCrossSurfaceTotalInvariant:
+    """Under the same ``days_int``, the equation's Total equals
+    ``_load_aggregates(days_int)["total"]`` (the Analytics row's Total
+    Errors KPI). This is the structural reconciliation that Epic #161
+    is built to guarantee.
+    """
+
+    def test_equation_total_equals_aggregates_total(self, tmp_path, monkeypatch):
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import sessionmaker
+
+        from orm import error_read_model
+        from orm.models import Base, ErrorLog
+        from utils.error_fallback_sink import (
+            ErrorLoggingConfig,
+            _reset_handler_cache,
+        )
+        from views.errors_helpers import _query_filtered
+
+        _reset_handler_cache()
+
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+        monkeypatch.setattr(error_read_model, "SessionLocal", Session)
+
+        # Seed three ErrorLog rows of mixed severities so query_aggregates
+        # has a non-trivial Total.
+        with Session() as session:
+            for sev in ("warning", "error", "critical"):
+                session.add(
+                    ErrorLog(
+                        category="sql_execution",
+                        severity=sev,
+                        error_type="RuntimeError",
+                        error_message=f"{sev}-msg",
+                        created_at=dt.datetime.now() - dt.timedelta(hours=1),
+                    )
+                )
+            session.commit()
+
+        cfg = ErrorLoggingConfig(
+            fallback_path=tmp_path / "x.jsonl",
+            fallback_max_bytes=5_000_000,
+            fallback_backup_count=5,
+        )
+
+        # Counts as the view sees them (unfiltered across sources).
+        _, counts = _query_filtered(
+            days=7,
+            sources_csv="",  # all three
+            categories_csv="",
+            severities_csv="",
+            search="",
+            user_id_text="",
+            fallback_config=cfg,
+        )
+
+        # Aggregates as the Analytics row sees them.
+        agg = error_read_model.query_aggregates(
+            dt.datetime.now() - dt.timedelta(days=7),
+            fallback_config=cfg,
+        )
+
+        # The equation's Total under any selected-source state equals
+        # the unfiltered cross-source sum, which by construction equals
+        # aggregates.total.
+        equation_md = _sources_equation_markdown(counts, [EL, AR, FS])
+        assert f"Total: {agg.total}" in equation_md, (
+            f"Equation Total must equal aggregates.total ({agg.total}); got equation: {equation_md!r}"
+        )
+
+        # And it stays equal even when a source is deselected
+        # (filter state is signaled via strike-through, not by recalculating).
+        equation_md_partial = _sources_equation_markdown(counts, [EL])
+        assert f"Total: {agg.total}" in equation_md_partial, (
+            "Equation Total must remain at the unfiltered sum even when "
+            "Source chips are deselected — otherwise Sources Total drifts "
+            "from Analytics Total, the exact drift Epic #161 prevents."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring — the wrapper hands the equation to st.markdown
+# ---------------------------------------------------------------------------
+
+
+class TestRenderWrapperDelegates:
+    """The thin Streamlit wrapper renders the pure-format string."""
+
+    def test_render_sources_equation_calls_st_markdown(self, monkeypatch):
+        from views import errors
+
+        markdown_calls: list[str] = []
+
+        class _StubSt:
+            def markdown(self, body, **_kw):
+                markdown_calls.append(str(body))
+
+        monkeypatch.setattr(errors, "st", _StubSt())
+
+        errors._render_sources_equation({EL: 1, AR: 2, FS: 3}, [EL, AR, FS])
+        assert markdown_calls == ["Total: 6 = Error Log (1) + Agent Runs (2) + Fallback File (3)"]

--- a/tests/views/test_errors_subset_kpi.py
+++ b/tests/views/test_errors_subset_kpi.py
@@ -1,0 +1,296 @@
+"""Tests for the Total-vs-subset visual treatment in the Errors-tab
+Analytics KPI row (Epic #161, Feature Spec #164).
+
+The four-card row renders as:
+
+- Total Errors    — primary (existing _kpi_card; additive style).
+- Critical        — subset (new _render_subset_kpi_card; "of N (Z.Z%)").
+- SQL Errors      — subset (new _render_subset_kpi_card; "of N (Z.Z%)").
+- Retry Success%  — rate (existing _kpi_card with % suffix).
+
+The subset cards textually signal that their counts are *slices* of
+Total, not addends. The Analytics caption adds explicit prose that the
+two subsets may overlap each other (a critical SQL-generation error
+counts toward both).
+
+All assertions exercise the pure-format helper
+:func:`views.errors._subset_kpi_caption_text` so the tests run without
+a Streamlit script context.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from views.errors import _subset_kpi_caption_text
+
+
+# ---------------------------------------------------------------------------
+# Pure-format helper — caption text
+# ---------------------------------------------------------------------------
+
+
+class TestSubsetCaptionShape:
+    """``_subset_kpi_caption_text(count, total)`` returns the denominator
+    text only — the count itself is rendered as the primary value by
+    the wrapper.
+    """
+
+    def test_basic_subset_denominator(self):
+        assert _subset_kpi_caption_text(5, 47) == "of 47 (10.6%)"
+
+    def test_zero_count_renders_zero_percent(self):
+        assert _subset_kpi_caption_text(0, 47) == "of 47 (0.0%)"
+
+    def test_count_equals_total_renders_100_percent(self):
+        assert _subset_kpi_caption_text(47, 47) == "of 47 (100.0%)"
+
+    def test_zero_total_omits_percentage_no_divide_by_zero(self):
+        # Empty time range — render "of 0" without a % suffix and
+        # without raising.
+        assert _subset_kpi_caption_text(0, 0) == "of 0"
+
+    def test_one_of_three_renders_33_3_percent(self):
+        # round(100/3, 1) == 33.3
+        assert _subset_kpi_caption_text(1, 3) == "of 3 (33.3%)"
+
+    def test_two_of_three_renders_66_7_percent(self):
+        # round(200/3, 1) == 66.7
+        assert _subset_kpi_caption_text(2, 3) == "of 3 (66.7%)"
+
+    def test_large_total_one_decimal_precision(self):
+        # 123 / 10000 = 0.0123 → 1.23% → rounded to 1.2%
+        assert _subset_kpi_caption_text(123, 10000) == "of 10000 (1.2%)"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper — _render_subset_kpi_card delegates correctly
+# ---------------------------------------------------------------------------
+
+
+class _Container:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _RecorderSt:
+    def __init__(self):
+        self.markdown_calls: list[str] = []
+        self.caption_calls: list[str] = []
+
+    def container(self, *_a, **_kw):
+        return _Container()
+
+    def markdown(self, body, **_kw):
+        self.markdown_calls.append(str(body))
+
+    def caption(self, body, **_kw):
+        self.caption_calls.append(str(body))
+
+
+class TestRenderSubsetKpiCardWrapper:
+    def test_renders_label_value_and_denominator(self, monkeypatch):
+        from views import errors
+
+        rec = _RecorderSt()
+        monkeypatch.setattr(errors, "st", rec)
+
+        errors._render_subset_kpi_card("Critical", 5, 47, help_text="Severity = critical")
+
+        # Label and value rendered via markdown.
+        assert "**Critical**" in rec.markdown_calls
+        assert any(">5<" in m for m in rec.markdown_calls), (
+            f"Expected the count 5 to appear as a <h3> value; got: {rec.markdown_calls}"
+        )
+
+        # Caption carries the denominator + help_text.
+        assert "of 47 (10.6%)" in rec.caption_calls
+        assert "Severity = critical" in rec.caption_calls
+
+    def test_zero_total_caption_omits_percentage(self, monkeypatch):
+        from views import errors
+
+        rec = _RecorderSt()
+        monkeypatch.setattr(errors, "st", rec)
+
+        errors._render_subset_kpi_card("Critical", 0, 0)
+        assert "of 0" in rec.caption_calls
+        # No percentage rendered for total=0.
+        assert not any("%" in c for c in rec.caption_calls), (
+            f"Caption must not include a percentage when total=0; got: {rec.caption_calls}"
+        )
+
+    def test_help_text_optional(self, monkeypatch):
+        from views import errors
+
+        rec = _RecorderSt()
+        monkeypatch.setattr(errors, "st", rec)
+
+        errors._render_subset_kpi_card("SQL Errors", 8, 47)
+        # Denominator caption is present; no extra caption beyond it.
+        assert rec.caption_calls == ["of 47 (17.0%)"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — helper-invocation spying in views.errors.render(...)
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyticsRowDelegatesToCorrectHelpers:
+    """Inside the Analytics row, Total Errors and Retry Success continue
+    to render via the existing ``_kpi_card`` (additive / rate style);
+    Critical and SQL Errors render via the new ``_render_subset_kpi_card``
+    (subset style). Verified by patching both helpers and asserting their
+    call signatures.
+    """
+
+    def _render_with_spies(self, monkeypatch, *, total=47, critical=5, sql_errors=8):
+        """Run views.errors.render with helpers patched; return the call lists."""
+        from views import errors
+
+        # Stub Streamlit primitives the render path touches so it
+        # completes without a Streamlit runtime.
+        from tests.views.test_admin_overview_error_kpis import _RecordingStreamlit
+
+        rec = _RecordingStreamlit()
+        monkeypatch.setattr(errors, "st", rec)
+
+        # Bypass the @st.cache_data layer by patching _load_aggregates
+        # directly. _load is also cached — patch it to return empty.
+        monkeypatch.setattr(
+            errors,
+            "_load_aggregates",
+            lambda days: {
+                "total": total,
+                "critical": critical,
+                "sql_errors": sql_errors,
+                "retry_success_rate": 75.0,
+                "over_time_by_category": [],
+                "by_category": {},
+                "by_severity": [],
+            },
+        )
+        monkeypatch.setattr(errors, "_load", lambda *_a, **_kw: ([], {}))
+
+        with patch.object(errors, "_kpi_card") as kpi_mock:
+            with patch.object(errors, "_render_subset_kpi_card") as subset_mock:
+                # Disable the equation render so we don't get extra calls
+                # tangled with the assertion — it's tested in #163.
+                with patch.object(errors, "_render_sources_equation"):
+                    try:
+                        errors.render(30)
+                    except Exception:
+                        # render() does substantial downstream work after
+                        # the KPI row (charts, expanders, etc); we only
+                        # need the helper-invocation calls to be recorded.
+                        pass
+        return kpi_mock, subset_mock
+
+    def test_total_errors_uses_kpi_card(self, monkeypatch):
+        kpi_mock, _ = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in kpi_mock.call_args_list if call.args]
+        assert "Total Errors" in labels, (
+            f"Total Errors must continue to render via _kpi_card (additive style); _kpi_card was called for: {labels}"
+        )
+
+    def test_retry_success_uses_kpi_card(self, monkeypatch):
+        kpi_mock, _ = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in kpi_mock.call_args_list if call.args]
+        assert "Retry Success" in labels, (
+            f"Retry Success must continue to render via _kpi_card (rate style); got: {labels}"
+        )
+
+    def test_critical_uses_subset_kpi_card(self, monkeypatch):
+        _, subset_mock = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in subset_mock.call_args_list if call.args]
+        assert "Critical" in labels, f"Critical must render via _render_subset_kpi_card (subset style); got: {labels}"
+
+    def test_sql_errors_uses_subset_kpi_card(self, monkeypatch):
+        _, subset_mock = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in subset_mock.call_args_list if call.args]
+        assert "SQL Errors" in labels, (
+            f"SQL Errors must render via _render_subset_kpi_card (subset style); got: {labels}"
+        )
+
+    def test_critical_not_rendered_via_kpi_card(self, monkeypatch):
+        """The Critical card must NOT also be sent through _kpi_card —
+        the subset visual treatment is the structural differentiator."""
+        kpi_mock, _ = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in kpi_mock.call_args_list if call.args]
+        assert "Critical" not in labels, f"Critical must NOT render via _kpi_card after #164; got: {labels}"
+
+    def test_sql_errors_not_rendered_via_kpi_card(self, monkeypatch):
+        kpi_mock, _ = self._render_with_spies(monkeypatch)
+        labels = [call.args[0] for call in kpi_mock.call_args_list if call.args]
+        assert "SQL Errors" not in labels, f"SQL Errors must NOT render via _kpi_card after #164; got: {labels}"
+
+    def test_subset_helper_receives_count_and_total(self, monkeypatch):
+        """The subset helper gets (count, total) so the denominator
+        renders correctly."""
+        _, subset_mock = self._render_with_spies(monkeypatch, total=47, critical=5, sql_errors=8)
+        # Build a map of label → (count, total) from the recorded calls.
+        rendered = {}
+        for call in subset_mock.call_args_list:
+            args = call.args
+            # Signature: _render_subset_kpi_card(label, count, total, help_text=...)
+            if len(args) >= 3:
+                rendered[args[0]] = (args[1], args[2])
+        assert rendered.get("Critical") == (5, 47), (
+            f"Critical must get (count=5, total=47); got: {rendered.get('Critical')}"
+        )
+        assert rendered.get("SQL Errors") == (8, 47), (
+            f"SQL Errors must get (count=8, total=47); got: {rendered.get('SQL Errors')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Caption disambiguation — admins are told the subsets may overlap
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyticsCaptionDisambiguation:
+    """The Analytics block caption explicitly states that Critical and
+    SQL Errors are subsets that may overlap each other. Without this,
+    admins eventually try to partition Total and get confused.
+    """
+
+    def test_caption_explains_subset_relationship(self, monkeypatch):
+        from views import errors
+
+        from tests.views.test_admin_overview_error_kpis import _RecordingStreamlit
+
+        rec = _RecordingStreamlit()
+        monkeypatch.setattr(errors, "st", rec)
+        monkeypatch.setattr(
+            errors,
+            "_load_aggregates",
+            lambda days: {
+                "total": 0,
+                "critical": 0,
+                "sql_errors": 0,
+                "retry_success_rate": 0.0,
+                "over_time_by_category": [],
+                "by_category": {},
+                "by_severity": [],
+            },
+        )
+        monkeypatch.setattr(errors, "_load", lambda *_a, **_kw: ([], {}))
+        try:
+            errors.render(30)
+        except Exception:
+            pass
+
+        captions = [body for (_, body) in rec.caption_calls]
+        # The Analytics caption must declare the subsets-of-Total relationship.
+        assert any("subsets of Total Errors" in c for c in captions), (
+            f"Analytics caption must declare that Critical and SQL Errors are "
+            f"subsets of Total Errors. Captions found: {captions}"
+        )
+        # And that the two subsets may overlap each other.
+        assert any("overlap" in c.lower() for c in captions), (
+            f"Analytics caption must explain the overlap (a critical "
+            f"SQL-generation error counts toward both). Captions: {captions}"
+        )

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -1,3 +1,26 @@
+"""Admin Analytics tabbed surface.
+
+Two-ledger error-count contract (Epic #161):
+
+  - **Ledger A — Chat-flow errors.** Counted from ``Message`` rows where
+    ``Message.type == ERROR``. Consumed by the Admin Overview "Chat Errors"
+    KPI (rendered in :func:`_render_overview_tab`). Surfaces the errors
+    that interrupted a chat turn.
+
+  - **Ledger B — System errors.** The 3-source union (``thrive_error_log``
+    + agent-run failures + JSONL fallback file) rolled up by
+    :func:`orm.error_read_model.query_aggregates` and cached via
+    :func:`views.errors._load_aggregates`. Consumed by the Errors tab and
+    by the Admin Overview "Critical System Errors" KPI. The Overview KPI
+    shares the ``_load_aggregates`` cache so it always equals the Errors
+    tab's Critical card under the same ``days_int``.
+
+New error-count surfaces MUST declare which ledger they consume and route
+through the corresponding loader. Do not introduce a third ad-hoc counter
+without updating this contract — that is the drift Epic #161 exists to
+prevent.
+"""
+
 import datetime as dt
 import json
 
@@ -179,7 +202,8 @@ def _to_dense_days(rows, days: int):
 
 def _render_overview_tab(days_int: int):
     """Render the Overview tab (existing content + new KPIs)."""
-    from orm.logging_functions import get_activity_stats, get_error_stats, get_llm_stats
+    from orm.logging_functions import get_activity_stats, get_llm_stats
+    from views.errors import _load_aggregates as _errors_load_aggregates
 
     (
         users_count,
@@ -193,7 +217,12 @@ def _render_overview_tab(days_int: int):
     # Get stats from new logging tables
     llm_stats = get_llm_stats(days=days_int)
     activity_stats = get_activity_stats(days=days_int)
-    error_stats = get_error_stats(days=days_int)
+    # Ledger B (System errors) — shared cache with the Errors tab.
+    # Importing _load_aggregates here mirrors the precedent at the global
+    # Refresh Data button below and guarantees Overview's "Critical System
+    # Errors" KPI always equals the Errors tab's Critical card under the
+    # same days_int (Epic #161).
+    error_aggregates = _errors_load_aggregates(days_int)
 
     # KPIs row - original + new
     k1, k2, k3, k4, k5, k6, k7, k8 = st.columns(8)
@@ -203,7 +232,11 @@ def _render_overview_tab(days_int: int):
     with k2:
         _kpi_card("Questions", int(df["questions"].sum()))
     with k3:
-        _kpi_card("Errors", int(df["errors"].sum()))
+        _kpi_card(
+            "Chat Errors",
+            int(df["errors"].sum()),
+            help_text=("Chat-flow errors (Message.type=ERROR). Distinct from the Errors tab's System Errors ledger."),
+        )
     with k4:
         _kpi_card("Active Users", active_users)
     with k5:
@@ -213,7 +246,14 @@ def _render_overview_tab(days_int: int):
     with k7:
         _kpi_card("Logins Today", activity_stats["logins_today"])
     with k8:
-        _kpi_card("Critical Errors", error_stats["critical"], "Requires attention")
+        _kpi_card(
+            "Critical System Errors",
+            error_aggregates["critical"],
+            help_text=(
+                "Severity=critical across ErrorLog + Agent Runs + Fallback "
+                "File. Matches the Errors tab's Critical card."
+            ),
+        )
 
     st.divider()
 

--- a/views/errors.py
+++ b/views/errors.py
@@ -10,6 +10,22 @@ Consumes :func:`orm.error_read_model.query_errors` and
 :func:`orm.error_read_model.count_errors_by_source` plus
 :func:`orm.error_read_model.query_aggregates` for the KPI / chart block,
 along with the pure helpers in :mod:`views.errors_helpers`.
+
+Two-ledger error-count contract (Epic #161):
+
+  - **Ledger A — Chat-flow errors.** ``Message`` rows where
+    ``Message.type == ERROR``. Consumed by the Admin Overview "Chat
+    Errors" KPI (see :mod:`views.admin_analytics`). Not consumed here.
+
+  - **Ledger B — System errors.** The 3-source union (``thrive_error_log``
+    + agent-run failures + JSONL fallback file) rolled up by
+    :func:`orm.error_read_model.query_aggregates`. THIS module's canonical
+    loader is :func:`_load_aggregates`, which Admin Overview's "Critical
+    System Errors" KPI also imports (shared cache). Every KPI rendered
+    in this module belongs to Ledger B.
+
+New error-count surfaces MUST declare which ledger they consume and
+route through the corresponding loader.
 """
 
 from __future__ import annotations

--- a/views/errors.py
+++ b/views/errors.py
@@ -100,6 +100,69 @@ def _kpi_card(
             st.caption(help_text)
 
 
+# Canonical display labels for the Sources-row additivity equation.
+# Order matches the three Source KPI cards rendered below.
+_SOURCE_DISPLAY_LABELS: tuple[tuple[str, str], ...] = (
+    (ErrorSource.ERROR_LOG.value, "Error Log"),
+    (ErrorSource.AGENT_RUN.value, "Agent Runs"),
+    (ErrorSource.FALLBACK_SINK.value, "Fallback File"),
+)
+
+
+def _sources_equation_markdown(
+    counts: dict[str, int],
+    selected_source_values: list[str],
+) -> str:
+    """Compose the Sources-row additivity equation as a markdown string.
+
+    Pure-format helper (no Streamlit) so unit tests can assert on the
+    output without a Streamlit script context. The thin wrapper
+    :func:`_render_sources_equation` calls ``st.markdown`` with the
+    return value.
+
+    The equation renders as::
+
+        Total: 47 = Error Log (32) + Agent Runs (12) + Fallback File (3)
+
+    Filter state is signaled by striking through any deselected term
+    (markdown ``~~term~~``) while the Total remains the unfiltered
+    cross-source sum. This preserves the Epic #161 invariant:
+    *Sources equation Total == Analytics Total Errors* regardless of
+    Source chip state. Recalculating Total based on selection would
+    reintroduce the exact drift this Epic is built to fix.
+
+    Edge cases:
+
+    - Missing keys in ``counts`` default to 0 via ``dict.get``.
+    - Empty ``selected_source_values`` renders all three terms struck
+      through; Total still shows the unfiltered sum.
+    """
+    selected = set(selected_source_values or [])
+    terms: list[str] = []
+    total = 0
+    for src_value, display_label in _SOURCE_DISPLAY_LABELS:
+        n = counts.get(src_value, 0)
+        total += n
+        term = f"{display_label} ({n})"
+        if src_value not in selected:
+            term = f"~~{term}~~"
+        terms.append(term)
+    return f"Total: {total} = " + " + ".join(terms)
+
+
+def _render_sources_equation(
+    counts: dict[str, int],
+    selected_source_values: list[str],
+) -> None:
+    """Render the Sources-row additivity equation under the 3 Source KPIs.
+
+    Thin wrapper around the pure-format helper
+    :func:`_sources_equation_markdown` so unit tests can assert on the
+    rendered markdown string without a Streamlit script context.
+    """
+    st.markdown(_sources_equation_markdown(counts, selected_source_values))
+
+
 @st.cache_data(ttl=ERRORS_CACHE_TTL_SECONDS, show_spinner="Loading errors...")
 def _load(
     days: int,
@@ -235,6 +298,13 @@ def render(days_int: int) -> None:
             help_text=kpi_help_text,
             dim=ErrorSource.FALLBACK_SINK.value not in selected_source_values,
         )
+
+    # Additivity equation — the structural reconciliation between the
+    # three Source KPI cards above and the Analytics-row Total Errors
+    # KPI below. Deselected sources are struck through; Total stays at
+    # the unfiltered cross-source sum so it always matches the Analytics
+    # Total under the same days_int (Epic #161).
+    _render_sources_equation(counts, selected_source_values)
 
     st.divider()
 

--- a/views/errors.py
+++ b/views/errors.py
@@ -163,6 +163,58 @@ def _render_sources_equation(
     st.markdown(_sources_equation_markdown(counts, selected_source_values))
 
 
+def _subset_kpi_caption_text(count: int, total: int) -> str:
+    """Compose the "of N (Z.Z%)" denominator caption for a subset KPI.
+
+    Pure-format helper (no Streamlit) so unit tests can assert on the
+    output without a Streamlit script context. The thin wrapper
+    :func:`_render_subset_kpi_card` calls ``st.caption`` with the
+    return value.
+
+    Behaviour:
+
+    - ``total == 0`` → ``"of 0"`` only (no ``%`` suffix, no
+      divide-by-zero). Empty time ranges render gracefully.
+    - ``total > 0`` → ``"of N (Z.Z%)"`` where percentage is
+      ``round(100 * count / total, 1)``.
+    - ``count == 0, total > 0`` → ``"0 of N (0.0%)"`` (via the count
+      surfaced separately as the primary value).
+    - ``count == total`` → ``"N of N (100.0%)"``.
+
+    The "of N" denominator carries the semantic weight that this is a
+    *slice* of Total, not an addend. The Analytics block caption adds
+    explicit prose disambiguation as a backup signal.
+    """
+    if total == 0:
+        return f"of {total}"
+    pct = round(100 * count / total, 1)
+    return f"of {total} ({pct}%)"
+
+
+def _render_subset_kpi_card(
+    label: str,
+    count: int,
+    total: int,
+    help_text: str | None = None,
+) -> None:
+    """Render a subset KPI card showing ``count`` plus an "of N" denominator.
+
+    Visually distinct from :func:`_kpi_card` (the primary / additive
+    style) by virtue of the explicit ``of N`` denominator below the
+    primary value — the textual signal that this card is a *slice* of
+    a parent Total, not an addend. Used in the Errors tab Analytics
+    row for the Critical and SQL Errors KPIs, both of which are subsets
+    of Total Errors and may overlap each other.
+    """
+    c = st.container(border=True)
+    with c:
+        st.markdown(f"**{label}**")
+        st.markdown(f"<h3 style='margin-top:0'>{count}</h3>", unsafe_allow_html=True)
+        st.caption(_subset_kpi_caption_text(count, total))
+        if help_text:
+            st.caption(help_text)
+
+
 @st.cache_data(ttl=ERRORS_CACHE_TTL_SECONDS, show_spinner="Loading errors...")
 def _load(
     days: int,
@@ -315,16 +367,28 @@ def render(days_int: int) -> None:
     st.subheader("Analytics")
     st.caption(
         "Time-range totals across all three sources. Not narrowed by the "
-        "Sources chip or the category / severity / user / search filters above."
+        "Sources chip or the category / severity / user / search filters above. "
+        "**Critical and SQL Errors are subsets of Total Errors and may overlap "
+        "each other** (a critical SQL-generation error counts toward both)."
     )
 
     a1, a2, a3, a4 = st.columns(4)
     with a1:
         _kpi_card("Total Errors", aggregates["total"])
     with a2:
-        _kpi_card("Critical", aggregates["critical"], help_text="Severity = critical")
+        _render_subset_kpi_card(
+            "Critical",
+            aggregates["critical"],
+            aggregates["total"],
+            help_text="Severity = critical",
+        )
     with a3:
-        _kpi_card("SQL Errors", aggregates["sql_errors"], help_text="Generation + Execution")
+        _render_subset_kpi_card(
+            "SQL Errors",
+            aggregates["sql_errors"],
+            aggregates["total"],
+            help_text="Categories: sql_generation + sql_execution",
+        )
     with a4:
         _kpi_card("Retry Success", f"{aggregates['retry_success_rate']}%")
 


### PR DESCRIPTION
Implements Epic #161 in one branch via three sequential commits — one per Feature Spec — so the reviewer can read the progression.

## Summary

This Epic resolves the long-standing confusion where multiple admin surfaces all said "Errors" or "Critical Errors" but counted different things and drifted out of agreement over time. The fix has three load-bearing pieces:

- **Two-ledger contract.** Module-level docstrings on `views/admin_analytics.py` and `views/errors.py` declare two ledgers: **Ledger A** (chat-flow errors via `Message.type=ERROR`) and **Ledger B** (system errors via the 3-source `query_aggregates` union). New error-count surfaces MUST declare which ledger they consume.
- **Shared cache.** Admin Overview's "Critical System Errors" KPI is rewired through the same `views.errors._load_aggregates` cached loader the Errors-tab Critical card uses — so under the same `days_int` they always agree.
- **Additive vs subset visual signal.** The Errors-tab Sources row gets an inline additivity equation (`Total: 47 = Error Log (32) + Agent Runs (12) + Fallback File (3)`) — Total stays at the unfiltered sum even when chips are deselected. The Analytics row's Critical / SQL Errors cards switch to a subset visual treatment with an "of N (Z.Z%)" denominator, and the caption explicitly tells admins the two subsets may overlap each other.

## Issues Resolved

Closes #162
Closes #163
Closes #164

References Epic #161.

## Changes Made

### Commit 1 — `feat(errors): rename + rewire Admin Overview KPIs to two-ledger model (#162)` (`8d8198f`)

- `views/admin_analytics.py`: Rename `Errors` → `Chat Errors` (counter unchanged — `Message.type=ERROR`). Rename `Critical Errors` → `Critical System Errors` and rewire it from the legacy ErrorLog-only `get_error_stats` to the 3-source `_load_aggregates`. Both KPIs gain `help_text` declaring their ledger. Add the two-ledger contract docstring at the top of the module.
- `views/errors.py`: Add the mirror two-ledger contract docstring.
- `orm/logging_functions.py`: Delete `get_error_stats` — no production call sites remain and no tests pin it.
- `tests/views/test_admin_overview_error_kpis.py` (new, 12 tests): label rename, value correctness against `_load_aggregates['critical']`, shared-cache contract (exactly one underlying `query_aggregates` call across both surfaces per `days_int`), counter independence from any re-added `get_error_stats`, two-ledger docstring assertions.

### Commit 2 — `feat(errors): additivity equation under Sources row (#163)` (`c1407d6`)

- `views/errors.py`: Pure-format helper `_sources_equation_markdown(counts, selected_source_values)` returning the rendered string (testable without a Streamlit script context), plus a thin `_render_sources_equation` wrapper. Wired in immediately after the three Source KPI cards.
- The equation's Total is the unfiltered cross-source sum and matches the Analytics row's Total Errors KPI under the same `days_int`. Deselecting a Source chip strikes through that term (`~~Error Log (32)~~`) but does NOT change Total. This is the load-bearing decision — recalculating Total based on the chip would reintroduce the exact drift this Epic exists to fix.
- `tests/views/test_errors_sources_equation.py` (new, 15 tests): shape / canonical order, strike-through on single / two / all-three deselect, edge cases (empty counts, missing keys, unknown keys), per-source card-consistency invariant, cross-surface Total invariant (real DB seed → `query_aggregates`), wrapper-delegates-to-`st.markdown` contract.

### Commit 3 — `feat(errors): subset visual treatment + overlap caption on Analytics row (#164)` (`a6fd960`)

- `views/errors.py`: Pure-format helper `_subset_kpi_caption_text(count, total)` returning the "of N (Z.Z%)" denominator (or "of 0" when total is zero — no divide-by-zero), plus thin Streamlit wrapper `_render_subset_kpi_card`. Two call-site swaps: Critical and SQL Errors in the Analytics row now use the subset helper. Total Errors and Retry Success% continue to use `_kpi_card`.
- Caption rewrite explicitly states Critical and SQL Errors are subsets of Total Errors AND may overlap each other (a critical SQL-generation error counts toward both). Proactively answers "why don't Critical + SQL Errors + other = Total?" before admins ask.
- `tests/views/test_errors_subset_kpi.py` (new, 18 tests): pure-format helper (basic / zero-count / count==total / zero-total / 33.3% / 66.7% / 1.2% rounding), wrapper delegation (label / value / denominator / help_text / no-percentage-when-total-zero), helper-invocation spying in `views.errors.render` (Total Errors + Retry Success → `_kpi_card`; Critical + SQL Errors → `_render_subset_kpi_card`; subset cards receive both `count` and `total`), caption disambiguation (mentions "subsets of Total Errors" + "overlap").

## Design Decisions

### Issue #162 — Shared-cache via cross-module import

`views.errors._load_aggregates` (`@st.cache_data(ttl=300)`) is the canonical Ledger-B loader. The precedent at `views/admin_analytics.py:1347` already imports it for cache-bust on the global Refresh Data button. The Overview KPI reuses the same loader so it shares the cache key with the Errors tab — guarantees agreement under the same `days_int` without any new admin-side adapter. Same TTL, negligible cache amplification.

**Alternative considered and rejected:** keeping `get_error_stats` and renaming only. Rejected because `get_error_stats` queries `ErrorLog` only and structurally under-counts. The drift would persist behind a renamed label — admins still see two surfaces that disagree.

### Issue #163 — Strike-through, not recalculation

When a Source chip is deselected, the equation term wraps in markdown strike-through but Total is **unchanged from the unfiltered cross-source sum**. This is load-bearing.

**Alternative considered and rejected:** recalculate Total based on selected sources. Rejected because it would cause the Sources-row Total to disagree with the Analytics row Total Errors KPI whenever any chip is off — reintroducing the exact drift this Epic exists to fix. The strike-through approach preserves the invariant `Sources equation Total == Analytics Total Errors` under all chip states.

The `counts` dict feeding the equation is structurally unfiltered: `count_errors_by_source` ignores the Sources chip filter and always returns counts across all three sources. The cross-surface invariant is therefore not just enforced by tests — it's structurally guaranteed by the data source.

### Issue #164 — Textual denominator as primary signal

The "of N (Z.Z%)" denominator carries the semantic weight that this card is a *slice* of Total, not an addend. The caption adds explicit prose disambiguation as a backup signal. No new CSS — the textual treatment is sufficient and avoids the maintenance cost of custom Streamlit styling.

Retry Success% stays as a `_kpi_card` because it's a rate metric (already visually distinct from additive cards via the `%` suffix on the primary value, and from subset cards via the absence of an "of N" denominator).

`total == 0` short-circuit returns `"of 0"` without a percentage suffix — empty time ranges render gracefully without divide-by-zero.

### Wrapper/body split for testability

Both new helpers (`_sources_equation_markdown` + `_render_sources_equation`, `_subset_kpi_caption_text` + `_render_subset_kpi_card`) follow the wrapper/body split pattern established by PR #158 — a pure-format function returns the rendered string, and a thin Streamlit wrapper calls `st.markdown` / `st.caption`. Unit tests assert on the pure-format function and avoid `@st.dialog`-style runtime constraints.

## Self-Review

Two rounds of cynical review per commit. Findings caught and fixed:

- **#162 — Test stub signature.** Initial `_stub_read_metrics(_days)` didn't accept the kw-arg form `_read_metrics(days=days_int)` the production code uses. Fixed to `def _stub_read_metrics(days=30)`.
- **#162 — Shared-cache test brittleness.** The first version of the cache test tried to render `_render_overview_tab` and then exercise the Errors tab path, but module-reloading interfered with `monkeypatch` scoping. Replaced with a direct double-call to `_load_aggregates(30)` plus a static-source assertion that `views.admin_analytics._render_overview_tab` imports `_load_aggregates` from `views.errors`. Two complementary tests instead of one brittle one — the structural import check catches future regressions where someone refactors to a sibling loader.
- **#162 — Downstream-DB exception swallow.** `_render_overview_tab` does substantial DB work (latency distribution, Latest Questions audit preview) AFTER the KPI row. Tests wrap the render call in `try/except` so DB failures don't mask the KPI-row assertions. Acceptable because the KPI markdown calls are recorded BEFORE the downstream DB work runs.
- **#163 — Unknown-key safety.** Initial implementation iterated over `counts.keys()`, which would have summed unknown keys into Total. Switched to iterating over the canonical `_SOURCE_DISPLAY_LABELS` tuple and using `counts.get(src_value, 0)` — unknown keys are silently ignored, the canonical 3-source Total is preserved.
- **#164 — Caption test cross-module import.** The `_RecordingStreamlit` helper is shared across the three new test files via `from tests.views.test_admin_overview_error_kpis import _RecordingStreamlit`. Acceptable trade-off: DRY vs cross-test coupling. The helper class is stable (just records streamlit primitive calls); if the host test file is ever renamed, this import would need updating. Noted for the reviewer.

Remaining concerns for the reviewer:

- **Visual differentiation primary signal is textual.** Per the spec, the subset card uses the `of N (Z.Z%)` denominator as the primary visual signal. Adding a tinted border or badge was explicitly left as implementer's choice — I opted not to add CSS to keep the diff focused and the styling consistent with the existing `_kpi_card`. If the design team wants a stronger visual cue, that can be a follow-up.

## Testing

- [x] All existing tests pass on the changed scope: `uv run pytest -m "not milvus" tests/views tests/orm` → **359 passed, 3 failed** (the 3 failures are pre-existing on `main`: `tests/views/test_agent_analytics.py` × 2 and `tests/views/test_user_import.py` import retired views — unrelated to this PR).
- [x] 45 new tests added across three files: `test_admin_overview_error_kpis.py` (12), `test_errors_sources_equation.py` (15), `test_errors_subset_kpi.py` (18).
- [x] `uv run ruff check` and `uv run ruff format --check` clean on all changed files (the pre-existing 139 ruff errors on `main` are unrelated and outside the scope of this PR).
- [ ] Manual UI verification recommended: visit Admin Analytics → Overview tab; confirm "Chat Errors" and "Critical System Errors" labels, then visit the Errors tab and confirm the Sources-row equation renders under the three KPI cards with strike-through behaviour when a chip is deselected, and that the Analytics-row Critical / SQL Errors cards show the "of N (Z.Z%)" denominator and the updated caption.

## Files Modified

- `views/admin_analytics.py` — Module docstring (two-ledger contract); KPI rename + rewire.
- `views/errors.py` — Module docstring (two-ledger contract); two new helper pairs (`_sources_equation_markdown` / `_render_sources_equation`, `_subset_kpi_caption_text` / `_render_subset_kpi_card`); Sources-row equation wired in; Analytics-row Critical + SQL Errors swapped to subset helper; caption rewritten.
- `orm/logging_functions.py` — `get_error_stats` deleted.
- `tests/views/test_admin_overview_error_kpis.py` — New (12 tests).
- `tests/views/test_errors_sources_equation.py` — New (15 tests).
- `tests/views/test_errors_subset_kpi.py` — New (18 tests).