### PR TITLE
feat(audit): Scope filter (Patient / Pop Health / Other / Legacy) on Questions audit (Epic #166)

### DIFF
--- a/alembic/versions/188ab391e291_add_index_on_agentrun_user_message_id.py
+++ b/alembic/versions/188ab391e291_add_index_on_agentrun_user_message_id.py
@@ -1,0 +1,52 @@
+"""add index on AgentRun.user_message_id
+
+Adds an index ``ix_thrive_agent_run_user_message_id`` on
+``thrive_agent_run.user_message_id`` so the LEFT JOIN added by the
+Question Audit Scope filter (Epic #166 / Feature #167) stays cheap as
+audit data grows. The audit base query joins
+``AgentRun.user_message_id = Message.id`` on every audit page render and
+on every CSV export; without the index this is a full-scan of
+``thrive_agent_run``.
+
+The index is hygiene; safe to leave in place on rollback. Migration is
+symmetric (create / drop).
+
+Revision ID: 188ab391e291
+Revises: b48e797bfa81
+Create Date: 2026-06-11 09:35:57.299037
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision: str = "188ab391e291"
+down_revision: Union[str, Sequence[str], None] = "b48e797bfa81"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_INDEX_NAME = "ix_thrive_agent_run_user_message_id"
+_TABLE_NAME = "thrive_agent_run"
+_COLUMN_NAME = "user_message_id"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {ix["name"] for ix in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME not in existing:
+        op.create_index(_INDEX_NAME, _TABLE_NAME, [_COLUMN_NAME])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {ix["name"] for ix in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in existing:
+        op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -384,6 +384,26 @@ def get_admin_actions(
 MAX_AUDIT_EXPORT_ROWS = 50_000
 _NO_ORG_SENTINEL = "(no org)"
 
+# Scope classification buckets (Epic #166 / Feature #167). Order matters: the
+# CASE expression is evaluated top-to-bottom.
+SCOPE_PATIENT = "Patient"
+SCOPE_POP_HEALTH = "Pop Health"
+SCOPE_OTHER = "Other"
+SCOPE_LEGACY = "Legacy/Unknown"
+
+ALL_SCOPES: tuple[str, ...] = (SCOPE_PATIENT, SCOPE_POP_HEALTH, SCOPE_OTHER, SCOPE_LEGACY)
+
+# Tool families that imply the agent acted on a single patient. Patient
+# *intent* counts even when the slot was never filled, so a run that only
+# called ``find_patient`` (without picking a candidate) still classifies as
+# Patient.
+_PATIENT_INTENT_TOOLS: tuple[str, ...] = (
+    "find_patient",
+    "get_patient_clinical_data",
+    "list_patient_documents",
+)
+_POP_HEALTH_TOOLS: tuple[str, ...] = ("search_patients_by_criteria",)
+
 
 def _question_audit_base_query(session, filters: dict):
     """Build the filtered base query over user-role Message rows joined to User.
@@ -391,18 +411,55 @@ def _question_audit_base_query(session, filters: dict):
     Returns a SQLAlchemy query that selects the rows in reverse-chronological
     order WITHOUT pagination. Used by both the paginated page helper and the
     export helper.
-    """
-    from sqlalchemy import or_
 
-    from orm.models import Message, User
+    A ``scope`` label is derived per row via a SQL ``CASE`` expression that
+    LEFT JOINs ``AgentRun`` (on ``user_message_id``) and an aggregated
+    ``ToolCall`` subquery (on ``run_id``). Classifying in SQL keeps
+    ``COUNT(*)`` and ``OFFSET/LIMIT`` honest under the scope filter — see
+    Epic #166 Architecture Considerations.
+    """
+    from sqlalchemy import case, or_
+
+    from orm.models import AgentRun, Message, ToolCall, User
     from utils.enums import MessageType, RoleType
 
     days = int(filters.get("days") or 30)
     usernames = filters.get("usernames") or []
     orgs = filters.get("orgs") or []
     search = filters.get("search") or None
+    scopes = filters.get("scopes") or None
 
     since = datetime.utcnow() - timedelta(days=days)
+
+    # Aggregated tool-call presence per run. One row per run_id with flags
+    # for the Patient-intent and Pop-Health tool families. ``MAX(CASE ...)``
+    # gives O(1) presence checks per audit row.
+    tool_agg_sq = (
+        session.query(
+            ToolCall.run_id.label("run_id"),
+            func.max(case((ToolCall.tool_name.in_(_PATIENT_INTENT_TOOLS), 1), else_=0)).label("has_patient_tool"),
+            func.max(case((ToolCall.tool_name.in_(_POP_HEALTH_TOOLS), 1), else_=0)).label("has_pop_tool"),
+        )
+        .filter(ToolCall.run_id.isnot(None))
+        .group_by(ToolCall.run_id)
+        .subquery()
+    )
+
+    # Order matters: Patient wins over Pop Health when both tool families
+    # fired in the same run; Legacy/Unknown only when there is no AgentRun
+    # at all for the message.
+    scope_case = case(
+        (AgentRun.id.is_(None), SCOPE_LEGACY),
+        (
+            or_(
+                AgentRun.selected_patient_source_id.isnot(None),
+                tool_agg_sq.c.has_patient_tool == 1,
+            ),
+            SCOPE_PATIENT,
+        ),
+        (tool_agg_sq.c.has_pop_tool == 1, SCOPE_POP_HEALTH),
+        else_=SCOPE_OTHER,
+    )
 
     query = (
         session.query(
@@ -412,8 +469,11 @@ def _question_audit_base_query(session, filters: dict):
             User.id.label("user_id"),
             User.username.label("username"),
             User.organization.label("organization"),
+            scope_case.label("scope"),
         )
         .join(User, User.id == Message.user_id)
+        .outerjoin(AgentRun, AgentRun.user_message_id == Message.id)
+        .outerjoin(tool_agg_sq, tool_agg_sq.c.run_id == AgentRun.run_id)
         .filter(Message.role == RoleType.USER.value, Message.created_at >= since)
     )
 
@@ -445,6 +505,13 @@ def _question_audit_base_query(session, filters: dict):
             & (SqlMsg.content.ilike(s))
         )
         query = query.filter(or_(Message.content.ilike(s), sql_exists))
+
+    # Scope filter is applied via the CASE expression so it participates in
+    # COUNT(*) and OFFSET/LIMIT — pagination correctness is load-bearing.
+    if scopes:
+        wanted = {s for s in scopes if s in ALL_SCOPES}
+        if wanted:
+            query = query.filter(scope_case.in_(wanted))
 
     return query.order_by(Message.created_at.desc())
 
@@ -552,6 +619,11 @@ def _enrich_with_assistant_aggregates(session, base_rows: list) -> list[dict]:
                 "dataframe_preview": agg["dataframe_preview"],
                 "error_text": agg["error_text"],
                 "user_message_id": r.user_message_id,
+                # Scope label derived in SQL via _question_audit_base_query's
+                # CASE expression (Epic #166 / Feature #167). Defensive
+                # ``getattr`` so callers that synthesise their own row
+                # objects in tests don't crash if they omit it.
+                "scope": getattr(r, "scope", None) or SCOPE_LEGACY,
             }
         )
     return items

--- a/orm/models.py
+++ b/orm/models.py
@@ -568,6 +568,9 @@ class AgentRun(Base):
         Index("ix_thrive_agent_run_selected_patient", "selected_patient_source_id"),
         Index("ix_thrive_agent_run_status", "status"),
         Index("ix_thrive_agent_run_review_status", "review_status"),
+        # Backs the LEFT JOIN added by the Question Audit Scope filter
+        # (Epic #166 / Feature #167). Matching migration: 188ab391e291.
+        Index("ix_thrive_agent_run_user_message_id", "user_message_id"),
     )
 
     id = Column(Integer, primary_key=True)

--- a/tests/orm/test_question_audit_scope.py
+++ b/tests/orm/test_question_audit_scope.py
@@ -1,0 +1,401 @@
+"""Tests for the Scope classification + filter on the Question audit page.
+
+Epic #166 / Feature #167. Classification is computed in SQL via a CASE
+expression in ``_question_audit_base_query`` so that pagination (``COUNT(*)``
++ ``OFFSET/LIMIT``) stays honest under the Scope filter — see Epic #166
+Architecture Considerations.
+
+The four buckets:
+
+  - ``Patient``      slot filled OR any patient-intent tool called
+  - ``Pop Health``   not Patient AND ``search_patients_by_criteria`` called
+  - ``Other``        AgentRun row exists, neither above
+  - ``Legacy/Unknown`` no AgentRun row at all
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import AgentRun, Base, Message, RoleTypeEnum, ToolCall, User, UserRole
+from utils.enums import MessageType, RoleType
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (lightly adapted from tests/orm/test_question_audit.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add_all(
+        [
+            UserRole(id=1, role_name="Admin", description="Admin", role=RoleTypeEnum.ADMIN),
+            UserRole(id=4, role_name="Patient", description="Patient", role=RoleTypeEnum.PATIENT),
+        ]
+    )
+    session.commit()
+
+
+def _seed_user(session, *, id, username, org=None, role_id=4):
+    session.add(
+        User(
+            id=id,
+            user_role_id=role_id,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+            organization=org,
+        )
+    )
+    session.commit()
+
+
+def _add_question(session, *, user_id, content, when):
+    """Seed a user-role Message row with a clamped ``created_at``. Returns the
+    new Message.id so the caller can link an AgentRun to it.
+    """
+    session.add(
+        Message(
+            role=RoleType.USER,
+            content=content,
+            type=MessageType.TEXT,
+            user_id=user_id,
+        )
+    )
+    session.commit()
+    last = session.query(Message).order_by(Message.id.desc()).first()
+    last.created_at = when
+    session.commit()
+    return last.id
+
+
+_DEFAULT_TOOL_KW = dict(
+    arguments_json="{}",
+    result_summary="{}",
+    elapsed_ms=1,
+    success=True,
+)
+
+
+def _add_agent_run(
+    session,
+    *,
+    run_id,
+    user_id,
+    user_message_id,
+    selected_patient_source_id=None,
+):
+    """Seed a minimal AgentRun row keyed to ``user_message_id``."""
+    session.add(
+        AgentRun(
+            run_id=run_id,
+            session_id=f"sess-{run_id}",
+            user_id=user_id,
+            user_role=RoleTypeEnum.PATIENT.value,
+            user_message_id=user_message_id,
+            selected_patient_source_id=selected_patient_source_id,
+            tool_call_count=0,
+            event_count=0,
+            status="completed",
+            success=True,
+            review_status="unreviewed",
+            logging_mode="full",
+            schema_version=1,
+        )
+    )
+    session.commit()
+
+
+def _add_tool_call(session, *, run_id, user_id, tool_name):
+    session.add(
+        ToolCall(
+            session_id=f"sess-{run_id}",
+            user_id=user_id,
+            user_role=RoleTypeEnum.PATIENT.value,
+            tool_name=tool_name,
+            run_id=run_id,
+            **_DEFAULT_TOOL_KW,
+        )
+    )
+    session.commit()
+
+
+def _filters(**overrides):
+    base = {"usernames": [], "orgs": [], "days": 30, "search": None}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# (1) Classification correctness — one row per bucket
+# ---------------------------------------------------------------------------
+
+
+def test_scope_legacy_when_no_agent_run(session_factory):
+    """A user-role Message with no linked AgentRun row classifies as
+    ``Legacy/Unknown`` (the pre-agentic-replatform case)."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _add_question(s, user_id=10, content="legacy q", when=datetime(2026, 6, 1, 12, 0, 0))
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert len(page["items"]) == 1
+    assert page["items"][0]["scope"] == "Legacy/Unknown"
+
+
+def test_scope_patient_when_slot_filled(session_factory):
+    """``AgentRun.selected_patient_source_id IS NOT NULL`` => Patient."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="slot-filled", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-a", user_id=10, user_message_id=mid, selected_patient_source_id="pat-123")
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["scope"] == "Patient"
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    ["find_patient", "get_patient_clinical_data", "list_patient_documents"],
+)
+def test_scope_patient_when_patient_intent_tool_only(session_factory, tool_name):
+    """Patient *intent* counts even when the slot never filled — a run that
+    called e.g. ``find_patient`` without picking a candidate still classifies
+    as Patient. This is the edge case spelled out in the spec."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content=f"intent-{tool_name}", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-b", user_id=10, user_message_id=mid)  # slot empty
+    _add_tool_call(s, run_id="run-b", user_id=10, tool_name=tool_name)
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["scope"] == "Patient"
+
+
+def test_scope_pop_health(session_factory):
+    """Not Patient AND ``search_patients_by_criteria`` was called => Pop Health."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="cohort q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-c", user_id=10, user_message_id=mid)  # no slot
+    _add_tool_call(s, run_id="run-c", user_id=10, tool_name="search_patients_by_criteria")
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["scope"] == "Pop Health"
+
+
+def test_scope_other_when_agent_run_but_no_classified_tools(session_factory):
+    """AgentRun exists, no slot, no Patient/Pop tools => Other."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="kb only", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-d", user_id=10, user_message_id=mid)
+    _add_tool_call(s, run_id="run-d", user_id=10, tool_name="search_knowledge_base")
+    _add_tool_call(s, run_id="run-d", user_id=10, tool_name="run_sql")
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["scope"] == "Other"
+
+
+def test_scope_patient_wins_over_pop_when_both_tool_families_fire(session_factory):
+    """When a single run fires both a Patient-intent tool and the Pop Health
+    tool, the spec's order says Patient wins. This is the same evaluation
+    order the SQL ``CASE`` uses."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="mixed", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-e", user_id=10, user_message_id=mid)
+    _add_tool_call(s, run_id="run-e", user_id=10, tool_name="find_patient")
+    _add_tool_call(s, run_id="run-e", user_id=10, tool_name="search_patients_by_criteria")
+
+    page = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["scope"] == "Patient"
+
+
+# ---------------------------------------------------------------------------
+# (2) Filter + total + pagination correctness on a mixed page
+# ---------------------------------------------------------------------------
+
+
+def _seed_mixed_page(s) -> dict[str, int]:
+    """Seed 10 user messages spread across all 4 buckets. Returns a dict
+    ``{bucket: count}`` for cross-checking expectations.
+
+    Counts: 4 Patient · 2 Pop Health · 2 Other · 2 Legacy/Unknown.
+    Timestamps are spaced so reverse-chronological order is deterministic.
+    """
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    n = 0
+
+    def _ts(i):
+        # Newest row first (i=0 is newest).
+        return base - timedelta(minutes=i)
+
+    # Patient rows
+    for i in range(4):
+        mid = _add_question(s, user_id=10, content=f"patient-{i}", when=_ts(n))
+        _add_agent_run(s, run_id=f"r-pat-{i}", user_id=10, user_message_id=mid, selected_patient_source_id=f"p{i}")
+        n += 1
+
+    # Pop Health rows
+    for i in range(2):
+        mid = _add_question(s, user_id=10, content=f"pop-{i}", when=_ts(n))
+        _add_agent_run(s, run_id=f"r-pop-{i}", user_id=10, user_message_id=mid)
+        _add_tool_call(s, run_id=f"r-pop-{i}", user_id=10, tool_name="search_patients_by_criteria")
+        n += 1
+
+    # Other rows
+    for i in range(2):
+        mid = _add_question(s, user_id=10, content=f"other-{i}", when=_ts(n))
+        _add_agent_run(s, run_id=f"r-oth-{i}", user_id=10, user_message_id=mid)
+        _add_tool_call(s, run_id=f"r-oth-{i}", user_id=10, tool_name="search_knowledge_base")
+        n += 1
+
+    # Legacy rows — no AgentRun
+    for i in range(2):
+        _add_question(s, user_id=10, content=f"legacy-{i}", when=_ts(n))
+        n += 1
+
+    assert n == 10
+    return {"Patient": 4, "Pop Health": 2, "Other": 2, "Legacy/Unknown": 2}
+
+
+def test_scope_filter_reduces_total_and_items(session_factory):
+    """Filtering by Scope must shrink BOTH ``total`` (via SQL WHERE before
+    COUNT(*)) and the returned ``items``."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    expected = _seed_mixed_page(s)
+
+    # Unfiltered: 10 rows.
+    unfiltered = get_question_audit_page(_filters(), page=1, page_size=50)
+    assert unfiltered["total"] == 10
+    assert len(unfiltered["items"]) == 10
+
+    # Filtered to Patient only.
+    only_patient = get_question_audit_page(_filters(scopes=["Patient"]), page=1, page_size=50)
+    assert only_patient["total"] == expected["Patient"]
+    assert {it["scope"] for it in only_patient["items"]} == {"Patient"}
+    assert len(only_patient["items"]) == expected["Patient"]
+
+
+def test_scope_filter_multiple_buckets_union(session_factory):
+    """A multi-bucket filter is OR-style (multiselect)."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    expected = _seed_mixed_page(s)
+
+    result = get_question_audit_page(_filters(scopes=["Pop Health", "Legacy/Unknown"]), page=1, page_size=50)
+    assert result["total"] == expected["Pop Health"] + expected["Legacy/Unknown"]
+    assert {it["scope"] for it in result["items"]} == {"Pop Health", "Legacy/Unknown"}
+
+
+def test_scope_filter_pagination_slices_filtered_set(session_factory):
+    """Page 2 under a Scope filter must return the correct slice of the
+    FILTERED set, not the unfiltered set. With page_size=2 + Patient filter
+    (4 rows), page 1 has 2 Patient rows and page 2 has the remaining 2."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_mixed_page(s)
+
+    p1 = get_question_audit_page(_filters(scopes=["Patient"]), page=1, page_size=2)
+    p2 = get_question_audit_page(_filters(scopes=["Patient"]), page=2, page_size=2)
+
+    assert p1["total"] == 4
+    assert p2["total"] == 4
+    assert len(p1["items"]) == 2
+    assert len(p2["items"]) == 2
+    # All four are Patient.
+    assert {it["scope"] for it in (*p1["items"], *p2["items"])} == {"Patient"}
+    # Disjoint slices.
+    p1_ids = {it["user_message_id"] for it in p1["items"]}
+    p2_ids = {it["user_message_id"] for it in p2["items"]}
+    assert p1_ids.isdisjoint(p2_ids)
+
+
+def test_scope_filter_empty_list_means_no_filter(session_factory):
+    """Empty / None scopes must NOT filter — same shape as the existing
+    usernames / orgs filters."""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    _seed_mixed_page(s)
+
+    none_filter = get_question_audit_page(_filters(scopes=None), page=1, page_size=50)
+    empty_filter = get_question_audit_page(_filters(scopes=[]), page=1, page_size=50)
+    assert none_filter["total"] == 10
+    assert empty_filter["total"] == 10
+
+
+def test_scope_filter_unknown_bucket_is_ignored(session_factory):
+    """Defensive: an unrecognised scope label is silently dropped from the
+    filter set, so the rest still narrow the result. (If we let unknowns
+    through to ``IN (...)`` the user sees an empty page instead of just
+    their intended filter.)"""
+    from orm.logging_functions import get_question_audit_page
+
+    s = session_factory()
+    expected = _seed_mixed_page(s)
+
+    result = get_question_audit_page(_filters(scopes=["Patient", "BogusBucket"]), page=1, page_size=50)
+    assert result["total"] == expected["Patient"]
+
+
+# ---------------------------------------------------------------------------
+# (3) CSV export honors the filter + classification flows through
+# ---------------------------------------------------------------------------
+
+
+def test_export_respects_scope_filter_and_carries_scope_field(session_factory):
+    from orm.logging_functions import get_question_audit_export
+
+    s = session_factory()
+    expected = _seed_mixed_page(s)
+
+    rows = get_question_audit_export(_filters(scopes=["Pop Health"]))
+    assert len(rows) == expected["Pop Health"]
+    assert {r["scope"] for r in rows} == {"Pop Health"}
+    # Same item shape as the page items — the existing keys must survive.
+    assert "question" in rows[0]
+    assert "status" in rows[0]

--- a/tests/views/test_audit_scope_filter.py
+++ b/tests/views/test_audit_scope_filter.py
@@ -1,0 +1,449 @@
+"""Tests for the Scope filter UI on the Questions audit tab.
+
+Epic #166 / Feature #167. Specifically:
+
+  - The Scope multiselect renders with the 4 expected options and a stable
+    ``audit_scope_filter`` session key (matching the existing
+    ``audit_user_filter`` / ``audit_org_filter`` convention).
+  - The selected scopes are plumbed into the ``filters`` dict and reach
+    ``get_question_audit_page`` and ``get_question_audit_export``.
+  - The Scope chip participates in the existing filter-signature reset
+    logic — changing it resets ``audit_page_num`` to 1.
+  - The grid table_rows include a ``"Scope"`` column.
+  - The CSV export DataFrame includes a ``"Scope"`` column.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from orm.models import RoleTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_item(*, user_message_id: int = 42, scope: str = "Patient") -> dict:
+    """One item matching ``_enrich_with_assistant_aggregates``' shape, now
+    carrying a ``scope`` label."""
+    return {
+        "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 7,
+        "username": "alice",
+        "organization": "Acme",
+        "question": "How many patients today?",
+        "sql_text": "SELECT count(*) FROM patient",
+        "status": "Success",
+        "elapsed_seconds": 1.25,
+        "summary_text": "There are 12 patients.",
+        "dataframe_preview": pd.DataFrame({"x": [1]}).to_json(),
+        "error_text": None,
+        "user_message_id": user_message_id,
+        "scope": scope,
+    }
+
+
+def _make_stub(
+    *,
+    secrets_mode: str = "full",
+    multiselect_returns: dict | None = None,
+    dataframe_returns_selection: bool = False,
+    button_returns: dict | None = None,
+    initial_session_state: dict | None = None,
+):
+    """Build a recording streamlit stub for ``_render_audit_trail_tab``.
+
+    Parameters
+    ----------
+    multiselect_returns : dict keyed by ``key=`` value. Lets tests inject
+        the "user picked these" values without faking widget interaction.
+    button_returns : dict keyed by ``key=`` value. Lets tests fire the CSV
+        export button on demand.
+    """
+
+    captured_multiselect_kwargs: list[dict] = []
+    captured_table_rows: list[list[dict]] = []
+    captured_download_kwargs: list[dict] = []
+    captured_export_df: list[pd.DataFrame] = []
+
+    multiselect_returns = multiselect_returns or {}
+    button_returns = button_returns or {}
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = dict(initial_session_state or {})
+            self.session_state.setdefault("user_role", RoleTypeEnum.ADMIN.value)
+            self.secrets = {"agent_logging": {"mode": secrets_mode}}
+            self.components = MagicMock()
+            self.components.v1 = MagicMock()
+            self.components.v1.html = MagicMock()
+
+        # -- widgets -------------------------------------------------------
+        def multiselect(self, label, options=None, key=None, **kw):
+            captured_multiselect_kwargs.append(
+                {
+                    "label": label,
+                    "options": list(options or []),
+                    "key": key,
+                    "kwargs": kw,
+                }
+            )
+            val = multiselect_returns.get(key, [])
+            if key is not None:
+                self.session_state.setdefault(key, val)
+                self.session_state[key] = val
+            return val
+
+        def text_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, 1)
+            return 1
+
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def dataframe(self, df, **_kw):
+            try:
+                captured_table_rows.append(df.to_dict(orient="records"))
+            except Exception:
+                captured_table_rows.append([])
+            if dataframe_returns_selection:
+                ev = MagicMock()
+                ev.selection = {"rows": [0]}
+                return ev
+            ev = MagicMock()
+            ev.selection = {"rows": []}
+            return ev
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, key=None, **_kw):
+            return button_returns.get(key, False)
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, _label, data=None, **kw):
+            captured_download_kwargs.append({"data": data, **kw})
+            # Reconstruct the export DataFrame from the encoded bytes so
+            # tests can assert on column shape without depending on the
+            # exact CSV serialization.
+            try:
+                from io import StringIO
+
+                df = pd.read_csv(StringIO(data.decode("utf-8")))
+                captured_export_df.append(df)
+            except Exception:
+                pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    stub = _Stub()
+    return stub, {
+        "multiselect": captured_multiselect_kwargs,
+        "table_rows": captured_table_rows,
+        "download_kwargs": captured_download_kwargs,
+        "export_df": captured_export_df,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (1) Scope multiselect is rendered with the right options + key
+# ---------------------------------------------------------------------------
+
+
+def test_scope_multiselect_options_and_key():
+    """The Scope chip must render with options
+    ``[Patient, Pop Health, Other, Legacy/Unknown]`` keyed by
+    ``audit_scope_filter`` — the spec's stable session key."""
+    from views import admin_analytics
+
+    stub, captures = _make_stub()
+    page_payload = {"items": [_make_item()], "total": 1}
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    scope_chip = next(
+        (m for m in captures["multiselect"] if m["key"] == "audit_scope_filter"),
+        None,
+    )
+    assert scope_chip is not None, "audit_scope_filter multiselect must be rendered"
+    assert scope_chip["options"] == [
+        "Patient",
+        "Pop Health",
+        "Other",
+        "Legacy/Unknown",
+    ]
+    assert scope_chip["label"] == "Scope"
+
+
+# ---------------------------------------------------------------------------
+# (2) Selected scopes are plumbed into the filters dict for both page + CSV
+# ---------------------------------------------------------------------------
+
+
+def test_selected_scope_is_passed_into_get_question_audit_page():
+    from views import admin_analytics
+
+    stub, _ = _make_stub(multiselect_returns={"audit_scope_filter": ["Patient", "Pop Health"]})
+    page_payload = {"items": [], "total": 0}
+
+    captured_filters: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        captured_filters.append(filters)
+        return page_payload
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", side_effect=_fake_page),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert captured_filters, "get_question_audit_page must have been called"
+    last = captured_filters[-1]
+    assert last["scopes"] == ["Patient", "Pop Health"]
+
+
+def test_csv_export_passes_scope_filter_through():
+    from views import admin_analytics
+
+    stub, captures = _make_stub(
+        multiselect_returns={"audit_scope_filter": ["Pop Health"]},
+        button_returns={"audit_export_btn": True},
+    )
+    page_payload = {"items": [_make_item(scope="Pop Health")], "total": 1}
+    export_rows = [_make_item(user_message_id=42, scope="Pop Health")]
+
+    captured_export_filters: list[dict] = []
+
+    def _fake_export(filters):
+        captured_export_filters.append(filters)
+        return export_rows
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.logging_functions.get_question_audit_export", side_effect=_fake_export),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert captured_export_filters, "Export filter dict must have been built"
+    assert captured_export_filters[-1]["scopes"] == ["Pop Health"]
+
+    # And the resulting CSV DataFrame must carry the Scope column.
+    assert captures["export_df"], "download_button data must have decoded as CSV"
+    df = captures["export_df"][-1]
+    assert "Scope" in df.columns
+    assert df["Scope"].tolist() == ["Pop Health"]
+
+
+# ---------------------------------------------------------------------------
+# (3) Filter signature includes Scope — changing it resets audit_page_num
+# ---------------------------------------------------------------------------
+
+
+def test_changing_scope_resets_audit_page_num_to_1():
+    """The filter-signature reset at views/admin_analytics.py:419-422 must
+    notice when ``audit_scope_filter`` changes."""
+    from views import admin_analytics
+
+    # First render: user has Patient selected; page bumped to 3 by hand
+    # (mimicking the user clicking Next twice).
+    stub1, _ = _make_stub(
+        multiselect_returns={"audit_scope_filter": ["Patient"]},
+        initial_session_state={"audit_page_num": 3},
+    )
+    page_payload = {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_analytics, "st", stub1),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    signature_with_patient = stub1.session_state["audit_filter_signature"]
+    # Page reset on filter change relative to the initial empty signature.
+    assert stub1.session_state["audit_page_num"] == 1
+
+    # Second render: same starting page (3), but Scope flipped to Pop
+    # Health. Carry the prior filter signature forward to simulate a
+    # genuine "same session, just changed the chip" rerun.
+    stub2, _ = _make_stub(
+        multiselect_returns={"audit_scope_filter": ["Pop Health"]},
+        initial_session_state={
+            "audit_page_num": 3,
+            "audit_filter_signature": signature_with_patient,
+        },
+    )
+    with (
+        patch.object(admin_analytics, "st", stub2),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert stub2.session_state["audit_page_num"] == 1
+    assert stub2.session_state["audit_filter_signature"] != signature_with_patient
+
+
+def test_stable_scope_does_not_reset_page():
+    """If the user only paginated (nothing about the filter changed), the
+    page bump should survive. This catches a stale-signature bug where the
+    Scope chip's session-state quirks accidentally triggered a reset."""
+    from views import admin_analytics
+
+    # Compute the expected signature once via a no-op render so the second
+    # render shares it.
+    bootstrap_stub, _ = _make_stub(
+        multiselect_returns={"audit_scope_filter": ["Patient"]},
+    )
+    page_payload = {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_analytics, "st", bootstrap_stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+    stable_signature = bootstrap_stub.session_state["audit_filter_signature"]
+
+    # Now the "user paginated" rerun. Same Scope, but page_num is 4 and
+    # the signature is already cached — reset must NOT fire.
+    stub, _ = _make_stub(
+        multiselect_returns={"audit_scope_filter": ["Patient"]},
+        initial_session_state={
+            "audit_page_num": 4,
+            "audit_filter_signature": stable_signature,
+        },
+    )
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+    assert stub.session_state["audit_page_num"] == 4
+
+
+# ---------------------------------------------------------------------------
+# (4) Grid surface — Scope column appears in the rendered table_rows
+# ---------------------------------------------------------------------------
+
+
+def test_grid_table_rows_include_scope_column_between_status_and_elapsed():
+    from views import admin_analytics
+
+    stub, captures = _make_stub()
+    page_payload = {
+        "items": [
+            _make_item(user_message_id=1, scope="Patient"),
+            _make_item(user_message_id=2, scope="Pop Health"),
+        ],
+        "total": 2,
+    }
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert captures["table_rows"], "dataframe must have been rendered"
+    rows = captures["table_rows"][-1]
+    assert all("Scope" in r for r in rows)
+    assert [r["Scope"] for r in rows] == ["Patient", "Pop Health"]
+
+    # And Scope must land between Status and Elapsed (s) (spec).
+    cols = list(rows[0].keys())
+    status_idx = cols.index("Status")
+    scope_idx = cols.index("Scope")
+    elapsed_idx = cols.index("Elapsed (s)")
+    assert status_idx < scope_idx < elapsed_idx, f"Scope must sit between Status and Elapsed; got column order {cols}"
+
+
+# ---------------------------------------------------------------------------
+# (5) Empty Scope selection means no filter is plumbed
+# ---------------------------------------------------------------------------
+
+
+def test_empty_scope_selection_passes_none_to_backend():
+    """Default state (no chips picked) must NOT send ``scopes`` as an empty
+    list to the backend — that would be ambiguous. Send ``None`` so the
+    backend's existing ``filters.get("scopes") or None`` short-circuits."""
+    from views import admin_analytics
+
+    stub, _ = _make_stub()  # default: multiselect returns []
+    captured: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        captured.append(filters)
+        return {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(admin_analytics, "_cached_audit_filter_options", return_value={"usernames": [], "orgs": []}),
+        patch("orm.logging_functions.get_question_audit_page", side_effect=_fake_page),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert captured[-1]["scopes"] is None

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -541,12 +541,26 @@ def _render_audit_trail_tab(days_int: int):
         except Exception as e:
             logger.warning("Audit deep-link prefill failed: %s", e)
 
-    f1, f2, f3 = st.columns([0.30, 0.30, 0.40])
+    # Scope options are sourced from the backend so the chip and the SQL
+    # CASE stay in sync. Importing inside the function mirrors the existing
+    # local-import convention in this module.
+    from orm.logging_functions import ALL_SCOPES as _AUDIT_SCOPE_OPTIONS
+
+    f1, f2, f3, f4 = st.columns([0.24, 0.24, 0.22, 0.30])
     with f1:
         usernames_sel = st.multiselect("User", options=options["usernames"], key="audit_user_filter")
     with f2:
         orgs_sel = st.multiselect("Organization", options=options["orgs"], key="audit_org_filter")
     with f3:
+        scopes_sel = st.multiselect(
+            "Scope",
+            options=list(_AUDIT_SCOPE_OPTIONS),
+            key="audit_scope_filter",
+            help="Patient = single-patient questions (PHI access). "
+            "Pop Health = cohort searches. Other = codes / KB / pure SQL. "
+            "Legacy/Unknown = pre-agentic-replatform rows.",
+        )
+    with f4:
         search = st.text_input(
             "Search question or SQL",
             placeholder="Substring match (case-insensitive)",
@@ -558,6 +572,8 @@ def _render_audit_trail_tab(days_int: int):
         "orgs": orgs_sel,
         "days": int(days_int),
         "search": search.strip() if search else None,
+        # ``set`` is JSON-unfriendly; backend accepts any iterable.
+        "scopes": sorted(scopes_sel) if scopes_sel else None,
     }
 
     # Reset pagination on filter change
@@ -601,6 +617,9 @@ def _render_audit_trail_tab(days_int: int):
                     "Question": _truncate(it["question"], 120),
                     "SQL": _truncate(it.get("sql_text"), 80),
                     "Status": _AUDIT_STATUS_EMOJI.get(it["status"], it["status"]),
+                    # Epic #166 / Feature #167: derived scope label —
+                    # Patient / Pop Health / Other / Legacy/Unknown.
+                    "Scope": it.get("scope") or "Legacy/Unknown",
                     "Elapsed (s)": round(float(it.get("elapsed_seconds") or 0.0), 3),
                 }
             )
@@ -692,6 +711,11 @@ def _render_audit_trail_tab(days_int: int):
                             "Question": r["question"],
                             "SQL": r.get("sql_text") or "",
                             "Status": r["status"],
+                            # Epic #166 / Feature #167: same derived label
+                            # the grid surfaces. CSV must obey the Scope
+                            # filter (transparent — same filters dict) AND
+                            # carry the classification through to the file.
+                            "Scope": r.get("scope") or "Legacy/Unknown",
                             "Elapsed (s)": round(float(r.get("elapsed_seconds") or 0.0), 3),
                         }
                         for r in export_rows


### PR DESCRIPTION
Closes #167. Part of Epic #166.

## Summary

Adds a **Scope** multiselect chip + **Scope** column + Scope CSV column to Admin → Audit → Questions, with classification computed at SQL time so pagination stays honest under the filter.

The four buckets:

| Bucket | Condition |
|---|---|
| **Patient** | `AgentRun.selected_patient_source_id IS NOT NULL` OR any tool call in `{find_patient, get_patient_clinical_data, list_patient_documents}` |
| **Pop Health** | Not Patient AND `search_patients_by_criteria` was called |
| **Other** | `AgentRun` row exists, neither above |
| **Legacy/Unknown** | No `AgentRun` row for the message (pre-agentic-replatform) |

## Changes

### Backend (`orm/logging_functions.py`)
- `_question_audit_base_query` LEFT JOINs `AgentRun` on `user_message_id` and an aggregated `ToolCall` subquery (`SELECT run_id, MAX(CASE ...) ... GROUP BY run_id`) on `run_id`, then derives a `scope` label via a SQL `CASE` expression in the documented order (Legacy → Patient → Pop Health → Other).
- Accepts `filters[\"scopes\"]`; applied as `WHERE` **before** `COUNT(*)` and `OFFSET/LIMIT` so `total` + page slicing reflect the filtered set. This is load-bearing — classifying in Python after the page loaded would silently shrink the page and lie about `total`.
- `_enrich_with_assistant_aggregates` threads `scope` through to the item shape.

### UI (`views/admin_analytics.py`)
- New `Scope` `st.multiselect` keyed `audit_scope_filter`, next to User / Organization.
- Column widths rebalanced from `[0.30, 0.30, 0.40]` to `[0.24, 0.24, 0.22, 0.30]` to fit a 4-chip row.
- Selected scopes plumbed into the `filters` dict; empty selection sends `None` (matches existing `usernames` / `orgs` convention).
- Filter signature already serializes the whole `filters` dict, so the new `scopes` key participates for free — changing it resets `audit_page_num` to 1.
- `Scope` column lands **between Status and Elapsed (s)** in the grid and the CSV.

### Migration
- `alembic/versions/188ab391e291_add_index_on_agentrun_user_message_id.py` adds `ix_thrive_agent_run_user_message_id` (idempotent, symmetric downgrade).
- Matching `Index(...)` declaration in `AgentRun.__table_args__` keeps the model and the DB in sync.

> **Note on the AgentRun.user_message_id index migration**: the new LEFT JOIN runs on every audit page render and every CSV export. Without the index, that's a full scan of `thrive_agent_run`. The migration is symmetric and safe to leave in place even on rollback — `git revert` of the merge commit alone is a complete rollback of behavior; downgrading the migration is optional cleanup.

## Design decisions

- **Classification is a SQL `CASE`, not Python post-load.** Spec calls this out explicitly. Backed by the `test_scope_filter_pagination_slices_filtered_set` test which proves page 2 under a Scope filter returns the correct slice of the **filtered** set.
- **`ToolCall` aggregated via subquery, not per-row.** One `GROUP BY run_id` join keeps the per-page cost bounded; no N+1.
- **Patient wins over Pop Health when both fire.** The `CASE` evaluates top-to-bottom; `test_scope_patient_wins_over_pop_when_both_tool_families_fire` pins this.
- **Empty `scopes` → `None`, not `[]`.** Backend short-circuits on `or None`; `test_empty_scope_selection_passes_none_to_backend` pins this.
- **Unknown bucket labels are dropped, not passed to `IN(...)`.** Defensive — `test_scope_filter_unknown_bucket_is_ignored` shows the rest of the filter still narrows correctly.

## Self-Review

- LOGIC: Verified `CASE` ordering, LEFT JOIN NULL propagation to Legacy bucket, and `MAX(CASE WHEN ...)` aggregation in subquery. Tests cover all four buckets including the patient-intent-only edge case (parametrized over the 3 tools).
- EDGE CASES: Empty/None scopes, unknown bucket labels, both-tool-families-in-one-run all explicitly tested.
- CONVENTIONS: Local imports inside `_question_audit_base_query` (matches existing style). `case((cond, val), else_=...)` matches the SQLAlchemy 2.0 syntax already used elsewhere in this file.
- SCOPE: Only the spec'd files touched — `orm/logging_functions.py`, `orm/models.py`, `views/admin_analytics.py`, the new Alembic revision, and the two new test files. No drift.
- REGRESSIONS: All 50 audit-related tests pass (29 existing + 21 new). Full `tests/views + tests/orm` runs with the 3 pre-existing unrelated failures from main (`test_agent_analytics.py`, `test_user_import.py` — both import retired views).

## Test plan

- [x] `uv sync && uv run alembic upgrade head` (verified clean apply on dev SQLite)
- [x] `uv run alembic downgrade -1 && uv run alembic upgrade head` (round-trip clean)
- [x] `uv run pytest -m \"not milvus\" tests/views tests/orm` — 384 passed, 3 pre-existing failures unrelated
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run ruff format --check` on changed files — clean
- [ ] Manual: spin up the app, navigate Admin → Audit → Questions, exercise the Scope chip + CSV export