### PR TITLE
fix(audit): prevent cross-tab dialog collision in Admin → Audit umbrella

### DIFF
--- a/tests/views/test_admin_audit_dialog_collision.py
+++ b/tests/views/test_admin_audit_dialog_collision.py
@@ -1,0 +1,613 @@
+"""Regression tests for the Admin → Audit umbrella tab dialog collision (#166).
+
+Background
+----------
+``views/admin_audit.py:render`` builds an inner ``st.tabs`` with three child
+audit tabs (Questions, Admin Actions, User Activity). Each child renders its
+own ``st.dataframe(on_select="rerun", selection_mode="single-row")`` whose
+selection state persists across reruns in ``st.session_state``. Because
+``st.tabs`` evaluates *every* tab body on every rerun (not just the visible
+one), and Streamlit forbids more than one ``st.dialog`` call per script run,
+the prior pattern — where each tab unconditionally called
+``_render_X_dialog(selected_item)`` whenever ``selected_rows`` was non-empty —
+could fire two dialogs in the same rerun and raise:
+
+    streamlit.errors.StreamlitAPIException:
+    Only one dialog is allowed to be opened at the same time.
+
+The fix introduces a per-rerun guard, ``_audit_dialog_claimed_this_rerun``:
+
+* ``views/admin_audit.py:render`` resets the flag to ``False`` at the top of
+  every rerun, before ``st.tabs`` is created.
+* Each of the three tab dialog branches checks-and-sets the flag *inside*
+  the ``if open_id != selected_item[...]`` gate, so at most one tab opens
+  a dialog per rerun, and a row already opened in a prior rerun does not
+  reopen on subsequent reruns.
+
+These tests pin both behaviours.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders (sample rows + Streamlit stub)
+# ---------------------------------------------------------------------------
+
+
+def _make_question_item(*, user_message_id: int = 1) -> dict:
+    """A Questions tab item shaped like ``get_question_audit_page`` output."""
+    return {
+        "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 7,
+        "username": "alice",
+        "organization": "Acme",
+        "question": "How many patients today?",
+        "sql_text": "SELECT count(*) FROM patient",
+        "status": "Success",
+        "elapsed_seconds": 1.0,
+        "summary_text": "12 patients.",
+        "dataframe_preview": None,
+        "error_text": None,
+        "user_message_id": user_message_id,
+    }
+
+
+def _make_admin_action_item(*, id: int = 1) -> dict:
+    """An Admin Actions tab item shaped like ``get_admin_actions_page`` output."""
+    return {
+        "id": id,
+        "created_at": datetime(2026, 6, 1, 12, 0, 0),
+        "admin_username": "alice_admin",
+        "action_type": "user_update",
+        "target_user_id": 42,
+        "target_username": "bob",
+        "target_entity_type": "user",
+        "target_entity_id": "42",
+        "description": "Updated bob's role",
+        "old_value": '{"role": "Patient"}',
+        "new_value": '{"role": "Doctor"}',
+        "affected_count": 1,
+        "success": True,
+        "error_message": None,
+    }
+
+
+def _make_user_activity_item(*, id: int = 1) -> dict:
+    """A User Activity tab item shaped like ``get_user_activity_page`` output."""
+    return {
+        "id": id,
+        "created_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 9,
+        "username": "carol",
+        "activity_type": "settings_change",
+        "description": "Changed theme",
+        "old_value": None,
+        "new_value": None,
+        "ip_address": "127.0.0.1",
+        "user_agent": "Mozilla/5.0 Test",
+    }
+
+
+class _SharedSessionStub:
+    """A Streamlit stub that mimics enough of the surface used by
+    ``admin_audit.render`` AND the three tab functions in ``admin_analytics``.
+
+    A single instance must be patched into BOTH ``views.admin_audit.st`` and
+    ``views.admin_analytics.st`` so the cross-tab guard
+    ``_audit_dialog_claimed_this_rerun`` lives on a SHARED ``session_state``
+    dict — that's the whole point of the fix.
+
+    ``per_key_selections`` lets each tab's dataframe report a different
+    ``selected_rows`` value, keyed by the dataframe's ``key=`` kwarg.
+    """
+
+    def __init__(
+        self,
+        *,
+        per_key_selections: dict | None = None,
+        initial_session: dict | None = None,
+        secrets: dict | None = None,
+    ):
+        self.session_state: dict = dict(initial_session or {})
+        self._per_key_selections = dict(per_key_selections or {})
+        self.secrets = secrets if secrets is not None else {"agent_logging": {"mode": "full"}}
+        # The dataframe kwargs captured per call, for diagnostics.
+        self.captured_dataframe_kwargs: list[dict] = []
+        # ``components.v1.html`` is invoked by the question dialog body; the
+        # tab body itself does not hit it but we expose it for safety.
+        self.components = MagicMock()
+        self.components.v1 = MagicMock()
+        self.components.v1.html = MagicMock()
+
+    # ---- Layout primitives -----------------------------------------------
+    def tabs(self, _labels):
+        # Return one MagicMock per label, each usable as a context manager.
+        result = []
+        for _ in _labels:
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=cm)
+            cm.__exit__ = MagicMock(return_value=False)
+            result.append(cm)
+        return result
+
+    def columns(self, spec, **_kw):
+        n = spec if isinstance(spec, int) else len(spec)
+        cols = []
+        for _ in range(n):
+            cm = MagicMock()
+            cm.__enter__ = MagicMock(return_value=cm)
+            cm.__exit__ = MagicMock(return_value=False)
+            cols.append(cm)
+        return cols
+
+    def container(self, **_kw):
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=cm)
+        cm.__exit__ = MagicMock(return_value=False)
+        return cm
+
+    def divider(self):
+        pass
+
+    # ---- Input widgets ---------------------------------------------------
+    def multiselect(self, *_a, key=None, **_kw):
+        if key is not None:
+            self.session_state.setdefault(key, [])
+        return []
+
+    def text_input(self, *_a, key=None, **_kw):
+        if key is not None:
+            self.session_state.setdefault(key, "")
+        return ""
+
+    def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+        opts = list(options or [])
+        val = opts[index] if opts else None
+        if key:
+            self.session_state.setdefault(key, val)
+        return val
+
+    def number_input(self, *_a, key=None, **_kw):
+        if key is not None:
+            self.session_state.setdefault(key, 1)
+        return 1
+
+    def button(self, *_a, **_kw):
+        return False
+
+    def download_button(self, *_a, **_kw):
+        return False
+
+    # ---- Output primitives ----------------------------------------------
+    def dataframe(self, _df, **kwargs):
+        self.captured_dataframe_kwargs.append(kwargs)
+        key = kwargs.get("key")
+        rows = self._per_key_selections.get(key, [])
+        ev = MagicMock()
+        ev.selection = {"rows": list(rows)}
+        return ev
+
+    def info(self, *_a, **_kw):
+        pass
+
+    def caption(self, *_a, **_kw):
+        pass
+
+    def markdown(self, *_a, **_kw):
+        pass
+
+    def write(self, *_a, **_kw):
+        pass
+
+    def code(self, *_a, **_kw):
+        pass
+
+    def text(self, *_a, **_kw):
+        pass
+
+    def json(self, *_a, **_kw):
+        pass
+
+    def warning(self, *_a, **_kw):
+        pass
+
+    def error(self, *_a, **_kw):
+        pass
+
+    def subheader(self, *_a, **_kw):
+        pass
+
+    def plotly_chart(self, *_a, **_kw):
+        pass
+
+    def metric(self, *_a, **_kw):
+        pass
+
+    # ---- Dialog decorator passthrough -----------------------------------
+    def dialog(self, _title):
+        def _decorator(fn):
+            return fn
+
+        return _decorator
+
+
+def _patches_for_render(
+    *,
+    stub: _SharedSessionStub,
+    questions_items: list,
+    actions_items: list,
+    activity_items: list,
+    spy_q,
+    spy_a,
+    spy_u,
+):
+    """Build the full chain of ``patch`` context managers needed to run
+    ``admin_audit.render`` end-to-end against the shared stub.
+
+    Returns a list of patchers that the test must enter (e.g. via
+    ``contextlib.ExitStack``). Loaders are patched to return controlled rows
+    so the three tab functions reach their selection branches deterministically.
+    """
+    from views import admin_analytics, admin_audit
+
+    patchers = [
+        # Share the same stub across both modules so the per-rerun guard key
+        # lives on a single session_state dict.
+        patch.object(admin_audit, "st", stub),
+        patch.object(admin_analytics, "st", stub),
+        # Spy on the three dialog functions. They become no-ops here so we
+        # don't need their bodies — only call counts matter.
+        patch.object(admin_analytics, "_render_audit_question_dialog", side_effect=spy_q),
+        patch.object(admin_analytics, "_render_admin_action_dialog", side_effect=spy_a),
+        patch.object(admin_analytics, "_render_user_activity_dialog", side_effect=spy_u),
+        # Loaders for the Questions tab.
+        patch.object(
+            admin_analytics,
+            "_cached_audit_filter_options",
+            return_value={"usernames": [], "orgs": []},
+        ),
+        patch(
+            "orm.logging_functions.get_question_audit_page",
+            return_value={"items": list(questions_items), "total": len(questions_items)},
+        ),
+        patch("orm.functions.get_all_users", return_value=[]),
+        # Loaders for the Admin Actions tab.
+        patch(
+            "orm.logging_functions.get_admin_actions_page",
+            return_value={"items": list(actions_items), "total": len(actions_items)},
+        ),
+        patch(
+            "orm.logging_functions.get_admin_action_stats",
+            return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+        ),
+        patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+        # Loaders for the User Activity tab.
+        patch(
+            "orm.logging_functions.get_activity_stats",
+            return_value={
+                "logins_today": 0,
+                "failed_logins": 0,
+                "settings_changes": 0,
+                "unique_users": 0,
+            },
+        ),
+        patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+        patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+        patch(
+            "orm.logging_functions.get_user_activity_page",
+            return_value={"items": list(activity_items), "total": len(activity_items)},
+        ),
+    ]
+    return patchers
+
+
+# ---------------------------------------------------------------------------
+# (1) At most one dialog per script run when multiple tabs have selections
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTabCollision:
+    def test_single_dialog_when_multiple_tabs_have_selections(self):
+        """Production repro: Questions tab has a lingering selection AND
+        Admin Actions tab has a lingering selection AND User Activity tab
+        has a lingering selection, all with tab-local ``open_id`` keys that
+        differ from the would-be selected items' ids. Without the fix, every
+        rerun fires two or three ``st.dialog`` calls and Streamlit raises.
+
+        With the fix, exactly ONE dialog is invoked per rerun.
+        """
+        from views import admin_audit
+
+        q_item = _make_question_item(user_message_id=314)
+        a_item = _make_admin_action_item(id=271)
+        u_item = _make_user_activity_item(id=42)
+
+        # All three tabs report a selected row 0; tab-local ``open_id`` keys
+        # are absent so the ``open_id != selected[id]`` guard would otherwise
+        # pass through to the dialog call in every tab.
+        stub = _SharedSessionStub(
+            per_key_selections={
+                "audit_dataframe": [0],
+                "audit_actions_dataframe": [0],
+                "audit_activity_dataframe": [0],
+            }
+        )
+
+        q_calls: list = []
+        a_calls: list = []
+        u_calls: list = []
+
+        patchers = _patches_for_render(
+            stub=stub,
+            questions_items=[q_item],
+            actions_items=[a_item],
+            activity_items=[u_item],
+            spy_q=q_calls.append,
+            spy_a=a_calls.append,
+            spy_u=u_calls.append,
+        )
+
+        # Apply all patches then call render. Using a nested ``with`` chain via
+        # ExitStack to keep the test readable.
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            admin_audit.render(30)
+
+        total_dialog_calls = len(q_calls) + len(a_calls) + len(u_calls)
+        assert total_dialog_calls <= 1, (
+            f"At most one dialog may open per script run; saw "
+            f"Q={len(q_calls)} A={len(a_calls)} U={len(u_calls)} (={total_dialog_calls} total). "
+            f"This is the exact crash mode reported in production."
+        )
+        # And we should still open exactly one — silently dropping all dialogs
+        # would also satisfy ``<= 1`` but would break the feature.
+        assert total_dialog_calls == 1, (
+            f"Expected exactly one dialog to open (the first tab to claim); got {total_dialog_calls}"
+        )
+
+    def test_same_row_reselection_does_not_reopen(self):
+        """If the Questions tab dataframe still reports the same selected row
+        whose ``user_message_id`` matches ``audit_dialog_open_user_message_id``
+        from a prior rerun, the dialog must NOT be re-fired. (Before the fix,
+        the dialog re-rendered on every rerun.)"""
+        from views import admin_audit
+
+        q_item = _make_question_item(user_message_id=999)
+
+        stub = _SharedSessionStub(
+            per_key_selections={"audit_dataframe": [0]},
+            # Same id already tracked — dialog was opened in a prior rerun.
+            initial_session={"audit_dialog_open_user_message_id": 999},
+        )
+
+        q_calls: list = []
+        a_calls: list = []
+        u_calls: list = []
+
+        patchers = _patches_for_render(
+            stub=stub,
+            questions_items=[q_item],
+            actions_items=[],
+            activity_items=[],
+            spy_q=q_calls.append,
+            spy_a=a_calls.append,
+            spy_u=u_calls.append,
+        )
+
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            admin_audit.render(30)
+
+        assert q_calls == [], (
+            f"Same-row reselection across reruns must not reopen the dialog; saw {len(q_calls)} call(s)"
+        )
+        # And no other tab should have fired either.
+        assert a_calls == []
+        assert u_calls == []
+
+    def test_guard_resets_per_rerun(self):
+        """The cross-tab claim guard must be cleared at the top of every rerun.
+        Two consecutive ``render`` calls with NEW selections must each fire
+        exactly one dialog. (If the guard leaked across reruns, the second
+        rerun would silently drop the dialog.)"""
+        from views import admin_audit
+
+        # Two distinct Questions items across the two reruns. Same dataframe
+        # key, different ``user_message_id``s, so each rerun's selection is
+        # genuinely "new" relative to whatever the tab tracked previously.
+        q_item_1 = _make_question_item(user_message_id=111)
+        q_item_2 = _make_question_item(user_message_id=222)
+
+        # A single shared stub across both reruns so session_state persists,
+        # just like real Streamlit. Only the loader return values + selections
+        # differ between reruns.
+        stub = _SharedSessionStub(
+            per_key_selections={"audit_dataframe": [0]},
+        )
+
+        # ---- Rerun 1 -----------------------------------------------------
+        q1: list = []
+        a1: list = []
+        u1: list = []
+
+        from views import admin_analytics
+
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch.object(admin_audit, "st", stub))
+            stack.enter_context(patch.object(admin_analytics, "st", stub))
+            stack.enter_context(patch.object(admin_analytics, "_render_audit_question_dialog", side_effect=q1.append))
+            stack.enter_context(patch.object(admin_analytics, "_render_admin_action_dialog", side_effect=a1.append))
+            stack.enter_context(patch.object(admin_analytics, "_render_user_activity_dialog", side_effect=u1.append))
+            stack.enter_context(
+                patch.object(
+                    admin_analytics,
+                    "_cached_audit_filter_options",
+                    return_value={"usernames": [], "orgs": []},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_question_audit_page",
+                    return_value={"items": [q_item_1], "total": 1},
+                )
+            )
+            stack.enter_context(patch("orm.functions.get_all_users", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_admin_actions_page",
+                    return_value={"items": [], "total": 0},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_admin_action_stats",
+                    return_value={"total": 0, "user_changes": 0, "training_actions": 0, "failed": 0},
+                )
+            )
+            stack.enter_context(patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_activity_stats",
+                    return_value={
+                        "logins_today": 0,
+                        "failed_logins": 0,
+                        "settings_changes": 0,
+                        "unique_users": 0,
+                    },
+                )
+            )
+            stack.enter_context(patch("orm.logging_functions.get_activity_over_time", return_value=[]))
+            stack.enter_context(patch("orm.logging_functions.get_activity_by_type", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_user_activity_page",
+                    return_value={"items": [], "total": 0},
+                )
+            )
+
+            admin_audit.render(30)
+
+        assert (len(q1), len(a1), len(u1)) == (1, 0, 0), (
+            f"Rerun 1 must open exactly one Questions dialog; got Q={len(q1)} A={len(a1)} U={len(u1)}"
+        )
+
+        # ---- Rerun 2 -----------------------------------------------------
+        # If the guard didn't reset, this would silently drop the dialog.
+        q2: list = []
+        a2: list = []
+        u2: list = []
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(patch.object(admin_audit, "st", stub))
+            stack.enter_context(patch.object(admin_analytics, "st", stub))
+            stack.enter_context(patch.object(admin_analytics, "_render_audit_question_dialog", side_effect=q2.append))
+            stack.enter_context(patch.object(admin_analytics, "_render_admin_action_dialog", side_effect=a2.append))
+            stack.enter_context(patch.object(admin_analytics, "_render_user_activity_dialog", side_effect=u2.append))
+            stack.enter_context(
+                patch.object(
+                    admin_analytics,
+                    "_cached_audit_filter_options",
+                    return_value={"usernames": [], "orgs": []},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_question_audit_page",
+                    return_value={"items": [q_item_2], "total": 1},
+                )
+            )
+            stack.enter_context(patch("orm.functions.get_all_users", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_admin_actions_page",
+                    return_value={"items": [], "total": 0},
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_admin_action_stats",
+                    return_value={"total": 0, "user_changes": 0, "training_actions": 0, "failed": 0},
+                )
+            )
+            stack.enter_context(patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_activity_stats",
+                    return_value={
+                        "logins_today": 0,
+                        "failed_logins": 0,
+                        "settings_changes": 0,
+                        "unique_users": 0,
+                    },
+                )
+            )
+            stack.enter_context(patch("orm.logging_functions.get_activity_over_time", return_value=[]))
+            stack.enter_context(patch("orm.logging_functions.get_activity_by_type", return_value=[]))
+            stack.enter_context(
+                patch(
+                    "orm.logging_functions.get_user_activity_page",
+                    return_value={"items": [], "total": 0},
+                )
+            )
+
+            admin_audit.render(30)
+
+        assert (len(q2), len(a2), len(u2)) == (1, 0, 0), (
+            f"Rerun 2 must also open exactly one Questions dialog (guard reset per rerun); "
+            f"got Q={len(q2)} A={len(a2)} U={len(u2)}"
+        )
+
+    def test_render_resets_guard_before_tabs(self):
+        """White-box check: even if a stale ``_audit_dialog_claimed_this_rerun``
+        is True at entry (e.g. left over from the previous rerun's last
+        execution), ``render`` must clear it before the tabs evaluate. This
+        pins the second half of the fix (the guard reset in admin_audit.py).
+        """
+        from views import admin_audit
+
+        q_item = _make_question_item(user_message_id=1)
+
+        stub = _SharedSessionStub(
+            per_key_selections={"audit_dataframe": [0]},
+            initial_session={"_audit_dialog_claimed_this_rerun": True},
+        )
+
+        q_calls: list = []
+        a_calls: list = []
+        u_calls: list = []
+
+        patchers = _patches_for_render(
+            stub=stub,
+            questions_items=[q_item],
+            actions_items=[],
+            activity_items=[],
+            spy_q=q_calls.append,
+            spy_a=a_calls.append,
+            spy_u=u_calls.append,
+        )
+
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            for p in patchers:
+                stack.enter_context(p)
+            admin_audit.render(30)
+
+        # If the guard had not been reset, the Questions dialog would have
+        # been silently dropped.
+        assert len(q_calls) == 1, (
+            f"render() must reset _audit_dialog_claimed_this_rerun before tabs evaluate; "
+            f"saw {len(q_calls)} Q dialog call(s) (expected 1)"
+        )

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -630,8 +630,16 @@ def _render_audit_trail_tab(days_int: int):
                     selected_item = items[row_idx]
                     open_id = st.session_state.get("audit_dialog_open_user_message_id")
                     if open_id != selected_item["user_message_id"]:
-                        st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
-                    _render_audit_question_dialog(selected_item)
+                        # NEW selection — claim the per-rerun dialog slot and open.
+                        # ``st.tabs`` runs every tab body each rerun and each tab has its
+                        # own persisted dataframe selection, so without the cross-tab
+                        # guard two tabs could both call ``st.dialog`` in the same script
+                        # run, which Streamlit forbids. Same-id reselection across reruns
+                        # short-circuits at the outer ``if`` and does NOT reopen.
+                        if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                            st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                            st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
+                            _render_audit_question_dialog(selected_item)
             else:
                 # Dataframe selection cleared (e.g. clicking the row again) — reset our
                 # tracking key so re-selecting the same row reopens the dialog.
@@ -1074,8 +1082,14 @@ def _render_activity_tab(days_int: int):
                 selected_item = items[row_idx]
                 open_id = st.session_state.get("audit_activity_dialog_open_id")
                 if open_id != selected_item["id"]:
-                    st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
-                _render_user_activity_dialog(selected_item)
+                    # NEW selection — claim the per-rerun dialog slot and open. See the
+                    # Questions tab branch above for the rationale: ``st.tabs`` evaluates
+                    # every tab body each rerun, so the cross-tab guard prevents two
+                    # tabs from both calling ``st.dialog`` in the same script run.
+                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                        st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
+                        _render_user_activity_dialog(selected_item)
         else:
             # Selection cleared — reset tracking key so re-selecting the same
             # row reopens the dialog.
@@ -1333,8 +1347,14 @@ def _render_audit_tab(days_int: int):
                 selected_item = items[row_idx]
                 open_id = st.session_state.get("audit_actions_dialog_open_id")
                 if open_id != selected_item["id"]:
-                    st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
-                _render_admin_action_dialog(selected_item)
+                    # NEW selection — claim the per-rerun dialog slot and open. See the
+                    # Questions tab branch in ``_render_audit_trail_tab`` for the full
+                    # rationale: Streamlit forbids two ``st.dialog`` calls per script
+                    # run and ``st.tabs`` evaluates every tab body each rerun.
+                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                        st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
+                        _render_admin_action_dialog(selected_item)
         else:
             # Selection cleared — drop the tracking key so re-selecting the
             # same row reopens the dialog.

--- a/views/admin_audit.py
+++ b/views/admin_audit.py
@@ -19,6 +19,13 @@ from views.admin_analytics import _render_activity_tab, _render_audit_tab, _rend
 
 
 def render(days_int: int) -> None:
+    # Per-rerun guard: Streamlit allows only one dialog open() per script run, but
+    # st.tabs runs ALL tab bodies on every rerun and each tab has its own dataframe
+    # selection state that persists across reruns. Whichever tab claims this flag
+    # first in a rerun gets to open its dialog; the others skip. Reset at the top
+    # so a new rerun starts with a clean slot.
+    st.session_state["_audit_dialog_claimed_this_rerun"] = False
+
     inner = st.tabs(["Questions", "Admin Actions", "User Activity"])
     with inner[0]:
         _render_audit_trail_tab(days_int)


### PR DESCRIPTION
## Summary

Production hotfix for a `StreamlitAPIException: Only one dialog is allowed to be opened at the same time` raised from the Admin → Audit umbrella tab. The audit-dialog Epic (#154 — landed via #158, #159, #160) introduced one `st.dataframe(on_select="rerun", selection_mode="single-row")` per audit sub-tab, but `st.tabs` evaluates *every* tab body on every rerun and each tab's selection state persists across reruns. Two tabs with lingering row selections would both call `st.dialog` in the same script run and crash.

Repro: select a Questions row → dialog opens → close it → switch to Admin Actions → select a row → boom.

## Root cause

Two interacting defects in the audit-tab dialog pattern:

1. **Dialog call was not gated by the `open_id != selected_item[...]` check.** At all three sites in `views/admin_analytics.py` (Questions ~631, User Activity ~1075, Admin Actions ~1334), the `if` only *updated session state* — the `_render_X_dialog(selected_item)` call happened unconditionally whenever `selected_rows` was non-empty. So the dialog re-fired every rerun while a row stayed selected.
2. **No cross-tab coordination.** Combined with (1), if Q tab and AA tab both had lingering selections, both dialog functions fired in the same script run → Streamlit raised.

## Fix

### Part 1 — Gate each dialog call (3 sites in `views/admin_analytics.py`)

Move the `_render_X_dialog(selected_item)` call INSIDE the `if open_id != selected_item[...]` block, with a cross-tab guard checked-and-set there:

```python
if open_id != selected_item["<id_field>"]:
    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
        st.session_state["_audit_dialog_claimed_this_rerun"] = True
        st.session_state["<tab_open_id_key>"] = selected_item["<id_field>"]
        _render_X_dialog(selected_item)
```

The cross-tab guard is *inside* the `if open_id != ...` block — if the same row is already open, we don't even claim. Existing `else: del session_state[<tab_open_id_key>]` branches on empty selection stay as-is.

### Part 2 — Reset the cross-tab claim guard at the top of `render`

`views/admin_audit.py:render` now sets `st.session_state["_audit_dialog_claimed_this_rerun"] = False` before `st.tabs(...)`. A new rerun starts with a clean slot; whichever tab claims first wins.

## Regression test

`tests/views/test_admin_audit_dialog_collision.py` (new):

- **Single-dialog-per-script-run.** Sets up Q/AA/UA all with selected row 0 and tab-local `open_id` absent; asserts exactly one of the three dialog mocks is called. Verified to fail without the fix (`Q=1 A=1 U=1 — 3 total`, exact production crash mode).
- **Same-row reselection.** Pre-sets `audit_dialog_open_user_message_id` to match the selected row; asserts the Questions dialog is NOT called. Verified to fail without the fix.
- **Guard resets per rerun.** Two consecutive `render(30)` calls with different selections each fire exactly one dialog.
- **`render` resets guard before `st.tabs`.** White-box check: even if `_audit_dialog_claimed_this_rerun` is True at entry (leftover from prior rerun's last execution), `render` clears it before tabs evaluate.

## Design Decisions

- **Cross-tab guard via shared `session_state` key over per-tab gating alone.** Per-tab same-row gating alone (Part 1 without the cross-tab key) would fix defect (1) but not defect (2) — distinct rows in different tabs would still both fire. The shared `_audit_dialog_claimed_this_rerun` key is the minimum machinery needed to handle the "tabs are all evaluated each rerun" reality.
- **Claim INSIDE `if open_id != ...` rather than outside.** Setting the guard outside (i.e. before the open_id check) would still prevent multi-dialog crashes but would also block legitimate same-row reselections after a different tab claimed. Inside-the-gate placement means the guard is only consumed when we actually intend to open.
- **Single underscore prefix on the key (`_audit_dialog_claimed_this_rerun`).** Matches the project's convention for ephemeral per-rerun state keys; not for cross-rerun persistence.

## Self-Review

The hostile review pass walked through LOGIC, EDGE CASES, SECURITY, CONVENTIONS, SCOPE, ERROR HANDLING, TESTS, REGRESSIONS:

- Verified the gating placement (`if open_id != ...` outer, `if not claimed` inner) handles all three cases: new selection in claiming tab (opens), new selection in losing tab (skipped, will fire next rerun), same-row reselection (short-circuits at outer gate without claiming).
- Verified `else: del session_state[<tab_open_id_key>]` paths are untouched — clearing a selection still resets that tab's open_id key independently of the cross-tab guard.
- Confirmed the test catches the production bug: stashed the fix and reran — `test_single_dialog_when_multiple_tabs_have_selections` fails with `Q=1 A=1 U=1 (=3 total)` matching the prod traceback, and `test_same_row_reselection_does_not_reopen` fails with `saw 1 call(s)`.
- No remaining concerns.

## Testing

- [x] `uv run pytest -m "not milvus" tests/views tests/orm` → 363 passed, 3 pre-existing failures unrelated (`tests/views/test_agent_analytics.py` and `tests/views/test_user_import.py` import retired views — also fail on `main`).
- [x] All 4 new collision tests pass; all 55 existing audit-dialog regression tests pass.
- [x] `uv run ruff check views/admin_audit.py views/admin_analytics.py tests/views/test_admin_audit_dialog_collision.py` → clean.
- [x] `uv run ruff format --check views/admin_audit.py views/admin_analytics.py tests/views/test_admin_audit_dialog_collision.py` → clean.
- [ ] Manual UI smoke: open Admin → Audit, click a Questions row, close the dialog, switch to Admin Actions, click a row. Should open the Admin Actions dialog (no `StreamlitAPIException`). Then back to Questions, click a different row → opens. Click the same Questions row twice → does not re-fire on rerun.

## Files Modified

- `views/admin_analytics.py` — gate dialog call at all 3 tab sites (Questions ~631, User Activity ~1075, Admin Actions ~1334) behind both the existing `open_id != selected[id]` check AND the new cross-tab `_audit_dialog_claimed_this_rerun` guard.
- `views/admin_audit.py` — reset the cross-tab guard at the top of `render` before `st.tabs(...)`.
- `tests/views/test_admin_audit_dialog_collision.py` (new) — 4 regression tests pinning the fix.

Refs Epic #154 (audit-dialog pattern: #155 / #156 / #157).