### PR TITLE
feat(audit): labeled View checkbox column + View Selected button on all 3 audit tables (Epic #169 v2)

### DIFF
--- a/tests/views/test_admin_actions_dialog.py
+++ b/tests/views/test_admin_actions_dialog.py
@@ -354,14 +354,21 @@ class TestTargetLine:
 # ---------------------------------------------------------------------------
 
 
-def _make_tab_stub():
-    """Build a stub ``st`` module sufficient for ``_render_audit_tab`` to run."""
+def _make_tab_stub(*, view_column_values=None, view_button_clicked: bool = False):
+    """Build a stub ``st`` module sufficient for ``_render_audit_tab`` to run.
+
+    Mirrors the new (Epic #169 / #170) data_editor + checkbox column +
+    View Selected button flow. ``view_column_values`` controls which rows
+    are 'checked' on the ``View`` column. ``view_button_clicked`` makes
+    ``audit_actions_view_selected_btn`` return True.
+    """
 
     class _Stub:
         def __init__(self):
             self.session_state = {}
-            self.captured_dataframe_kwargs: list[dict] = []
+            self.captured_data_editor_kwargs: list[dict] = []
             self.dialog_invocations: list[dict] = []
+            self.column_config = MagicMock()
 
         # Streamlit surface --------------------------------------------------
         def columns(self, spec):
@@ -391,13 +398,21 @@ def _make_tab_stub():
             self.session_state.setdefault(key, 1)
             return 1
 
-        def dataframe(self, _df, **kwargs):
-            self.captured_dataframe_kwargs.append(kwargs)
-            # Default: simulate the configured selection_event hook (set per test).
-            return getattr(self, "_dataframe_event", None) or MagicMock(selection={"rows": []})
+        def data_editor(self, df, **kwargs):
+            self.captured_data_editor_kwargs.append(kwargs)
+            # Simulate user toggling the View checkboxes.
+            out = df.copy()
+            if "View" in out.columns and view_column_values:
+                vals = list(view_column_values) + [False] * max(0, len(out) - len(view_column_values))
+                out["View"] = vals[: len(out)]
+            return out
 
-        def button(self, *_a, **_kw):
-            return False
+        def dataframe(self, _df, **_kw):
+            # Distribution table still uses st.dataframe; just return a Mock.
+            return MagicMock()
+
+        def button(self, *_a, key=None, **_kw):
+            return bool(view_button_clicked) if key == "audit_actions_view_selected_btn" else False
 
         def caption(self, *_a, **_kw):
             pass
@@ -439,19 +454,17 @@ def _make_tab_stub():
 
 
 class TestSelectionStateTrigger:
-    def test_row_selection_opens_dialog_and_sets_state(self):
-        """When the dataframe event reports a selected row, _render_audit_tab
-        must set ``audit_actions_dialog_open_id`` and invoke the dialog
-        function for that row."""
+    def test_button_click_with_one_row_checked_opens_dialog(self):
+        """When the View checkbox is ticked for exactly one row AND the
+        View Selected button is clicked, ``_render_audit_tab`` must set
+        ``audit_actions_dialog_open_id`` and invoke the dialog function
+        for that row."""
         from views import admin_analytics
 
         item = _make_action(id=314)
         dialog_calls: list[dict] = []
 
-        stub = _make_tab_stub()
-        ev = MagicMock()
-        ev.selection = {"rows": [0]}
-        stub._dataframe_event = ev
+        stub = _make_tab_stub(view_column_values=[True], view_button_clicked=True)
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -468,20 +481,18 @@ class TestSelectionStateTrigger:
         ):
             admin_analytics._render_audit_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked for the selected row's item"
+        assert dialog_calls == [item], "Dialog must be invoked for the checked row's item"
         assert stub.session_state.get("audit_actions_dialog_open_id") == 314
 
-    def test_no_selection_clears_dialog_state_key(self):
+    def test_no_button_click_does_not_open_dialog(self):
+        """If the user ticks a checkbox but never clicks View Selected,
+        the dialog must NOT fire."""
         from views import admin_analytics
 
         item = _make_action(id=314)
 
-        stub = _make_tab_stub()
-        # Pre-existing tracking key — must be cleared when selection is empty.
-        stub.session_state["audit_actions_dialog_open_id"] = 314
-        ev = MagicMock()
-        ev.selection = {"rows": []}
-        stub._dataframe_event = ev
+        # Row is checked, but button is NOT clicked.
+        stub = _make_tab_stub(view_column_values=[True], view_button_clicked=False)
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -501,10 +512,10 @@ class TestSelectionStateTrigger:
         dialog_mock.assert_not_called()
         assert "audit_actions_dialog_open_id" not in stub.session_state
 
-    def test_dataframe_wired_with_single_row_selection_primitive(self):
-        """The grid must always use the locked-in trigger primitive:
-        ``selection_mode='single-row'``, ``on_select='rerun'``, and a stable
-        key. Epic #154 mandates this for #156 + #157."""
+    def test_data_editor_wired_with_view_checkbox_column(self):
+        """The Admin Actions grid must call ``st.data_editor`` with a
+        leading ``View`` ``CheckboxColumn`` and a stable key
+        (``audit_actions_dataframe``). Epic #169 / Feature #170."""
         from views import admin_analytics
 
         item = _make_action()
@@ -525,11 +536,13 @@ class TestSelectionStateTrigger:
         ):
             admin_analytics._render_audit_tab(30)
 
-        assert stub.captured_dataframe_kwargs, "Expected st.dataframe to be called for the grid"
-        kw = stub.captured_dataframe_kwargs[0]
-        assert kw.get("selection_mode") == "single-row"
-        assert kw.get("on_select") == "rerun"
+        assert stub.captured_data_editor_kwargs, "Expected st.data_editor to be called for the grid"
+        kw = stub.captured_data_editor_kwargs[0]
         assert kw.get("key") == "audit_actions_dataframe"
+        cc = kw.get("column_config")
+        assert cc is not None and "View" in cc, (
+            f"Expected a 'View' entry in column_config; saw keys={list((cc or {}).keys())}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/views/test_admin_actions_dialog.py
+++ b/tests/views/test_admin_actions_dialog.py
@@ -354,18 +354,19 @@ class TestTargetLine:
 # ---------------------------------------------------------------------------
 
 
-def _make_tab_stub(*, view_column_values=None, view_button_clicked: bool = False):
+def _make_tab_stub(*, view_column_values=None, initial_session: dict | None = None):
     """Build a stub ``st`` module sufficient for ``_render_audit_tab`` to run.
 
     Mirrors the new (Epic #169 / #170) data_editor + checkbox column +
-    View Selected button flow. ``view_column_values`` controls which rows
-    are 'checked' on the ``View`` column. ``view_button_clicked`` makes
-    ``audit_actions_view_selected_btn`` return True.
+    auto-open-on-tick flow. ``view_column_values`` controls which rows
+    are 'checked' on the ``View`` column. ``initial_session`` seeds
+    ``session_state`` — used by the "sticky tick across reruns" tests
+    to pre-populate ``audit_actions_dialog_open_id``.
     """
 
     class _Stub:
         def __init__(self):
-            self.session_state = {}
+            self.session_state = dict(initial_session or {})
             self.captured_data_editor_kwargs: list[dict] = []
             self.dialog_invocations: list[dict] = []
             self.column_config = MagicMock()
@@ -412,7 +413,9 @@ def _make_tab_stub(*, view_column_values=None, view_button_clicked: bool = False
             return MagicMock()
 
         def button(self, *_a, key=None, **_kw):
-            return bool(view_button_clicked) if key == "audit_actions_view_selected_btn" else False
+            # No button participates in the auto-open flow — Prev/Next
+            # buttons still render but do nothing here.
+            return False
 
         def caption(self, *_a, **_kw):
             pass
@@ -454,17 +457,17 @@ def _make_tab_stub(*, view_column_values=None, view_button_clicked: bool = False
 
 
 class TestSelectionStateTrigger:
-    def test_button_click_with_one_row_checked_opens_dialog(self):
-        """When the View checkbox is ticked for exactly one row AND the
-        View Selected button is clicked, ``_render_audit_tab`` must set
-        ``audit_actions_dialog_open_id`` and invoke the dialog function
-        for that row."""
+    def test_one_tick_auto_opens_dialog(self):
+        """When the View checkbox is ticked for exactly one row,
+        ``_render_audit_tab`` must set ``audit_actions_dialog_open_id``
+        and auto-invoke the dialog function for that row — no button
+        click needed."""
         from views import admin_analytics
 
         item = _make_action(id=314)
         dialog_calls: list[dict] = []
 
-        stub = _make_tab_stub(view_column_values=[True], view_button_clicked=True)
+        stub = _make_tab_stub(view_column_values=[True])
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -481,18 +484,22 @@ class TestSelectionStateTrigger:
         ):
             admin_analytics._render_audit_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked for the checked row's item"
+        assert dialog_calls == [item], "Dialog must be invoked for the ticked row's item"
         assert stub.session_state.get("audit_actions_dialog_open_id") == 314
 
-    def test_no_button_click_does_not_open_dialog(self):
-        """If the user ticks a checkbox but never clicks View Selected,
-        the dialog must NOT fire."""
+    def test_zero_ticks_does_not_open_dialog(self):
+        """If no row is ticked, the dialog must NOT fire and the per-tab
+        ``open_id`` gate is cleared so the same row can be re-ticked."""
         from views import admin_analytics
 
         item = _make_action(id=314)
 
-        # Row is checked, but button is NOT clicked.
-        stub = _make_tab_stub(view_column_values=[True], view_button_clicked=False)
+        # No row is checked. Pre-populate the gate to verify it gets
+        # cleared.
+        stub = _make_tab_stub(
+            view_column_values=[False],
+            initial_session={"audit_actions_dialog_open_id": 314},
+        )
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -510,7 +517,43 @@ class TestSelectionStateTrigger:
             admin_analytics._render_audit_tab(30)
 
         dialog_mock.assert_not_called()
-        assert "audit_actions_dialog_open_id" not in stub.session_state
+        assert "audit_actions_dialog_open_id" not in stub.session_state, (
+            "Zero ticks must clear the open_id gate so the same row can be re-ticked"
+        )
+
+    def test_sticky_tick_across_rerun_does_not_refire(self):
+        """If the checkbox stays ticked between reruns (Streamlit
+        ``data_editor`` retains the True value) the dialog must NOT
+        re-fire — the per-tab gate stops it."""
+        from views import admin_analytics
+
+        item = _make_action(id=314)
+
+        # Row is still ticked AND the gate already records this row as
+        # open from a prior rerun.
+        stub = _make_tab_stub(
+            view_column_values=[True],
+            initial_session={"audit_actions_dialog_open_id": 314},
+        )
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_admin_action_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_admin_actions_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch(
+                "orm.logging_functions.get_admin_action_stats",
+                return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+            ),
+            patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+        ):
+            admin_analytics._render_audit_tab(30)
+
+        dialog_mock.assert_not_called()
+        # Gate stays set to the same id (sticky tick).
+        assert stub.session_state.get("audit_actions_dialog_open_id") == 314
 
     def test_data_editor_wired_with_view_checkbox_column(self):
         """The Admin Actions grid must call ``st.data_editor`` with a

--- a/tests/views/test_admin_audit_dialog.py
+++ b/tests/views/test_admin_audit_dialog.py
@@ -1,14 +1,18 @@
-"""Tests for the Questions audit tab row-click dialog (#155).
+"""Tests for the Questions audit tab View Selected dialog (#155 / #170).
 
 Covers:
-  (a) Dialog opens when selection state changes and closes when cleared.
+  (a) Dialog opens when the View Selected button is clicked with exactly
+      one row checked (Epic #169 / #170 swapped the dataframe selection
+      trigger for a ``st.data_editor`` + checkbox column + explicit
+      button).
   (b) Deep-link round-trip — setting `manage_users_pref_user_id` causes
       Manage Users to pre-populate `mu_selected_label` with the target user.
   (c) `role_can_see_query_details` returning False hides the SQL block and
       the full DataFrame inside the dialog body while keeping question /
       summary / error visible.
   (d) `[agent_logging].mode = "disabled"` makes the dialog unreachable
-      (selection_mode is not passed to st.dataframe).
+      (``st.data_editor`` is not invoked; only the read-only ``st.dataframe``
+      branch runs).
   (e) The dialog renders all rows from `dataframe_preview`, not just the
       first 5 (regression on the old expander `.head(5)` truncation).
 """
@@ -376,15 +380,19 @@ class TestManageUsersInboundPrefill:
 
 
 class TestAgentLoggingDisabled:
-    def test_disabled_mode_skips_selection_mode_kwarg(self):
+    def test_disabled_mode_uses_dataframe_not_data_editor(self):
         """When `[agent_logging].mode = "disabled"`, the audit tab must
-        render the dataframe WITHOUT `selection_mode`, so a click cannot
-        open the dialog (defense in depth — disabled mode should produce
-        no rows in the first place)."""
+        render via the read-only ``st.dataframe`` branch and NOT call
+        ``st.data_editor`` — so there's no checkbox column and no
+        ``View Selected`` button, making the dialog unreachable
+        (defense in depth — disabled mode should produce no rows in the
+        first place). The read-only display must also drop the ``View``
+        column entirely (it would be a confusing always-False checkbox)."""
         from views import admin_analytics
 
-        # Capture the kwargs passed to st.dataframe by the audit tab.
-        captured_kwargs: list[dict] = []
+        dataframe_call_count = [0]
+        data_editor_call_count = [0]
+        captured_readonly_dfs = []
 
         class _Stub:
             def __init__(self):
@@ -393,8 +401,8 @@ class TestAgentLoggingDisabled:
                 self.components = MagicMock()
                 self.components.v1 = MagicMock()
                 self.components.v1.html = MagicMock()
+                self.column_config = MagicMock()
 
-            # Streamlit surface ----
             def multiselect(self, *_a, key=None, **_kw):
                 self.session_state.setdefault(key, [])
                 return []
@@ -418,9 +426,17 @@ class TestAgentLoggingDisabled:
                 n = spec if isinstance(spec, int) else len(spec)
                 return [MagicMock() for _ in range(n)]
 
-            def dataframe(self, _df, **kwargs):
-                captured_kwargs.append(kwargs)
+            def dataframe(self, df, **_kwargs):
+                dataframe_call_count[0] += 1
+                # Capture only DataFrames whose key indicates the audit grid
+                # so we don't grab unrelated read-only tables.
+                if _kwargs.get("key") == "audit_dataframe":
+                    captured_readonly_dfs.append(df)
                 return MagicMock()
+
+            def data_editor(self, df, **_kwargs):
+                data_editor_call_count[0] += 1
+                return df
 
             def info(self, *_a, **_kw):
                 pass
@@ -459,9 +475,6 @@ class TestAgentLoggingDisabled:
                 return _decorator
 
         stub = _Stub()
-
-        # Stub the cached filter options + page result with one row, so the
-        # dataframe code path runs.
         filter_options = {"usernames": ["alice"], "orgs": ["Acme"]}
         page_payload = {
             "items": [_make_item()],
@@ -476,24 +489,29 @@ class TestAgentLoggingDisabled:
         ):
             admin_analytics._render_audit_trail_tab(30)
 
-        assert captured_kwargs, "Expected st.dataframe to be called"
-        # In disabled mode, NO selection_mode kwarg should be passed.
-        for kw in captured_kwargs:
-            assert "selection_mode" not in kw, (
-                "When agent_logging.mode == 'disabled', selection_mode must "
-                f"be omitted from st.dataframe; saw kwargs: {kw}"
-            )
-            assert "on_select" not in kw, (
-                f"When agent_logging.mode == 'disabled', on_select must be omitted from st.dataframe; saw kwargs: {kw}"
-            )
+        assert data_editor_call_count[0] == 0, (
+            "When agent_logging.mode == 'disabled', st.data_editor must NOT be called — "
+            "the dialog must be unreachable. The audit table should fall through to the "
+            "read-only st.dataframe branch."
+        )
+        assert dataframe_call_count[0] >= 1, (
+            "In disabled mode, the table should still render via the read-only st.dataframe branch."
+        )
+        # The read-only DataFrame must NOT carry a meaningless ``View`` column.
+        assert captured_readonly_dfs, "Expected the audit grid to render via st.dataframe in disabled mode"
+        assert "View" not in captured_readonly_dfs[0].columns, (
+            "In disabled mode the read-only display must drop the View column entirely; "
+            f"saw columns={list(captured_readonly_dfs[0].columns)}"
+        )
 
-    def test_full_mode_passes_selection_mode_kwarg(self):
+    def test_full_mode_uses_data_editor_with_view_checkbox_column(self):
         """When `[agent_logging].mode` is anything other than 'disabled'
-        (default 'full'), the audit tab must wire up selection_mode + on_select
-        so row clicks open the dialog."""
+        (default 'full'), the audit tab must call ``st.data_editor`` and
+        configure a leading ``View`` ``CheckboxColumn`` so the explicit
+        ``View Selected`` button workflow is wired up."""
         from views import admin_analytics
 
-        captured_kwargs: list[dict] = []
+        captured_data_editor_kwargs: list[dict] = []
 
         class _Stub:
             def __init__(self):
@@ -502,6 +520,9 @@ class TestAgentLoggingDisabled:
                 self.components = MagicMock()
                 self.components.v1 = MagicMock()
                 self.components.v1.html = MagicMock()
+                # column_config attribute: returning the call args lets
+                # downstream code (the tab) inspect what was configured.
+                self.column_config = MagicMock()
 
             def multiselect(self, *_a, key=None, **_kw):
                 self.session_state.setdefault(key, [])
@@ -526,13 +547,14 @@ class TestAgentLoggingDisabled:
                 n = spec if isinstance(spec, int) else len(spec)
                 return [MagicMock() for _ in range(n)]
 
-            def dataframe(self, _df, **kwargs):
-                captured_kwargs.append(kwargs)
-                # No selection — simulate the user not clicking anything,
-                # so the dialog branch doesn't execute.
-                ev = MagicMock()
-                ev.selection = {"rows": []}
-                return ev
+            def data_editor(self, df, **kwargs):
+                captured_data_editor_kwargs.append(kwargs)
+                # Return the DataFrame unchanged so the tab can read
+                # ``edited_df["View"]`` (all False by default).
+                return df
+
+            def dataframe(self, _df, **_kw):
+                return MagicMock()
 
             def info(self, *_a, **_kw):
                 pass
@@ -582,102 +604,135 @@ class TestAgentLoggingDisabled:
         ):
             admin_analytics._render_audit_trail_tab(30)
 
-        assert captured_kwargs, "Expected st.dataframe to be called"
-        kw = captured_kwargs[0]
-        assert kw.get("selection_mode") == "single-row"
-        assert kw.get("on_select") == "rerun"
+        assert captured_data_editor_kwargs, "Expected st.data_editor to be called"
+        kw = captured_data_editor_kwargs[0]
         assert kw.get("key") == "audit_dataframe"
+        cc = kw.get("column_config")
+        assert cc is not None and "View" in cc, (
+            f"Expected a 'View' entry in column_config; saw keys={list((cc or {}).keys())}"
+        )
 
 
 # ---------------------------------------------------------------------------
-# (a) Selection state opens / closes the dialog
+# (a) View Selected button opens the dialog; no click → no dialog
 # ---------------------------------------------------------------------------
+
+
+def _make_questions_stub(*, view_column_values: list[bool], view_button_clicked: bool = False):
+    """Build a Streamlit stub for ``_render_audit_trail_tab`` that simulates
+    the new (Epic #169) data_editor + checkbox + View Selected button flow.
+
+    ``view_column_values`` controls which rows the user has 'checked' on
+    the ``View`` column. The stub seeds those values back into ``edited_df``
+    so the production code's ``edited_df[edited_df['View']]`` filter picks
+    them up just like Streamlit would after a checkbox toggle.
+
+    ``view_button_clicked`` is True iff the test wants the
+    ``audit_questions_view_selected_btn`` to be 'clicked'.
+    """
+    import pandas as pd
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.components = MagicMock()
+            self.components.v1 = MagicMock()
+            self.components.v1.html = MagicMock()
+            self.column_config = MagicMock()
+            self.captured_data_editor_kwargs: list[dict] = []
+
+        def multiselect(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, [])
+            return []
+
+        def text_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def data_editor(self, df, **kwargs):
+            self.captured_data_editor_kwargs.append(kwargs)
+            # Simulate the user toggling checkboxes: rebuild ``View`` with
+            # the per-test values so the production filter picks them up.
+            out = df.copy()
+            if "View" in out.columns and view_column_values:
+                # Pad / truncate to the row count.
+                vals = list(view_column_values) + [False] * max(0, len(out) - len(view_column_values))
+                out["View"] = vals[: len(out)]
+            return out
+
+        def dataframe(self, _df, **_kw):
+            return MagicMock()
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, key=None, **_kw):
+            return bool(view_button_clicked) if key == "audit_questions_view_selected_btn" else False
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub(), pd  # pd returned for the test's local convenience
 
 
 class TestSelectionStateTrigger:
-    def test_row_selection_opens_dialog_and_sets_state(self):
-        """When the dataframe event reports a selected row, the audit tab must
-        set `audit_dialog_open_user_message_id` and invoke the dialog function
-        for that row."""
+    def test_button_click_with_one_row_checked_opens_dialog(self):
+        """When exactly one row's View checkbox is checked AND the
+        View Selected button is clicked, the audit tab must set
+        ``audit_dialog_open_user_message_id`` and invoke the dialog
+        function for that row."""
         from views import admin_analytics
 
         item = _make_item(user_message_id=314)
         dialog_calls: list[dict] = []
 
-        class _Stub:
-            def __init__(self):
-                self.session_state = {}
-                self.secrets = {"agent_logging": {"mode": "full"}}
-                self.components = MagicMock()
-                self.components.v1 = MagicMock()
-                self.components.v1.html = MagicMock()
-
-            def multiselect(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, [])
-                return []
-
-            def text_input(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, "")
-                return ""
-
-            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
-                opts = list(options or [])
-                val = opts[index] if opts else None
-                if key:
-                    self.session_state.setdefault(key, val)
-                return val
-
-            def number_input(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, 1)
-                return 1
-
-            def columns(self, spec):
-                n = spec if isinstance(spec, int) else len(spec)
-                return [MagicMock() for _ in range(n)]
-
-            def dataframe(self, _df, **_kw):
-                # Simulate the user selecting row 0.
-                ev = MagicMock()
-                ev.selection = {"rows": [0]}
-                return ev
-
-            def info(self, *_a, **_kw):
-                pass
-
-            def button(self, *_a, **_kw):
-                return False
-
-            def caption(self, *_a, **_kw):
-                pass
-
-            def markdown(self, *_a, **_kw):
-                pass
-
-            def write(self, *_a, **_kw):
-                pass
-
-            def code(self, *_a, **_kw):
-                pass
-
-            def divider(self):
-                pass
-
-            def warning(self, *_a, **_kw):
-                pass
-
-            def error(self, *_a, **_kw):
-                pass
-
-            def download_button(self, *_a, **_kw):
-                pass
-
-            def dialog(self, _title):
-                def _decorator(fn):
-                    return fn
-
-                return _decorator
-
-        stub = _Stub()
+        stub, _pd = _make_questions_stub(
+            view_column_values=[True],
+            view_button_clicked=True,
+        )
 
         def _fake_dialog(passed_item):
             dialog_calls.append(passed_item)
@@ -698,91 +753,21 @@ class TestSelectionStateTrigger:
         ):
             admin_analytics._render_audit_trail_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked for the selected row's item"
+        assert dialog_calls == [item], "Dialog must be invoked for the checked row's item"
         assert stub.session_state.get("audit_dialog_open_user_message_id") == 314
 
-    def test_no_selection_clears_dialog_state_key(self):
-        """When the user clears the selection (rows: []), the dialog tracking
-        key should be removed from session_state so re-selecting the same row
-        reopens the dialog."""
+    def test_no_button_click_does_not_open_dialog(self):
+        """If the user checks a row but never clicks View Selected, the
+        dialog must NOT open and no tracking key is set."""
         from views import admin_analytics
 
         item = _make_item(user_message_id=314)
 
-        class _Stub:
-            def __init__(self):
-                # Pre-existing open key from a prior dialog session.
-                self.session_state = {"audit_dialog_open_user_message_id": 314}
-                self.secrets = {"agent_logging": {"mode": "full"}}
-                self.components = MagicMock()
-                self.components.v1 = MagicMock()
-                self.components.v1.html = MagicMock()
-
-            def multiselect(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, [])
-                return []
-
-            def text_input(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, "")
-                return ""
-
-            def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
-                opts = list(options or [])
-                val = opts[index] if opts else None
-                if key:
-                    self.session_state.setdefault(key, val)
-                return val
-
-            def number_input(self, *_a, key=None, **_kw):
-                self.session_state.setdefault(key, 1)
-                return 1
-
-            def columns(self, spec):
-                n = spec if isinstance(spec, int) else len(spec)
-                return [MagicMock() for _ in range(n)]
-
-            def dataframe(self, _df, **_kw):
-                ev = MagicMock()
-                ev.selection = {"rows": []}
-                return ev
-
-            def info(self, *_a, **_kw):
-                pass
-
-            def button(self, *_a, **_kw):
-                return False
-
-            def caption(self, *_a, **_kw):
-                pass
-
-            def markdown(self, *_a, **_kw):
-                pass
-
-            def write(self, *_a, **_kw):
-                pass
-
-            def code(self, *_a, **_kw):
-                pass
-
-            def divider(self):
-                pass
-
-            def warning(self, *_a, **_kw):
-                pass
-
-            def error(self, *_a, **_kw):
-                pass
-
-            def download_button(self, *_a, **_kw):
-                pass
-
-            def dialog(self, _title):
-                def _decorator(fn):
-                    return fn
-
-                return _decorator
-
-        stub = _Stub()
+        # Row is checked, but button is NOT clicked.
+        stub, _pd = _make_questions_stub(
+            view_column_values=[True],
+            view_button_clicked=False,
+        )
 
         with (
             patch.object(admin_analytics, "st", stub),

--- a/tests/views/test_admin_audit_dialog.py
+++ b/tests/views/test_admin_audit_dialog.py
@@ -1,10 +1,10 @@
-"""Tests for the Questions audit tab View Selected dialog (#155 / #170).
+"""Tests for the Questions audit tab View checkbox dialog (#155 / #170).
 
 Covers:
-  (a) Dialog opens when the View Selected button is clicked with exactly
-      one row checked (Epic #169 / #170 swapped the dataframe selection
-      trigger for a ``st.data_editor`` + checkbox column + explicit
-      button).
+  (a) Dialog auto-opens when exactly one row's ``View`` checkbox is
+      ticked (Epic #169 / #170 swapped the dataframe selection trigger
+      for a ``st.data_editor`` + labeled checkbox column that auto-opens
+      the dialog on tick).
   (b) Deep-link round-trip — setting `manage_users_pref_user_id` causes
       Manage Users to pre-populate `mu_selected_label` with the target user.
   (c) `role_can_see_query_details` returning False hides the SQL block and
@@ -383,11 +383,11 @@ class TestAgentLoggingDisabled:
     def test_disabled_mode_uses_dataframe_not_data_editor(self):
         """When `[agent_logging].mode = "disabled"`, the audit tab must
         render via the read-only ``st.dataframe`` branch and NOT call
-        ``st.data_editor`` — so there's no checkbox column and no
-        ``View Selected`` button, making the dialog unreachable
-        (defense in depth — disabled mode should produce no rows in the
-        first place). The read-only display must also drop the ``View``
-        column entirely (it would be a confusing always-False checkbox)."""
+        ``st.data_editor`` — so there's no checkbox column, making the
+        dialog unreachable (defense in depth — disabled mode should
+        produce no rows in the first place). The read-only display
+        must also drop the ``View`` column entirely (it would be a
+        confusing always-False checkbox)."""
         from views import admin_analytics
 
         dataframe_call_count = [0]
@@ -507,8 +507,8 @@ class TestAgentLoggingDisabled:
     def test_full_mode_uses_data_editor_with_view_checkbox_column(self):
         """When `[agent_logging].mode` is anything other than 'disabled'
         (default 'full'), the audit tab must call ``st.data_editor`` and
-        configure a leading ``View`` ``CheckboxColumn`` so the explicit
-        ``View Selected`` button workflow is wired up."""
+        configure a leading ``View`` ``CheckboxColumn`` so the
+        auto-open-on-tick workflow is wired up."""
         from views import admin_analytics
 
         captured_data_editor_kwargs: list[dict] = []
@@ -614,27 +614,28 @@ class TestAgentLoggingDisabled:
 
 
 # ---------------------------------------------------------------------------
-# (a) View Selected button opens the dialog; no click → no dialog
+# (a) Auto-open dialog on tick; 0 ticks → no dialog; sticky tick → no re-fire
 # ---------------------------------------------------------------------------
 
 
-def _make_questions_stub(*, view_column_values: list[bool], view_button_clicked: bool = False):
+def _make_questions_stub(*, view_column_values: list[bool], initial_session: dict | None = None):
     """Build a Streamlit stub for ``_render_audit_trail_tab`` that simulates
-    the new (Epic #169) data_editor + checkbox + View Selected button flow.
+    the new (Epic #169 / #170) data_editor + auto-open-on-tick flow.
 
     ``view_column_values`` controls which rows the user has 'checked' on
     the ``View`` column. The stub seeds those values back into ``edited_df``
     so the production code's ``edited_df[edited_df['View']]`` filter picks
     them up just like Streamlit would after a checkbox toggle.
 
-    ``view_button_clicked`` is True iff the test wants the
-    ``audit_questions_view_selected_btn`` to be 'clicked'.
+    ``initial_session`` seeds ``session_state`` — used by the "sticky
+    tick across reruns" tests to pre-populate
+    ``audit_dialog_open_user_message_id``.
     """
     import pandas as pd
 
     class _Stub:
         def __init__(self):
-            self.session_state = {}
+            self.session_state = dict(initial_session or {})
             self.secrets = {"agent_logging": {"mode": "full"}}
             self.components = MagicMock()
             self.components.v1 = MagicMock()
@@ -683,7 +684,9 @@ def _make_questions_stub(*, view_column_values: list[bool], view_button_clicked:
             pass
 
         def button(self, *_a, key=None, **_kw):
-            return bool(view_button_clicked) if key == "audit_questions_view_selected_btn" else False
+            # No button participates in the auto-open flow — Prev/Next/
+            # Export buttons still render but do nothing here.
+            return False
 
         def caption(self, *_a, **_kw):
             pass
@@ -719,20 +722,16 @@ def _make_questions_stub(*, view_column_values: list[bool], view_button_clicked:
 
 
 class TestSelectionStateTrigger:
-    def test_button_click_with_one_row_checked_opens_dialog(self):
-        """When exactly one row's View checkbox is checked AND the
-        View Selected button is clicked, the audit tab must set
-        ``audit_dialog_open_user_message_id`` and invoke the dialog
-        function for that row."""
+    def test_one_tick_auto_opens_dialog(self):
+        """When exactly one row's View checkbox is ticked, the audit tab
+        must set ``audit_dialog_open_user_message_id`` and auto-invoke
+        the dialog function for that row — no button click needed."""
         from views import admin_analytics
 
         item = _make_item(user_message_id=314)
         dialog_calls: list[dict] = []
 
-        stub, _pd = _make_questions_stub(
-            view_column_values=[True],
-            view_button_clicked=True,
-        )
+        stub, _pd = _make_questions_stub(view_column_values=[True])
 
         def _fake_dialog(passed_item):
             dialog_calls.append(passed_item)
@@ -753,20 +752,22 @@ class TestSelectionStateTrigger:
         ):
             admin_analytics._render_audit_trail_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked for the checked row's item"
+        assert dialog_calls == [item], "Dialog must be invoked for the ticked row's item"
         assert stub.session_state.get("audit_dialog_open_user_message_id") == 314
 
-    def test_no_button_click_does_not_open_dialog(self):
-        """If the user checks a row but never clicks View Selected, the
-        dialog must NOT open and no tracking key is set."""
+    def test_zero_ticks_does_not_open_dialog(self):
+        """If no row is ticked, the dialog must NOT open and the per-tab
+        ``open_id`` gate is cleared so the next tick of the same row will
+        reopen the dialog cleanly."""
         from views import admin_analytics
 
         item = _make_item(user_message_id=314)
 
-        # Row is checked, but button is NOT clicked.
+        # No row is ticked. Pre-populate the gate so we can assert it gets
+        # cleared (the "untick clears gate" half of the contract).
         stub, _pd = _make_questions_stub(
-            view_column_values=[True],
-            view_button_clicked=False,
+            view_column_values=[False],
+            initial_session={"audit_dialog_open_user_message_id": 314},
         )
 
         with (
@@ -786,4 +787,42 @@ class TestSelectionStateTrigger:
             admin_analytics._render_audit_trail_tab(30)
 
         dialog_mock.assert_not_called()
-        assert "audit_dialog_open_user_message_id" not in stub.session_state
+        assert "audit_dialog_open_user_message_id" not in stub.session_state, (
+            "Zero ticks must clear the open_id gate so the same row can be re-ticked"
+        )
+
+    def test_sticky_tick_across_rerun_does_not_refire(self):
+        """If the checkbox stays ticked between reruns (Streamlit
+        ``data_editor`` retains the True value) the dialog must NOT
+        re-fire — the per-tab gate stops it. Without the gate, every
+        rerun would trigger another dialog."""
+        from views import admin_analytics
+
+        item = _make_item(user_message_id=314)
+
+        # Row is still ticked, AND the gate already records this row as
+        # open from a prior rerun.
+        stub, _pd = _make_questions_stub(
+            view_column_values=[True],
+            initial_session={"audit_dialog_open_user_message_id": 314},
+        )
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(
+                admin_analytics,
+                "_cached_audit_filter_options",
+                return_value={"usernames": [], "orgs": []},
+            ),
+            patch.object(admin_analytics, "_render_audit_question_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_question_audit_page",
+                return_value={"items": [item], "total": 1},
+            ),
+            patch("orm.functions.get_all_users", return_value=[]),
+        ):
+            admin_analytics._render_audit_trail_tab(30)
+
+        dialog_mock.assert_not_called()
+        # Gate stays set to the same id (sticky tick).
+        assert stub.session_state.get("audit_dialog_open_user_message_id") == 314

--- a/tests/views/test_admin_audit_dialog_collision.py
+++ b/tests/views/test_admin_audit_dialog_collision.py
@@ -3,28 +3,23 @@
 Background
 ----------
 ``views/admin_audit.py:render`` builds an inner ``st.tabs`` with three child
-audit tabs (Questions, Admin Actions, User Activity). Each child renders its
-own ``st.dataframe(on_select="rerun", selection_mode="single-row")`` whose
-selection state persists across reruns in ``st.session_state``. Because
-``st.tabs`` evaluates *every* tab body on every rerun (not just the visible
-one), and Streamlit forbids more than one ``st.dialog`` call per script run,
-the prior pattern — where each tab unconditionally called
-``_render_X_dialog(selected_item)`` whenever ``selected_rows`` was non-empty —
-could fire two dialogs in the same rerun and raise:
+audit tabs (Questions, Admin Actions, User Activity). Epic #169 / #170
+swapped each tab's trigger primitive from
+``st.dataframe(on_select=..., selection_mode='single-row')`` to
+``st.data_editor`` + a leading ``View`` ``CheckboxColumn`` + an explicit
+``View Selected`` button. ``st.tabs`` still evaluates *every* tab body on
+every rerun, and Streamlit still forbids more than one ``st.dialog`` call
+per script run — so the cross-tab claim guard remains as defense in depth.
 
-    streamlit.errors.StreamlitAPIException:
-    Only one dialog is allowed to be opened at the same time.
-
-The fix introduces a per-rerun guard, ``_audit_dialog_claimed_this_rerun``:
+The per-rerun guard, ``_audit_dialog_claimed_this_rerun``:
 
 * ``views/admin_audit.py:render`` resets the flag to ``False`` at the top of
   every rerun, before ``st.tabs`` is created.
 * Each of the three tab dialog branches checks-and-sets the flag *inside*
-  the ``if open_id != selected_item[...]`` gate, so at most one tab opens
-  a dialog per rerun, and a row already opened in a prior rerun does not
-  reopen on subsequent reruns.
+  the View Selected button-click branch, so at most one tab opens a dialog
+  per rerun.
 
-These tests pin both behaviours.
+These tests pin both behaviours under the new (data_editor + button) flow.
 """
 
 from __future__ import annotations
@@ -101,27 +96,46 @@ class _SharedSessionStub:
     ``_audit_dialog_claimed_this_rerun`` lives on a SHARED ``session_state``
     dict — that's the whole point of the fix.
 
-    ``per_key_selections`` lets each tab's dataframe report a different
-    ``selected_rows`` value, keyed by the dataframe's ``key=`` kwarg.
+    Epic #169 / #170 changed the trigger primitive. Each tab now wires its
+    grid as ``st.data_editor`` + a ``View`` checkbox column, and opens its
+    dialog when the ``audit_<tab>_view_selected_btn`` button is clicked
+    with exactly one row's checkbox ticked.
+
+    ``per_key_view_checked`` lets each tab's data_editor seed the ``View``
+    column with a per-row list of booleans, keyed by the data_editor's
+    ``key=`` kwarg (one of ``audit_dataframe``, ``audit_actions_dataframe``,
+    ``audit_activity_dataframe``).
+    ``per_key_button_clicks`` lets each tab's View Selected button report
+    as 'clicked', keyed by the button's ``key=`` kwarg.
     """
+
+    # The View column key/value used by all three tabs.
+    _VIEW_COL = "View"
 
     def __init__(
         self,
         *,
-        per_key_selections: dict | None = None,
+        per_key_view_checked: dict | None = None,
+        per_key_button_clicks: dict | None = None,
         initial_session: dict | None = None,
         secrets: dict | None = None,
     ):
         self.session_state: dict = dict(initial_session or {})
-        self._per_key_selections = dict(per_key_selections or {})
+        self._per_key_view_checked = dict(per_key_view_checked or {})
+        self._per_key_button_clicks = dict(per_key_button_clicks or {})
         self.secrets = secrets if secrets is not None else {"agent_logging": {"mode": "full"}}
-        # The dataframe kwargs captured per call, for diagnostics.
-        self.captured_dataframe_kwargs: list[dict] = []
+        # The data_editor kwargs captured per call, for diagnostics.
+        self.captured_data_editor_kwargs: list[dict] = []
         # ``components.v1.html`` is invoked by the question dialog body; the
         # tab body itself does not hit it but we expose it for safety.
         self.components = MagicMock()
         self.components.v1 = MagicMock()
         self.components.v1.html = MagicMock()
+        # Real ``st.column_config`` is fine to expose as a Mock; the
+        # production tab calls ``st.column_config.CheckboxColumn(...)`` /
+        # ``TextColumn(...)`` purely to populate the ``column_config`` kwarg
+        # we don't introspect here.
+        self.column_config = MagicMock()
 
     # ---- Layout primitives -----------------------------------------------
     def tabs(self, _labels):
@@ -176,20 +190,26 @@ class _SharedSessionStub:
             self.session_state.setdefault(key, 1)
         return 1
 
-    def button(self, *_a, **_kw):
-        return False
+    def button(self, *_a, key=None, **_kw):
+        return bool(self._per_key_button_clicks.get(key, False))
 
     def download_button(self, *_a, **_kw):
         return False
 
     # ---- Output primitives ----------------------------------------------
-    def dataframe(self, _df, **kwargs):
-        self.captured_dataframe_kwargs.append(kwargs)
+    def data_editor(self, df, **kwargs):
+        self.captured_data_editor_kwargs.append(kwargs)
         key = kwargs.get("key")
-        rows = self._per_key_selections.get(key, [])
-        ev = MagicMock()
-        ev.selection = {"rows": list(rows)}
-        return ev
+        checks = self._per_key_view_checked.get(key, [])
+        out = df.copy()
+        if self._VIEW_COL in out.columns and checks:
+            vals = list(checks) + [False] * max(0, len(out) - len(checks))
+            out[self._VIEW_COL] = vals[: len(out)]
+        return out
+
+    def dataframe(self, _df, **_kwargs):
+        # Disabled-mode (read-only) branch + the Action Distribution table.
+        return MagicMock()
 
     def info(self, *_a, **_kw):
         pass
@@ -312,13 +332,13 @@ def _patches_for_render(
 
 class TestCrossTabCollision:
     def test_single_dialog_when_multiple_tabs_have_selections(self):
-        """Production repro: Questions tab has a lingering selection AND
-        Admin Actions tab has a lingering selection AND User Activity tab
-        has a lingering selection, all with tab-local ``open_id`` keys that
-        differ from the would-be selected items' ids. Without the fix, every
-        rerun fires two or three ``st.dialog`` calls and Streamlit raises.
+        """Production repro: Questions tab has row 0 checked AND clicks
+        View Selected AND Admin Actions tab has row 0 checked AND clicks
+        View Selected AND same for User Activity — all in the same rerun.
+        Without the cross-tab guard, every rerun would fire two or three
+        ``st.dialog`` calls and Streamlit would raise.
 
-        With the fix, exactly ONE dialog is invoked per rerun.
+        With the guard, exactly ONE dialog is invoked per rerun.
         """
         from views import admin_audit
 
@@ -326,15 +346,20 @@ class TestCrossTabCollision:
         a_item = _make_admin_action_item(id=271)
         u_item = _make_user_activity_item(id=42)
 
-        # All three tabs report a selected row 0; tab-local ``open_id`` keys
-        # are absent so the ``open_id != selected[id]`` guard would otherwise
-        # pass through to the dialog call in every tab.
+        # All three tabs have row 0 checked, AND all three tabs' View
+        # Selected buttons are 'clicked' simultaneously — that's the
+        # cross-tab collision the guard exists to prevent.
         stub = _SharedSessionStub(
-            per_key_selections={
-                "audit_dataframe": [0],
-                "audit_actions_dataframe": [0],
-                "audit_activity_dataframe": [0],
-            }
+            per_key_view_checked={
+                "audit_dataframe": [True],
+                "audit_actions_dataframe": [True],
+                "audit_activity_dataframe": [True],
+            },
+            per_key_button_clicks={
+                "audit_questions_view_selected_btn": True,
+                "audit_actions_view_selected_btn": True,
+                "audit_activity_view_selected_btn": True,
+            },
         )
 
         q_calls: list = []
@@ -373,16 +398,20 @@ class TestCrossTabCollision:
         )
 
     def test_same_row_reselection_does_not_reopen(self):
-        """If the Questions tab dataframe still reports the same selected row
-        whose ``user_message_id`` matches ``audit_dialog_open_user_message_id``
-        from a prior rerun, the dialog must NOT be re-fired. (Before the fix,
-        the dialog re-rendered on every rerun.)"""
+        """If the user has row 0 checked on the Questions tab but does
+        NOT click View Selected again, the dialog must NOT re-fire on
+        subsequent reruns. (Under the new explicit-button pattern the
+        dialog trigger is the button click event itself — Streamlit
+        button events are not sticky across reruns — so this is naturally
+        defensible, but we pin it.)"""
         from views import admin_audit
 
         q_item = _make_question_item(user_message_id=999)
 
         stub = _SharedSessionStub(
-            per_key_selections={"audit_dataframe": [0]},
+            per_key_view_checked={"audit_dataframe": [True]},
+            # No button click this rerun.
+            per_key_button_clicks={},
             # Same id already tracked — dialog was opened in a prior rerun.
             initial_session={"audit_dialog_open_user_message_id": 999},
         )
@@ -417,22 +446,23 @@ class TestCrossTabCollision:
 
     def test_guard_resets_per_rerun(self):
         """The cross-tab claim guard must be cleared at the top of every rerun.
-        Two consecutive ``render`` calls with NEW selections must each fire
-        exactly one dialog. (If the guard leaked across reruns, the second
-        rerun would silently drop the dialog.)"""
+        Two consecutive ``render`` calls in which the user re-clicks the
+        Questions tab's ``View Selected`` button must each fire exactly
+        one dialog. (If the guard leaked across reruns, the second rerun
+        would silently drop the dialog.)"""
         from views import admin_audit
 
-        # Two distinct Questions items across the two reruns. Same dataframe
-        # key, different ``user_message_id``s, so each rerun's selection is
-        # genuinely "new" relative to whatever the tab tracked previously.
+        # Two distinct Questions items across the two reruns. Same
+        # data_editor key, different ``user_message_id``s.
         q_item_1 = _make_question_item(user_message_id=111)
         q_item_2 = _make_question_item(user_message_id=222)
 
         # A single shared stub across both reruns so session_state persists,
-        # just like real Streamlit. Only the loader return values + selections
-        # differ between reruns.
+        # just like real Streamlit. Row 0 is checked in both reruns AND
+        # the View Selected button is 'clicked' in both reruns.
         stub = _SharedSessionStub(
-            per_key_selections={"audit_dataframe": [0]},
+            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_button_clicks={"audit_questions_view_selected_btn": True},
         )
 
         # ---- Rerun 1 -----------------------------------------------------
@@ -580,7 +610,8 @@ class TestCrossTabCollision:
         q_item = _make_question_item(user_message_id=1)
 
         stub = _SharedSessionStub(
-            per_key_selections={"audit_dataframe": [0]},
+            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_button_clicks={"audit_questions_view_selected_btn": True},
             initial_session={"_audit_dialog_claimed_this_rerun": True},
         )
 

--- a/tests/views/test_admin_audit_dialog_collision.py
+++ b/tests/views/test_admin_audit_dialog_collision.py
@@ -6,20 +6,22 @@ Background
 audit tabs (Questions, Admin Actions, User Activity). Epic #169 / #170
 swapped each tab's trigger primitive from
 ``st.dataframe(on_select=..., selection_mode='single-row')`` to
-``st.data_editor`` + a leading ``View`` ``CheckboxColumn`` + an explicit
-``View Selected`` button. ``st.tabs`` still evaluates *every* tab body on
-every rerun, and Streamlit still forbids more than one ``st.dialog`` call
-per script run — so the cross-tab claim guard remains as defense in depth.
+``st.data_editor`` + a leading labeled ``View`` ``CheckboxColumn`` that
+auto-opens the detail dialog when exactly one row is ticked.
+``st.tabs`` still evaluates *every* tab body on every rerun, and
+Streamlit still forbids more than one ``st.dialog`` call per script run
+— so the cross-tab claim guard remains as defense in depth.
 
 The per-rerun guard, ``_audit_dialog_claimed_this_rerun``:
 
 * ``views/admin_audit.py:render`` resets the flag to ``False`` at the top of
   every rerun, before ``st.tabs`` is created.
 * Each of the three tab dialog branches checks-and-sets the flag *inside*
-  the View Selected button-click branch, so at most one tab opens a dialog
-  per rerun.
+  the auto-open-on-tick branch, so at most one tab opens a dialog per
+  rerun.
 
-These tests pin both behaviours under the new (data_editor + button) flow.
+These tests pin both behaviours under the new (data_editor + auto-open)
+flow.
 """
 
 from __future__ import annotations
@@ -97,16 +99,13 @@ class _SharedSessionStub:
     dict — that's the whole point of the fix.
 
     Epic #169 / #170 changed the trigger primitive. Each tab now wires its
-    grid as ``st.data_editor`` + a ``View`` checkbox column, and opens its
-    dialog when the ``audit_<tab>_view_selected_btn`` button is clicked
-    with exactly one row's checkbox ticked.
+    grid as ``st.data_editor`` + a labeled ``View`` checkbox column, and
+    auto-opens its dialog when exactly one row's checkbox is ticked.
 
     ``per_key_view_checked`` lets each tab's data_editor seed the ``View``
     column with a per-row list of booleans, keyed by the data_editor's
     ``key=`` kwarg (one of ``audit_dataframe``, ``audit_actions_dataframe``,
     ``audit_activity_dataframe``).
-    ``per_key_button_clicks`` lets each tab's View Selected button report
-    as 'clicked', keyed by the button's ``key=`` kwarg.
     """
 
     # The View column key/value used by all three tabs.
@@ -116,13 +115,11 @@ class _SharedSessionStub:
         self,
         *,
         per_key_view_checked: dict | None = None,
-        per_key_button_clicks: dict | None = None,
         initial_session: dict | None = None,
         secrets: dict | None = None,
     ):
         self.session_state: dict = dict(initial_session or {})
         self._per_key_view_checked = dict(per_key_view_checked or {})
-        self._per_key_button_clicks = dict(per_key_button_clicks or {})
         self.secrets = secrets if secrets is not None else {"agent_logging": {"mode": "full"}}
         # The data_editor kwargs captured per call, for diagnostics.
         self.captured_data_editor_kwargs: list[dict] = []
@@ -191,7 +188,9 @@ class _SharedSessionStub:
         return 1
 
     def button(self, *_a, key=None, **_kw):
-        return bool(self._per_key_button_clicks.get(key, False))
+        # No button participates in the auto-open flow — Prev/Next/
+        # Export buttons still render but do nothing here.
+        return False
 
     def download_button(self, *_a, **_kw):
         return False
@@ -332,11 +331,11 @@ def _patches_for_render(
 
 class TestCrossTabCollision:
     def test_single_dialog_when_multiple_tabs_have_selections(self):
-        """Production repro: Questions tab has row 0 checked AND clicks
-        View Selected AND Admin Actions tab has row 0 checked AND clicks
-        View Selected AND same for User Activity — all in the same rerun.
-        Without the cross-tab guard, every rerun would fire two or three
-        ``st.dialog`` calls and Streamlit would raise.
+        """Production repro: Questions tab has row 0 ticked AND Admin
+        Actions tab has row 0 ticked AND User Activity tab has row 0
+        ticked — all in the same rerun. Without the cross-tab guard,
+        every rerun would fire two or three ``st.dialog`` calls and
+        Streamlit would raise.
 
         With the guard, exactly ONE dialog is invoked per rerun.
         """
@@ -346,19 +345,13 @@ class TestCrossTabCollision:
         a_item = _make_admin_action_item(id=271)
         u_item = _make_user_activity_item(id=42)
 
-        # All three tabs have row 0 checked, AND all three tabs' View
-        # Selected buttons are 'clicked' simultaneously — that's the
+        # All three tabs have row 0 ticked simultaneously — that's the
         # cross-tab collision the guard exists to prevent.
         stub = _SharedSessionStub(
             per_key_view_checked={
                 "audit_dataframe": [True],
                 "audit_actions_dataframe": [True],
                 "audit_activity_dataframe": [True],
-            },
-            per_key_button_clicks={
-                "audit_questions_view_selected_btn": True,
-                "audit_actions_view_selected_btn": True,
-                "audit_activity_view_selected_btn": True,
             },
         )
 
@@ -398,20 +391,18 @@ class TestCrossTabCollision:
         )
 
     def test_same_row_reselection_does_not_reopen(self):
-        """If the user has row 0 checked on the Questions tab but does
-        NOT click View Selected again, the dialog must NOT re-fire on
-        subsequent reruns. (Under the new explicit-button pattern the
-        dialog trigger is the button click event itself — Streamlit
-        button events are not sticky across reruns — so this is naturally
-        defensible, but we pin it.)"""
+        """If the user has row 0 ticked on the Questions tab AND the
+        per-tab ``open_id`` gate already records that row, the dialog
+        must NOT re-fire on subsequent reruns. This is the gating
+        behaviour added in the auto-open refactor — without it, every
+        rerun while the checkbox stayed ticked would re-fire the
+        dialog."""
         from views import admin_audit
 
         q_item = _make_question_item(user_message_id=999)
 
         stub = _SharedSessionStub(
             per_key_view_checked={"audit_dataframe": [True]},
-            # No button click this rerun.
-            per_key_button_clicks={},
             # Same id already tracked — dialog was opened in a prior rerun.
             initial_session={"audit_dialog_open_user_message_id": 999},
         )
@@ -445,24 +436,26 @@ class TestCrossTabCollision:
         assert u_calls == []
 
     def test_guard_resets_per_rerun(self):
-        """The cross-tab claim guard must be cleared at the top of every rerun.
-        Two consecutive ``render`` calls in which the user re-clicks the
-        Questions tab's ``View Selected`` button must each fire exactly
-        one dialog. (If the guard leaked across reruns, the second rerun
-        would silently drop the dialog.)"""
+        """The cross-tab claim guard must be cleared at the top of every
+        rerun. Two consecutive ``render`` calls in which the user ticks
+        the Questions tab's ``View`` checkbox on a different row each
+        time must each fire exactly one dialog. (If the guard leaked
+        across reruns, the second rerun would silently drop the dialog.)
+        """
         from views import admin_audit
 
         # Two distinct Questions items across the two reruns. Same
-        # data_editor key, different ``user_message_id``s.
+        # data_editor key, different ``user_message_id``s — so the
+        # per-tab ``open_id`` gate naturally allows the second rerun's
+        # dialog to fire (different id → different gate value).
         q_item_1 = _make_question_item(user_message_id=111)
         q_item_2 = _make_question_item(user_message_id=222)
 
         # A single shared stub across both reruns so session_state persists,
-        # just like real Streamlit. Row 0 is checked in both reruns AND
-        # the View Selected button is 'clicked' in both reruns.
+        # just like real Streamlit. Row 0 is ticked in both reruns; the
+        # second rerun's row has a different ``user_message_id``.
         stub = _SharedSessionStub(
             per_key_view_checked={"audit_dataframe": [True]},
-            per_key_button_clicks={"audit_questions_view_selected_btn": True},
         )
 
         # ---- Rerun 1 -----------------------------------------------------
@@ -611,7 +604,6 @@ class TestCrossTabCollision:
 
         stub = _SharedSessionStub(
             per_key_view_checked={"audit_dataframe": [True]},
-            per_key_button_clicks={"audit_questions_view_selected_btn": True},
             initial_session={"_audit_dialog_claimed_this_rerun": True},
         )
 

--- a/tests/views/test_audit_scope_filter.py
+++ b/tests/views/test_audit_scope_filter.py
@@ -52,7 +52,6 @@ def _make_stub(
     *,
     secrets_mode: str = "full",
     multiselect_returns: dict | None = None,
-    dataframe_returns_selection: bool = False,
     button_returns: dict | None = None,
     initial_session_state: dict | None = None,
 ):
@@ -63,13 +62,20 @@ def _make_stub(
     multiselect_returns : dict keyed by ``key=`` value. Lets tests inject
         the "user picked these" values without faking widget interaction.
     button_returns : dict keyed by ``key=`` value. Lets tests fire the CSV
-        export button on demand.
+        export button (``audit_export_btn``) or the View Selected button
+        (``audit_questions_view_selected_btn``) on demand.
+
+    Epic #169 / #170: the Questions audit grid is now ``st.data_editor``,
+    so ``table_rows`` are captured from ``data_editor(df, ...)`` rather
+    than ``dataframe(df, ...)``. The read-only ``st.dataframe`` branch
+    (agent_logging.mode = 'disabled') is also captured for completeness.
     """
 
     captured_multiselect_kwargs: list[dict] = []
     captured_table_rows: list[list[dict]] = []
     captured_download_kwargs: list[dict] = []
     captured_export_df: list[pd.DataFrame] = []
+    captured_data_editor_kwargs: list[dict] = []
 
     multiselect_returns = multiselect_returns or {}
     button_returns = button_returns or {}
@@ -82,6 +88,7 @@ def _make_stub(
             self.components = MagicMock()
             self.components.v1 = MagicMock()
             self.components.v1.html = MagicMock()
+            self.column_config = MagicMock()
 
         # -- widgets -------------------------------------------------------
         def multiselect(self, label, options=None, key=None, **kw):
@@ -120,18 +127,24 @@ def _make_stub(
             n = spec if isinstance(spec, int) else len(spec)
             return [MagicMock() for _ in range(n)]
 
-        def dataframe(self, df, **_kw):
+        def data_editor(self, df, **kw):
+            captured_data_editor_kwargs.append(kw)
             try:
                 captured_table_rows.append(df.to_dict(orient="records"))
             except Exception:
                 captured_table_rows.append([])
-            if dataframe_returns_selection:
-                ev = MagicMock()
-                ev.selection = {"rows": [0]}
-                return ev
-            ev = MagicMock()
-            ev.selection = {"rows": []}
-            return ev
+            # Return the DataFrame unchanged (no rows checked by default,
+            # so the View Selected button will be disabled and no dialog
+            # branch fires).
+            return df
+
+        def dataframe(self, df, **_kw):
+            # Disabled-mode read-only branch.
+            try:
+                captured_table_rows.append(df.to_dict(orient="records"))
+            except Exception:
+                captured_table_rows.append([])
+            return MagicMock()
 
         def info(self, *_a, **_kw):
             pass
@@ -185,6 +198,7 @@ def _make_stub(
         "table_rows": captured_table_rows,
         "download_kwargs": captured_download_kwargs,
         "export_df": captured_export_df,
+        "data_editor_kwargs": captured_data_editor_kwargs,
     }
 
 

--- a/tests/views/test_audit_scope_filter.py
+++ b/tests/views/test_audit_scope_filter.py
@@ -62,13 +62,14 @@ def _make_stub(
     multiselect_returns : dict keyed by ``key=`` value. Lets tests inject
         the "user picked these" values without faking widget interaction.
     button_returns : dict keyed by ``key=`` value. Lets tests fire the CSV
-        export button (``audit_export_btn``) or the View Selected button
-        (``audit_questions_view_selected_btn``) on demand.
+        export button (``audit_export_btn``) on demand.
 
-    Epic #169 / #170: the Questions audit grid is now ``st.data_editor``,
-    so ``table_rows`` are captured from ``data_editor(df, ...)`` rather
-    than ``dataframe(df, ...)``. The read-only ``st.dataframe`` branch
-    (agent_logging.mode = 'disabled') is also captured for completeness.
+    Epic #169 / #170: the Questions audit grid is now ``st.data_editor``
+    with a labeled ``View`` checkbox column that auto-opens the detail
+    dialog on tick (no button). ``table_rows`` are captured from
+    ``data_editor(df, ...)`` rather than ``dataframe(df, ...)``. The
+    read-only ``st.dataframe`` branch (agent_logging.mode = 'disabled')
+    is also captured for completeness.
     """
 
     captured_multiselect_kwargs: list[dict] = []
@@ -134,8 +135,7 @@ def _make_stub(
             except Exception:
                 captured_table_rows.append([])
             # Return the DataFrame unchanged (no rows checked by default,
-            # so the View Selected button will be disabled and no dialog
-            # branch fires).
+            # so the auto-open dialog branch does not fire).
             return df
 
         def dataframe(self, df, **_kw):

--- a/tests/views/test_audit_view_checkbox_column.py
+++ b/tests/views/test_audit_view_checkbox_column.py
@@ -1,0 +1,665 @@
+"""Tests for Epic #169 / Feature #170 — the labeled ``View`` checkbox
+column + ``View Selected`` action button shared by all three audit
+tables (Questions, Admin Actions, User Activity).
+
+Covers, parametrised across the 3 tabs where possible:
+
+  - The ``View`` column is configured as ``st.column_config.CheckboxColumn``
+    with the spec's label and help tooltip.
+  - All non-View data columns are configured with ``disabled=True``.
+  - The ``View Selected`` button is disabled when 0 or >1 rows are
+    checked, enabled with exactly 1; its tooltip when disabled equals
+    ``_VIEW_SELECTED_DISABLED_HELP``.
+  - Clicking the button with exactly one row checked invokes the
+    corresponding detail dialog with the matching row payload.
+  - CSV export for the Questions tab does NOT include the ``View``
+    column (it lives only in the on-screen ``edited_df``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders — one row matching each tab's loader shape
+# ---------------------------------------------------------------------------
+
+
+def _make_question_item(*, user_message_id: int = 1) -> dict:
+    return {
+        "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 7,
+        "username": "alice",
+        "organization": "Acme",
+        "question": "How many patients today?",
+        "sql_text": "SELECT count(*) FROM patient",
+        "status": "Success",
+        "elapsed_seconds": 1.0,
+        "summary_text": "12 patients.",
+        "dataframe_preview": None,
+        "error_text": None,
+        "user_message_id": user_message_id,
+        "scope": "Patient",
+    }
+
+
+def _make_admin_action_item(*, id: int = 1) -> dict:
+    return {
+        "id": id,
+        "created_at": datetime(2026, 6, 1, 12, 0, 0),
+        "admin_username": "alice_admin",
+        "action_type": "user_update",
+        "target_user_id": 42,
+        "target_username": "bob",
+        "target_entity_type": "user",
+        "target_entity_id": "42",
+        "description": "Updated bob's role",
+        "old_value": '{"role": "Patient"}',
+        "new_value": '{"role": "Doctor"}',
+        "affected_count": 1,
+        "success": True,
+        "error_message": None,
+    }
+
+
+def _make_user_activity_item(*, id: int = 1) -> dict:
+    return {
+        "id": id,
+        "created_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 9,
+        "username": "carol",
+        "activity_type": "settings_change",
+        "description": "Changed theme",
+        "old_value": None,
+        "new_value": None,
+        "ip_address": "127.0.0.1",
+        "user_agent": "Mozilla/5.0 Test",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-tab harness — wraps the three tab functions behind one interface so
+# the parametrised tests stay readable.
+# ---------------------------------------------------------------------------
+
+
+class _TabHarness:
+    """Encapsulates per-tab details (render function, item factory,
+    data_editor key, View Selected button key, dialog function name)
+    so the parametrised tests can drive any of the 3 audit tabs from
+    a single body."""
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        render_fn_name: str,
+        item_factory,
+        data_editor_key: str,
+        button_key: str,
+        dialog_attr: str,
+        loader_patches: list,
+    ):
+        self.label = label
+        self.render_fn_name = render_fn_name
+        self.item_factory = item_factory
+        self.data_editor_key = data_editor_key
+        self.button_key = button_key
+        self.dialog_attr = dialog_attr
+        self.loader_patches = loader_patches  # callable returning list of patchers
+
+    def __repr__(self) -> str:  # nicer pytest IDs
+        return self.label
+
+
+def _questions_loader_patches(items):
+    from views import admin_analytics
+
+    return [
+        patch.object(
+            admin_analytics,
+            "_cached_audit_filter_options",
+            return_value={"usernames": [], "orgs": []},
+        ),
+        patch(
+            "orm.logging_functions.get_question_audit_page",
+            return_value={"items": list(items), "total": len(items)},
+        ),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ]
+
+
+def _actions_loader_patches(items):
+    return [
+        patch(
+            "orm.logging_functions.get_admin_actions_page",
+            return_value={"items": list(items), "total": len(items)},
+        ),
+        patch(
+            "orm.logging_functions.get_admin_action_stats",
+            return_value={"total": 1, "user_changes": 0, "training_actions": 0, "failed": 0},
+        ),
+        patch("orm.logging_functions.get_admin_actions_by_type", return_value=[]),
+    ]
+
+
+def _activity_loader_patches(items):
+    return [
+        patch(
+            "orm.logging_functions.get_activity_stats",
+            return_value={
+                "logins_today": 0,
+                "failed_logins": 0,
+                "settings_changes": 0,
+                "unique_users": 0,
+            },
+        ),
+        patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+        patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+        patch(
+            "orm.logging_functions.get_user_activity_page",
+            return_value={"items": list(items), "total": len(items)},
+        ),
+    ]
+
+
+def _all_harnesses() -> list[_TabHarness]:
+    return [
+        _TabHarness(
+            label="questions",
+            render_fn_name="_render_audit_trail_tab",
+            item_factory=lambda i: _make_question_item(user_message_id=i),
+            data_editor_key="audit_dataframe",
+            button_key="audit_questions_view_selected_btn",
+            dialog_attr="_render_audit_question_dialog",
+            loader_patches=_questions_loader_patches,
+        ),
+        _TabHarness(
+            label="admin_actions",
+            render_fn_name="_render_audit_tab",
+            item_factory=lambda i: _make_admin_action_item(id=i),
+            data_editor_key="audit_actions_dataframe",
+            button_key="audit_actions_view_selected_btn",
+            dialog_attr="_render_admin_action_dialog",
+            loader_patches=_actions_loader_patches,
+        ),
+        _TabHarness(
+            label="user_activity",
+            render_fn_name="_render_activity_tab",
+            item_factory=lambda i: _make_user_activity_item(id=i),
+            data_editor_key="audit_activity_dataframe",
+            button_key="audit_activity_view_selected_btn",
+            dialog_attr="_render_user_activity_dialog",
+            loader_patches=_activity_loader_patches,
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Streamlit stub that records ``column_config`` args (CheckboxColumn /
+# TextColumn) so tests can introspect what the tab passed.
+# ---------------------------------------------------------------------------
+
+
+class _ColumnConfigCall:
+    """A captured ``st.column_config.<Kind>(label, **kwargs)`` call.
+    Mimics enough surface to flow through ``column_config={...}`` to
+    ``st.data_editor`` and back so tests can introspect it."""
+
+    def __init__(self, kind: str, args: tuple, kwargs: dict):
+        self.kind = kind
+        self.args = args
+        self.kwargs = kwargs
+
+    @property
+    def label(self):
+        if self.args:
+            return self.args[0]
+        return self.kwargs.get("label")
+
+    @property
+    def help(self):
+        return self.kwargs.get("help")
+
+    @property
+    def disabled(self) -> bool:
+        return bool(self.kwargs.get("disabled", False))
+
+
+class _ColumnConfig:
+    """Stand-in for ``st.column_config`` that records each
+    ``CheckboxColumn(...)`` / ``TextColumn(...)`` call."""
+
+    def __init__(self):
+        self.calls: list[_ColumnConfigCall] = []
+
+    def CheckboxColumn(self, *args, **kwargs):  # noqa: N802 — mirror Streamlit's name
+        call = _ColumnConfigCall("CheckboxColumn", args, kwargs)
+        self.calls.append(call)
+        return call
+
+    def TextColumn(self, *args, **kwargs):  # noqa: N802
+        call = _ColumnConfigCall("TextColumn", args, kwargs)
+        self.calls.append(call)
+        return call
+
+
+def _make_stub(
+    *,
+    view_column_values: list[bool] | None = None,
+    button_clicks: dict | None = None,
+    capture_button_kwargs: dict | None = None,
+):
+    """Build a streamlit stub for any of the three tab render functions.
+
+    ``view_column_values`` is the list of per-row checkbox values written
+    back into ``edited_df`` (simulating user toggles).
+    ``button_clicks`` is a dict keyed by button ``key=`` value; lets
+    tests fire any specific button on demand.
+    ``capture_button_kwargs`` (optional output dict): if passed, the
+    stub appends ``{label, key, kwargs}`` for every ``st.button(...)``
+    call into ``capture_button_kwargs["calls"]``.
+    """
+
+    button_clicks = button_clicks or {}
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.components = MagicMock()
+            self.components.v1 = MagicMock()
+            self.components.v1.html = MagicMock()
+            self.column_config = _ColumnConfig()
+            self.captured_data_editor_kwargs: list[dict] = []
+
+        # -- Layout / widgets ----------------------------------------------
+        def multiselect(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, [])
+            return []
+
+        def text_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, 1)
+            return 1
+
+        def columns(self, spec, **_kw):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None) for _ in range(n)]
+
+        def container(self, **_kw):
+            return MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None)
+
+        def metric(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def subheader(self, *_a, **_kw):
+            pass
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def text(self, *_a, **_kw):
+            pass
+
+        def json(self, *_a, **_kw):
+            pass
+
+        def plotly_chart(self, *_a, **_kw):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        # -- The two grid primitives ---------------------------------------
+        def data_editor(self, df, **kwargs):
+            self.captured_data_editor_kwargs.append(kwargs)
+            out = df.copy()
+            if "View" in out.columns and view_column_values:
+                vals = list(view_column_values) + [False] * max(0, len(out) - len(view_column_values))
+                out["View"] = vals[: len(out)]
+            return out
+
+        def dataframe(self, _df, **_kwargs):
+            return MagicMock()
+
+        # -- Buttons -------------------------------------------------------
+        def button(self, label="", key=None, **kwargs):
+            if capture_button_kwargs is not None:
+                capture_button_kwargs.setdefault("calls", []).append({"label": label, "key": key, "kwargs": kwargs})
+            return bool(button_clicks.get(key, False))
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        # -- Dialog decorator passthrough ----------------------------------
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub()
+
+
+def _run_tab(harness: _TabHarness, stub, item, dialog_recorder=None):
+    """Drive any tab's render function with the given stub, item, and
+    (optional) dialog spy. Centralises the common boilerplate."""
+    from views import admin_analytics
+
+    import contextlib
+
+    dialog_target = getattr(admin_analytics, harness.dialog_attr)
+    spy_kwargs = {}
+    if dialog_recorder is not None:
+        spy_kwargs["side_effect"] = dialog_recorder
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(admin_analytics, "st", stub))
+        stack.enter_context(patch.object(admin_analytics, harness.dialog_attr, **spy_kwargs))
+        for p in harness.loader_patches([item]):
+            stack.enter_context(p)
+        getattr(admin_analytics, harness.render_fn_name)(30)
+    return dialog_target
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — View column is a CheckboxColumn with the spec label + help
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_view_column_is_checkbox_column_with_label_and_help(harness):
+    """Every audit tab's data_editor must configure the leading ``View``
+    column as ``st.column_config.CheckboxColumn`` with ``label='View'``
+    and the spec's ``help`` tooltip."""
+    from views import admin_analytics
+
+    stub = _make_stub(view_column_values=[])
+    _run_tab(harness, stub, harness.item_factory(1))
+
+    assert stub.captured_data_editor_kwargs, f"Expected st.data_editor to be called on {harness.label}"
+    cc = stub.captured_data_editor_kwargs[0].get("column_config")
+    assert cc and "View" in cc, (
+        f"{harness.label}: column_config must include a 'View' entry; saw keys={list((cc or {}).keys())}"
+    )
+
+    view_call: _ColumnConfigCall = cc["View"]
+    assert view_call.kind == "CheckboxColumn", (
+        f"{harness.label}: View column must be a CheckboxColumn; saw {view_call.kind}"
+    )
+    assert view_call.label == "View", f"{harness.label}: View column label must equal 'View'"
+    assert view_call.help == admin_analytics._VIEW_COLUMN_HELP, (
+        f"{harness.label}: View column help must equal _VIEW_COLUMN_HELP"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — All non-View columns are disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_non_view_columns_are_disabled(harness):
+    """Every non-View entry in the data_editor's ``column_config`` must
+    carry ``disabled=True`` so admins can't accidentally edit audit data."""
+    stub = _make_stub(view_column_values=[])
+    _run_tab(harness, stub, harness.item_factory(1))
+
+    cc = stub.captured_data_editor_kwargs[0].get("column_config")
+    assert cc, f"{harness.label}: column_config must be passed to st.data_editor"
+    for col_name, call in cc.items():
+        if col_name == "View":
+            continue
+        assert call.disabled is True, f"{harness.label}: non-View column {col_name!r} must be disabled=True"
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — View Selected button enabled state (0 / 1 / many)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+@pytest.mark.parametrize(
+    "checked_count,expected_disabled",
+    [(0, True), (1, False), (2, True), (3, True)],
+    ids=["zero", "one", "two", "three"],
+)
+def test_view_selected_button_enabled_state(harness, checked_count, expected_disabled):
+    """``View Selected`` button is disabled when 0 or >1 rows are
+    checked; enabled when exactly 1 is checked. When disabled, the
+    button's ``help`` tooltip equals ``_VIEW_SELECTED_DISABLED_HELP``."""
+    from views import admin_analytics
+
+    # We need ``len(items)`` to equal ``checked_count`` worth of rows so
+    # the dataframe slot exists for each checkbox value. Pre-build enough
+    # items.
+    items = [harness.item_factory(i) for i in range(1, max(1, checked_count) + 1)]
+    view_vals = [True] * checked_count + [False] * (len(items) - checked_count)
+
+    button_kwargs_capture: dict = {}
+    stub = _make_stub(view_column_values=view_vals, capture_button_kwargs=button_kwargs_capture)
+
+    # Patch loader to return our pre-built items list, NOT just one row.
+    def _swap_loaders(_items):
+        return harness.loader_patches(items)
+
+    swapped = _TabHarness(
+        label=harness.label,
+        render_fn_name=harness.render_fn_name,
+        item_factory=harness.item_factory,
+        data_editor_key=harness.data_editor_key,
+        button_key=harness.button_key,
+        dialog_attr=harness.dialog_attr,
+        loader_patches=_swap_loaders,
+    )
+
+    _run_tab(swapped, stub, items[0])
+
+    # Find the View Selected button call by its key.
+    btn_calls = [c for c in button_kwargs_capture.get("calls", []) if c["key"] == harness.button_key]
+    assert btn_calls, (
+        f"{harness.label}: ``st.button({harness.button_key!r})`` was never called — "
+        "the View Selected button must always render below the data_editor"
+    )
+    call = btn_calls[0]
+    assert call["kwargs"].get("disabled") is expected_disabled, (
+        f"{harness.label} / checked={checked_count}: button disabled state mismatch; "
+        f"got disabled={call['kwargs'].get('disabled')}, expected {expected_disabled}"
+    )
+    if expected_disabled:
+        assert call["kwargs"].get("help") == admin_analytics._VIEW_SELECTED_DISABLED_HELP, (
+            f"{harness.label}: disabled-state tooltip must equal _VIEW_SELECTED_DISABLED_HELP"
+        )
+    # Label always equals _VIEW_SELECTED_BUTTON_LABEL.
+    assert call["label"] == admin_analytics._VIEW_SELECTED_BUTTON_LABEL
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — Button click with one row checked fires the dialog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_button_click_with_one_row_checked_invokes_dialog(harness):
+    """With exactly one ``View`` checkbox ticked and the View Selected
+    button clicked, the corresponding dialog function is invoked with
+    the matching row's payload."""
+    item = harness.item_factory(314)
+    dialog_recorder: list[dict] = []
+    stub = _make_stub(
+        view_column_values=[True],
+        button_clicks={harness.button_key: True},
+    )
+    _run_tab(harness, stub, item, dialog_recorder=dialog_recorder.append)
+
+    assert dialog_recorder == [item], (
+        f"{harness.label}: the dialog must be invoked exactly once with the checked row's item; "
+        f"got {len(dialog_recorder)} call(s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — CSV export DOES NOT include the View column (Questions tab)
+# ---------------------------------------------------------------------------
+
+
+def test_csv_export_does_not_include_view_column():
+    """The on-screen ``edited_df`` carries the ``View`` column (for the
+    checkbox), but the CSV export DataFrame must NOT — exports build
+    from a separate aggregator (``get_question_audit_export``). Each
+    table's export path is unchanged from PRs #135 / #167."""
+    from views import admin_analytics
+
+    # We render the Questions tab AND click ``audit_export_btn`` to
+    # cause the export DataFrame to be built and pushed through
+    # ``st.download_button``. The stub captures the CSV bytes so we can
+    # decode them and assert on columns.
+    captured_export_dfs: list[pd.DataFrame] = []
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {"user_role": 0}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.components = MagicMock()
+            self.components.v1 = MagicMock()
+            self.components.v1.html = MagicMock()
+            self.column_config = _ColumnConfig()
+
+        def multiselect(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, [])
+            return []
+
+        def text_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            if key:
+                self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            if key is not None:
+                self.session_state.setdefault(key, 1)
+            return 1
+
+        def columns(self, spec, **_kw):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def container(self, **_kw):
+            return MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None)
+
+        def divider(self):
+            pass
+
+        def subheader(self, *_a, **_kw):
+            pass
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def data_editor(self, df, **_kw):
+            # No rows checked — irrelevant for export.
+            return df
+
+        def dataframe(self, _df, **_kw):
+            return MagicMock()
+
+        def button(self, _label="", key=None, **_kw):
+            return key == "audit_export_btn"
+
+        def download_button(self, _label, data=None, **_kw):
+            from io import StringIO
+
+            try:
+                df = pd.read_csv(StringIO(data.decode("utf-8")))
+                captured_export_dfs.append(df)
+            except Exception:
+                pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    stub = _Stub()
+    page_payload = {"items": [_make_question_item(user_message_id=1)], "total": 1}
+    export_rows = [_make_question_item(user_message_id=1)]
+
+    with (
+        patch.object(admin_analytics, "st", stub),
+        patch.object(
+            admin_analytics,
+            "_cached_audit_filter_options",
+            return_value={"usernames": [], "orgs": []},
+        ),
+        patch("orm.logging_functions.get_question_audit_page", return_value=page_payload),
+        patch("orm.logging_functions.get_question_audit_export", return_value=export_rows),
+        patch("orm.functions.get_all_users", return_value=[]),
+    ):
+        admin_analytics._render_audit_trail_tab(30)
+
+    assert captured_export_dfs, "download_button data must have decoded as CSV"
+    df = captured_export_dfs[-1]
+    assert "View" not in df.columns, f"CSV export must NOT include the View column; saw columns={list(df.columns)}"

--- a/tests/views/test_audit_view_checkbox_column.py
+++ b/tests/views/test_audit_view_checkbox_column.py
@@ -1,17 +1,21 @@
 """Tests for Epic #169 / Feature #170 — the labeled ``View`` checkbox
-column + ``View Selected`` action button shared by all three audit
-tables (Questions, Admin Actions, User Activity).
+column shared by all three audit tables (Questions, Admin Actions, User
+Activity).
+
+Per the post-PR-#187 refactor (Feature #170), the trigger is **auto-open
+on tick**: ticking exactly one ``View`` checkbox opens the corresponding
+detail dialog immediately — there is no ``View Selected`` button.
 
 Covers, parametrised across the 3 tabs where possible:
 
   - The ``View`` column is configured as ``st.column_config.CheckboxColumn``
     with the spec's label and help tooltip.
   - All non-View data columns are configured with ``disabled=True``.
-  - The ``View Selected`` button is disabled when 0 or >1 rows are
-    checked, enabled with exactly 1; its tooltip when disabled equals
-    ``_VIEW_SELECTED_DISABLED_HELP``.
-  - Clicking the button with exactly one row checked invokes the
-    corresponding detail dialog with the matching row payload.
+  - Ticking exactly one row auto-fires the dialog with the matching row
+    payload; 0 and >1 ticks do NOT fire the dialog.
+  - With the per-tab ``open_id`` already set in ``session_state``,
+    re-rendering with the same row still ticked does NOT re-fire the
+    dialog (gate prevents re-fire on every rerun).
   - CSV export for the Questions tab does NOT include the ``View``
     column (it lives only in the on-screen ``edited_df``).
 """
@@ -90,9 +94,9 @@ def _make_user_activity_item(*, id: int = 1) -> dict:
 
 class _TabHarness:
     """Encapsulates per-tab details (render function, item factory,
-    data_editor key, View Selected button key, dialog function name)
-    so the parametrised tests can drive any of the 3 audit tabs from
-    a single body."""
+    data_editor key, dialog gate session key + id field, dialog function
+    name) so the parametrised tests can drive any of the 3 audit tabs
+    from a single body."""
 
     def __init__(
         self,
@@ -101,7 +105,8 @@ class _TabHarness:
         render_fn_name: str,
         item_factory,
         data_editor_key: str,
-        button_key: str,
+        dialog_id_key: str,
+        id_field: str,
         dialog_attr: str,
         loader_patches: list,
     ):
@@ -109,7 +114,8 @@ class _TabHarness:
         self.render_fn_name = render_fn_name
         self.item_factory = item_factory
         self.data_editor_key = data_editor_key
-        self.button_key = button_key
+        self.dialog_id_key = dialog_id_key
+        self.id_field = id_field
         self.dialog_attr = dialog_attr
         self.loader_patches = loader_patches  # callable returning list of patchers
 
@@ -175,7 +181,8 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_audit_trail_tab",
             item_factory=lambda i: _make_question_item(user_message_id=i),
             data_editor_key="audit_dataframe",
-            button_key="audit_questions_view_selected_btn",
+            dialog_id_key="audit_dialog_open_user_message_id",
+            id_field="user_message_id",
             dialog_attr="_render_audit_question_dialog",
             loader_patches=_questions_loader_patches,
         ),
@@ -184,7 +191,8 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_audit_tab",
             item_factory=lambda i: _make_admin_action_item(id=i),
             data_editor_key="audit_actions_dataframe",
-            button_key="audit_actions_view_selected_btn",
+            dialog_id_key="audit_actions_dialog_open_id",
+            id_field="id",
             dialog_attr="_render_admin_action_dialog",
             loader_patches=_actions_loader_patches,
         ),
@@ -193,7 +201,8 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_activity_tab",
             item_factory=lambda i: _make_user_activity_item(id=i),
             data_editor_key="audit_activity_dataframe",
-            button_key="audit_activity_view_selected_btn",
+            dialog_id_key="audit_activity_dialog_open_id",
+            id_field="id",
             dialog_attr="_render_user_activity_dialog",
             loader_patches=_activity_loader_patches,
         ),
@@ -252,25 +261,20 @@ class _ColumnConfig:
 def _make_stub(
     *,
     view_column_values: list[bool] | None = None,
-    button_clicks: dict | None = None,
-    capture_button_kwargs: dict | None = None,
+    initial_session: dict | None = None,
 ):
     """Build a streamlit stub for any of the three tab render functions.
 
     ``view_column_values`` is the list of per-row checkbox values written
     back into ``edited_df`` (simulating user toggles).
-    ``button_clicks`` is a dict keyed by button ``key=`` value; lets
-    tests fire any specific button on demand.
-    ``capture_button_kwargs`` (optional output dict): if passed, the
-    stub appends ``{label, key, kwargs}`` for every ``st.button(...)``
-    call into ``capture_button_kwargs["calls"]``.
+    ``initial_session`` seeds the stub's ``session_state`` dict — used
+    by the "checkbox stays ticked across rerun" tests to pre-populate
+    the tab's ``open_id`` gate.
     """
-
-    button_clicks = button_clicks or {}
 
     class _Stub:
         def __init__(self):
-            self.session_state = {}
+            self.session_state = dict(initial_session or {})
             self.secrets = {"agent_logging": {"mode": "full"}}
             self.components = MagicMock()
             self.components.v1 = MagicMock()
@@ -361,9 +365,10 @@ def _make_stub(
 
         # -- Buttons -------------------------------------------------------
         def button(self, label="", key=None, **kwargs):
-            if capture_button_kwargs is not None:
-                capture_button_kwargs.setdefault("calls", []).append({"label": label, "key": key, "kwargs": kwargs})
-            return bool(button_clicks.get(key, False))
+            # No buttons participate in the auto-open flow anymore. The
+            # Prev/Next/Export buttons still render — we just return False
+            # so they do nothing.
+            return False
 
         def download_button(self, *_a, **_kw):
             pass
@@ -451,32 +456,72 @@ def test_non_view_columns_are_disabled(harness):
 
 
 # ---------------------------------------------------------------------------
-# Test 3 — View Selected button enabled state (0 / 1 / many)
+# Test 3 — Auto-open: exactly one tick fires the dialog
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
-@pytest.mark.parametrize(
-    "checked_count,expected_disabled",
-    [(0, True), (1, False), (2, True), (3, True)],
-    ids=["zero", "one", "two", "three"],
-)
-def test_view_selected_button_enabled_state(harness, checked_count, expected_disabled):
-    """``View Selected`` button is disabled when 0 or >1 rows are
-    checked; enabled when exactly 1 is checked. When disabled, the
-    button's ``help`` tooltip equals ``_VIEW_SELECTED_DISABLED_HELP``."""
-    from views import admin_analytics
+def test_one_tick_auto_opens_dialog(harness):
+    """With exactly one ``View`` checkbox ticked the corresponding
+    dialog function is auto-invoked with the matching row's payload —
+    no button click is needed."""
+    item = harness.item_factory(314)
+    dialog_recorder: list[dict] = []
+    stub = _make_stub(view_column_values=[True])
+    _run_tab(harness, stub, item, dialog_recorder=dialog_recorder.append)
 
-    # We need ``len(items)`` to equal ``checked_count`` worth of rows so
-    # the dataframe slot exists for each checkbox value. Pre-build enough
-    # items.
-    items = [harness.item_factory(i) for i in range(1, max(1, checked_count) + 1)]
-    view_vals = [True] * checked_count + [False] * (len(items) - checked_count)
+    assert dialog_recorder == [item], (
+        f"{harness.label}: ticking exactly one row must auto-fire the dialog; got {len(dialog_recorder)} call(s)"
+    )
+    # The per-tab open_id gate must be set to the row's id so subsequent
+    # reruns don't re-fire the dialog while the checkbox stays ticked.
+    assert stub.session_state.get(harness.dialog_id_key) == item[harness.id_field]
 
-    button_kwargs_capture: dict = {}
-    stub = _make_stub(view_column_values=view_vals, capture_button_kwargs=button_kwargs_capture)
 
-    # Patch loader to return our pre-built items list, NOT just one row.
+# ---------------------------------------------------------------------------
+# Test 4 — Zero ticks: no dialog, gate cleared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_zero_ticks_does_not_open_dialog(harness):
+    """No rows ticked → the dialog must not fire. The per-tab gate is
+    also cleared so a subsequent tick of the same row reopens the
+    dialog cleanly."""
+    item = harness.item_factory(7)
+    dialog_recorder: list[dict] = []
+    stub = _make_stub(
+        view_column_values=[False],
+        # Pre-populate the gate to verify it gets cleared on zero ticks.
+        initial_session={harness.dialog_id_key: item[harness.id_field]},
+    )
+    _run_tab(harness, stub, item, dialog_recorder=dialog_recorder.append)
+
+    assert dialog_recorder == [], (
+        f"{harness.label}: zero ticks must NOT open the dialog; got {len(dialog_recorder)} call(s)"
+    )
+    assert harness.dialog_id_key not in stub.session_state, (
+        f"{harness.label}: zero ticks must clear the {harness.dialog_id_key!r} gate so the "
+        "same row can be re-ticked to reopen the dialog"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — Multi-tick: no dialog fires
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+@pytest.mark.parametrize("n_checked", [2, 3], ids=["two", "three"])
+def test_multi_tick_does_not_open_dialog(harness, n_checked):
+    """More than one row ticked → no dialog fires. User must untick the
+    extras down to exactly one for the dialog to open."""
+    items = [harness.item_factory(i) for i in range(1, n_checked + 1)]
+    view_vals = [True] * n_checked
+    dialog_recorder: list[dict] = []
+
+    stub = _make_stub(view_column_values=view_vals)
+
     def _swap_loaders(_items):
         return harness.loader_patches(items)
 
@@ -485,58 +530,100 @@ def test_view_selected_button_enabled_state(harness, checked_count, expected_dis
         render_fn_name=harness.render_fn_name,
         item_factory=harness.item_factory,
         data_editor_key=harness.data_editor_key,
-        button_key=harness.button_key,
+        dialog_id_key=harness.dialog_id_key,
+        id_field=harness.id_field,
         dialog_attr=harness.dialog_attr,
         loader_patches=_swap_loaders,
     )
 
-    _run_tab(swapped, stub, items[0])
+    _run_tab(swapped, stub, items[0], dialog_recorder=dialog_recorder.append)
 
-    # Find the View Selected button call by its key.
-    btn_calls = [c for c in button_kwargs_capture.get("calls", []) if c["key"] == harness.button_key]
-    assert btn_calls, (
-        f"{harness.label}: ``st.button({harness.button_key!r})`` was never called — "
-        "the View Selected button must always render below the data_editor"
+    assert dialog_recorder == [], (
+        f"{harness.label}: {n_checked} ticks must NOT open the dialog; got {len(dialog_recorder)} call(s)"
     )
-    call = btn_calls[0]
-    assert call["kwargs"].get("disabled") is expected_disabled, (
-        f"{harness.label} / checked={checked_count}: button disabled state mismatch; "
-        f"got disabled={call['kwargs'].get('disabled')}, expected {expected_disabled}"
-    )
-    if expected_disabled:
-        assert call["kwargs"].get("help") == admin_analytics._VIEW_SELECTED_DISABLED_HELP, (
-            f"{harness.label}: disabled-state tooltip must equal _VIEW_SELECTED_DISABLED_HELP"
-        )
-    # Label always equals _VIEW_SELECTED_BUTTON_LABEL.
-    assert call["label"] == admin_analytics._VIEW_SELECTED_BUTTON_LABEL
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — Button click with one row checked fires the dialog
+# Test 6 — Checkbox stays ticked across rerun: dialog does NOT re-fire
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
-def test_button_click_with_one_row_checked_invokes_dialog(harness):
-    """With exactly one ``View`` checkbox ticked and the View Selected
-    button clicked, the corresponding dialog function is invoked with
-    the matching row's payload."""
-    item = harness.item_factory(314)
+def test_checkbox_stays_ticked_across_rerun_does_not_refire(harness):
+    """If the checkbox stays ticked between reruns (Streamlit
+    ``data_editor`` retains the row's True value) the dialog must NOT
+    re-fire — the per-tab ``open_id`` gate stops it. This is the
+    critical regression: without the gate, every rerun would trigger
+    another dialog."""
+    item = harness.item_factory(42)
     dialog_recorder: list[dict] = []
+
+    # Simulate "the dialog was already opened in a prior rerun" by
+    # pre-populating the per-tab gate. The checkbox is still ticked.
     stub = _make_stub(
         view_column_values=[True],
-        button_clicks={harness.button_key: True},
+        initial_session={harness.dialog_id_key: item[harness.id_field]},
     )
     _run_tab(harness, stub, item, dialog_recorder=dialog_recorder.append)
 
-    assert dialog_recorder == [item], (
-        f"{harness.label}: the dialog must be invoked exactly once with the checked row's item; "
-        f"got {len(dialog_recorder)} call(s)"
+    assert dialog_recorder == [], (
+        f"{harness.label}: with the per-tab gate already set to this row's id and the "
+        "checkbox still ticked, the dialog must NOT re-fire on this rerun. "
+        f"Got {len(dialog_recorder)} unwanted call(s)."
     )
+    # Gate stays set to the same id.
+    assert stub.session_state.get(harness.dialog_id_key) == item[harness.id_field]
 
 
 # ---------------------------------------------------------------------------
-# Test 5 — CSV export DOES NOT include the View column (Questions tab)
+# Test 7 — Untick then re-tick reopens the dialog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_untick_then_retick_reopens_dialog(harness):
+    """Rerun A: row ticked → dialog opens, gate set. Rerun B: row
+    unticked → gate cleared. Rerun C: row re-ticked → dialog opens
+    again. This is what "Allow re-ticking the same row to reopen" in
+    the spec means."""
+    item = harness.item_factory(99)
+
+    # Rerun A — row ticked, fresh session.
+    a_calls: list = []
+    stub_a = _make_stub(view_column_values=[True])
+    _run_tab(harness, stub_a, item, dialog_recorder=a_calls.append)
+    assert a_calls == [item], f"{harness.label}: rerun A must open the dialog"
+    assert stub_a.session_state.get(harness.dialog_id_key) == item[harness.id_field]
+
+    # Rerun B — row unticked. Carry session_state forward. The cross-tab
+    # claim flag is reset by ``admin_audit.render`` in production at the
+    # top of every rerun, before the inner ``st.tabs`` evaluate; we
+    # simulate that here by dropping it on each new rerun.
+    b_session = dict(stub_a.session_state)
+    b_session.pop("_audit_dialog_claimed_this_rerun", None)
+    b_calls: list = []
+    stub_b = _make_stub(
+        view_column_values=[False],
+        initial_session=b_session,
+    )
+    _run_tab(harness, stub_b, item, dialog_recorder=b_calls.append)
+    assert b_calls == [], f"{harness.label}: rerun B (unticked) must not fire"
+    assert harness.dialog_id_key not in stub_b.session_state, f"{harness.label}: untick must clear the gate"
+
+    # Rerun C — row re-ticked.
+    c_session = dict(stub_b.session_state)
+    c_session.pop("_audit_dialog_claimed_this_rerun", None)
+    c_calls: list = []
+    stub_c = _make_stub(
+        view_column_values=[True],
+        initial_session=c_session,
+    )
+    _run_tab(harness, stub_c, item, dialog_recorder=c_calls.append)
+    assert c_calls == [item], f"{harness.label}: rerun C (re-ticked after untick) must reopen the dialog"
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — CSV export DOES NOT include the View column (Questions tab)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/views/test_audit_view_checkbox_column.py
+++ b/tests/views/test_audit_view_checkbox_column.py
@@ -105,6 +105,7 @@ class _TabHarness:
         render_fn_name: str,
         item_factory,
         data_editor_key: str,
+        prev_view_checks_key: str,
         dialog_id_key: str,
         id_field: str,
         dialog_attr: str,
@@ -114,6 +115,7 @@ class _TabHarness:
         self.render_fn_name = render_fn_name
         self.item_factory = item_factory
         self.data_editor_key = data_editor_key
+        self.prev_view_checks_key = prev_view_checks_key
         self.dialog_id_key = dialog_id_key
         self.id_field = id_field
         self.dialog_attr = dialog_attr
@@ -181,6 +183,7 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_audit_trail_tab",
             item_factory=lambda i: _make_question_item(user_message_id=i),
             data_editor_key="audit_dataframe",
+            prev_view_checks_key="audit_questions_prev_view_checks",
             dialog_id_key="audit_dialog_open_user_message_id",
             id_field="user_message_id",
             dialog_attr="_render_audit_question_dialog",
@@ -191,6 +194,7 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_audit_tab",
             item_factory=lambda i: _make_admin_action_item(id=i),
             data_editor_key="audit_actions_dataframe",
+            prev_view_checks_key="audit_actions_prev_view_checks",
             dialog_id_key="audit_actions_dialog_open_id",
             id_field="id",
             dialog_attr="_render_admin_action_dialog",
@@ -201,6 +205,7 @@ def _all_harnesses() -> list[_TabHarness]:
             render_fn_name="_render_activity_tab",
             item_factory=lambda i: _make_user_activity_item(id=i),
             data_editor_key="audit_activity_dataframe",
+            prev_view_checks_key="audit_activity_prev_view_checks",
             dialog_id_key="audit_activity_dialog_open_id",
             id_field="id",
             dialog_attr="_render_user_activity_dialog",
@@ -281,6 +286,7 @@ def _make_stub(
             self.components.v1.html = MagicMock()
             self.column_config = _ColumnConfig()
             self.captured_data_editor_kwargs: list[dict] = []
+            self.rerun = MagicMock()
 
         # -- Layout / widgets ----------------------------------------------
         def multiselect(self, *_a, key=None, **_kw):
@@ -530,6 +536,7 @@ def test_multi_tick_does_not_open_dialog(harness, n_checked):
         render_fn_name=harness.render_fn_name,
         item_factory=harness.item_factory,
         data_editor_key=harness.data_editor_key,
+        prev_view_checks_key=harness.prev_view_checks_key,
         dialog_id_key=harness.dialog_id_key,
         id_field=harness.id_field,
         dialog_attr=harness.dialog_attr,
@@ -750,3 +757,150 @@ def test_csv_export_does_not_include_view_column():
     assert captured_export_dfs, "download_button data must have decoded as CSV"
     df = captured_export_dfs[-1]
     assert "View" not in df.columns, f"CSV export must NOT include the View column; saw columns={list(df.columns)}"
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — Single-select enforcement (multi-tick auto-unticks older rows)
+# ---------------------------------------------------------------------------
+
+
+def _build_multi_item_harness(harness, items):
+    """Clone ``harness`` so its loader returns ``items`` (multi-row case).
+    Mirrors the swap pattern from ``test_multi_tick_does_not_open_dialog``.
+    """
+
+    def _swap_loaders(_items):
+        return harness.loader_patches(items)
+
+    return _TabHarness(
+        label=harness.label,
+        render_fn_name=harness.render_fn_name,
+        item_factory=harness.item_factory,
+        data_editor_key=harness.data_editor_key,
+        prev_view_checks_key=harness.prev_view_checks_key,
+        dialog_id_key=harness.dialog_id_key,
+        id_field=harness.id_field,
+        dialog_attr=harness.dialog_attr,
+        loader_patches=_swap_loaders,
+    )
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_two_ticks_unticks_older_row_and_reruns(harness):
+    """User had row 1 ticked. They tick row 2 as well. Single-select
+    enforcement must:
+    (a) clear row 1's ``View`` entry from the data_editor's widget-state
+        ``edited_rows`` (so the next render shows row 1 as unticked),
+    (b) call ``st.rerun()`` exactly once,
+    (c) NOT open any dialog on this rerun — the dialog opens on the NEXT
+        rerun when ``checked_count == 1`` is true again.
+    """
+    items = [harness.item_factory(i) for i in range(1, 4)]  # 3 rows
+    swapped = _build_multi_item_harness(harness, items)
+
+    initial_session = {
+        harness.prev_view_checks_key: [1],
+        harness.data_editor_key: {
+            "edited_rows": {1: {"View": True}, 2: {"View": True}},
+        },
+    }
+
+    calls: list = []
+    stub = _make_stub(
+        view_column_values=[False, True, True],
+        initial_session=initial_session,
+    )
+    _run_tab(swapped, stub, items[0], dialog_recorder=calls.append)
+
+    edited_rows = stub.session_state[harness.data_editor_key].get("edited_rows", {})
+    # Row 1 (older tick) must be cleared.
+    assert "View" not in edited_rows.get(1, {}), (
+        f"{harness.label}: row 1 (older tick) must be removed from edited_rows; saw edited_rows={edited_rows!r}"
+    )
+    # Row 2 (newer tick) must be preserved.
+    assert edited_rows.get(2, {}).get("View") is True, f"{harness.label}: row 2 (newer tick) must remain in edited_rows"
+
+    stub.rerun.assert_called_once()
+    assert calls == [], (
+        f"{harness.label}: multi-tick rerun must not open dialog "
+        f"(dialog opens on the NEXT rerun once edits are reflected)"
+    )
+
+    # ``prev_view_checks`` is updated to the kept row.
+    assert stub.session_state.get(harness.prev_view_checks_key) == [2], (
+        f"{harness.label}: prev_view_checks must reflect the kept row"
+    )
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_three_ticks_keeps_a_newly_checked_row(harness):
+    """User had row 0 ticked previously. They add ticks on rows 1 and 2
+    in the same interaction (now 3 total). Enforcement keeps one newly-
+    checked row and unticks the older row 0."""
+    items = [harness.item_factory(i) for i in range(1, 4)]  # 3 rows
+    swapped = _build_multi_item_harness(harness, items)
+
+    initial_session = {
+        harness.prev_view_checks_key: [0],
+        harness.data_editor_key: {
+            "edited_rows": {
+                0: {"View": True},
+                1: {"View": True},
+                2: {"View": True},
+            },
+        },
+    }
+
+    calls: list = []
+    stub = _make_stub(
+        view_column_values=[True, True, True],
+        initial_session=initial_session,
+    )
+    _run_tab(swapped, stub, items[0], dialog_recorder=calls.append)
+
+    edited_rows = stub.session_state[harness.data_editor_key].get("edited_rows", {})
+    # Row 0 (only prev-checked row) must be cleared.
+    assert "View" not in edited_rows.get(0, {}), (
+        f"{harness.label}: row 0 (only prev-checked) must be cleared; saw edited_rows={edited_rows!r}"
+    )
+    # At least one of {1, 2} must remain (the keeper).
+    remaining = [idx for idx in (1, 2) if edited_rows.get(idx, {}).get("View") is True]
+    assert remaining, f"{harness.label}: at least one newly-checked row must remain; saw edited_rows={edited_rows!r}"
+
+    stub.rerun.assert_called_once()
+    assert calls == []
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_single_tick_does_not_trigger_rerun(harness):
+    """Sanity check: the new enforcement block is a no-op when only one
+    row is ticked. ``st.rerun()`` must NOT be called and the dialog must
+    open normally."""
+    item = harness.item_factory(99)
+
+    calls: list = []
+    stub = _make_stub(view_column_values=[True])
+    _run_tab(harness, stub, item, dialog_recorder=calls.append)
+
+    stub.rerun.assert_not_called()
+    assert calls == [item]
+    assert stub.session_state.get(harness.prev_view_checks_key) == [0]
+
+
+@pytest.mark.parametrize("harness", _all_harnesses(), ids=lambda h: h.label)
+def test_zero_ticks_resets_prev_view_checks_to_empty(harness):
+    """When the user unticks everything, ``prev_view_checks`` resets to
+    the empty list so a subsequent single tick is treated as fresh."""
+    item = harness.item_factory(99)
+
+    initial_session = {harness.prev_view_checks_key: [1]}
+    calls: list = []
+    stub = _make_stub(
+        view_column_values=[False, False, False],
+        initial_session=initial_session,
+    )
+    _run_tab(harness, stub, item, dialog_recorder=calls.append)
+
+    stub.rerun.assert_not_called()
+    assert calls == []
+    assert stub.session_state.get(harness.prev_view_checks_key) == []

--- a/tests/views/test_user_activity_dialog.py
+++ b/tests/views/test_user_activity_dialog.py
@@ -423,17 +423,18 @@ def _activity_tab_stub_class():
     Returns the class so tests can mutate per-test behaviour.
 
     Epic #169 / Feature #170: the trigger primitive is now
-    ``st.data_editor`` + ``View`` ``CheckboxColumn`` + ``View Selected``
-    button. ``view_column_values`` controls which rows are 'checked'
-    and ``view_button_clicked`` fires the button.
+    ``st.data_editor`` + labeled ``View`` ``CheckboxColumn`` that auto-
+    opens the dialog when exactly one row is ticked.
+    ``view_column_values`` controls which rows are 'checked'.
+    ``initial_session`` seeds ``session_state`` — used to pre-populate
+    ``audit_activity_dialog_open_id`` for the sticky-tick tests.
     """
 
     class _Stub:
-        def __init__(self, *, view_column_values=None, view_button_clicked=False, initial_session=None):
+        def __init__(self, *, view_column_values=None, initial_session=None):
             self.session_state = dict(initial_session or {})
             self.captured_data_editor_kwargs: list[dict] = []
             self._view_column_values = list(view_column_values or [])
-            self._view_button_clicked = bool(view_button_clicked)
             self.components = MagicMock()
             self.components.v1 = MagicMock()
             self.components.v1.html = MagicMock()
@@ -484,7 +485,9 @@ def _activity_tab_stub_class():
             pass
 
         def button(self, *_a, key=None, **_kw):
-            return self._view_button_clicked if key == "audit_activity_view_selected_btn" else False
+            # No button participates in the auto-open flow — Prev/Next
+            # buttons still render but do nothing here.
+            return False
 
         def caption(self, *_a, **_kw):
             pass
@@ -558,15 +561,16 @@ class TestActivityTabSelectionTrigger:
             f"Expected a 'View' entry in column_config; saw keys={list((cc or {}).keys())}"
         )
 
-    def test_button_click_with_one_row_checked_opens_dialog(self):
-        """With exactly one View checkbox ticked AND the View Selected
-        button clicked, ``audit_activity_dialog_open_id`` is set and the
-        dialog is invoked with the corresponding item."""
+    def test_one_tick_auto_opens_dialog(self):
+        """With exactly one View checkbox ticked,
+        ``audit_activity_dialog_open_id`` is set and the dialog is
+        auto-invoked with the corresponding item — no button click
+        needed."""
         from views import admin_analytics
 
         item = _make_item(id=777)
         Stub = _activity_tab_stub_class()
-        stub = Stub(view_column_values=[True], view_button_clicked=True)
+        stub = Stub(view_column_values=[True])
         dialog_calls: list[dict] = []
 
         def _fake_dialog(passed_item):
@@ -593,18 +597,22 @@ class TestActivityTabSelectionTrigger:
         ):
             admin_analytics._render_activity_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked with the checked row's item"
+        assert dialog_calls == [item], "Dialog must be invoked with the ticked row's item"
         assert stub.session_state.get("audit_activity_dialog_open_id") == 777
 
-    def test_no_button_click_does_not_open_dialog(self):
-        """Checking the box without clicking View Selected must NOT open
-        the dialog."""
+    def test_zero_ticks_does_not_open_dialog(self):
+        """No row ticked → no dialog. The per-tab ``open_id`` gate is
+        also cleared so the same row can be re-ticked to reopen the
+        dialog."""
         from views import admin_analytics
 
         item = _make_item(id=777)
         Stub = _activity_tab_stub_class()
-        # Row checked, button not clicked.
-        stub = Stub(view_column_values=[True], view_button_clicked=False)
+        # No row checked. Pre-populate the gate to verify it gets cleared.
+        stub = Stub(
+            view_column_values=[False],
+            initial_session={"audit_activity_dialog_open_id": 777},
+        )
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -628,7 +636,47 @@ class TestActivityTabSelectionTrigger:
             admin_analytics._render_activity_tab(30)
 
         dialog_mock.assert_not_called()
-        assert "audit_activity_dialog_open_id" not in stub.session_state
+        assert "audit_activity_dialog_open_id" not in stub.session_state, (
+            "Zero ticks must clear the open_id gate so the same row can be re-ticked"
+        )
+
+    def test_sticky_tick_across_rerun_does_not_refire(self):
+        """If the checkbox stays ticked between reruns the dialog must
+        NOT re-fire — the per-tab gate stops it."""
+        from views import admin_analytics
+
+        item = _make_item(id=777)
+        Stub = _activity_tab_stub_class()
+        # Row still ticked, gate already records this row.
+        stub = Stub(
+            view_column_values=[True],
+            initial_session={"audit_activity_dialog_open_id": 777},
+        )
+
+        with (
+            patch.object(admin_analytics, "st", stub),
+            patch.object(admin_analytics, "_render_user_activity_dialog") as dialog_mock,
+            patch(
+                "orm.logging_functions.get_activity_stats",
+                return_value={
+                    "logins_today": 0,
+                    "failed_logins": 0,
+                    "settings_changes": 0,
+                    "unique_users": 0,
+                },
+            ),
+            patch("orm.logging_functions.get_activity_over_time", return_value=[]),
+            patch("orm.logging_functions.get_activity_by_type", return_value=[]),
+            patch(
+                "orm.logging_functions.get_user_activity_page",
+                return_value={"items": [item], "total": 1},
+            ),
+        ):
+            admin_analytics._render_activity_tab(30)
+
+        dialog_mock.assert_not_called()
+        # Gate stays set to the same id (sticky tick).
+        assert stub.session_state.get("audit_activity_dialog_open_id") == 777
 
 
 # ---------------------------------------------------------------------------

--- a/tests/views/test_user_activity_dialog.py
+++ b/tests/views/test_user_activity_dialog.py
@@ -420,17 +420,24 @@ class TestDeepLinkRoundTrip:
 def _activity_tab_stub_class():
     """Build a Streamlit stub for ``_render_activity_tab`` testing.
 
-    Returns the class so tests can mutate per-test behaviour (e.g.
-    different `selected_rows`)."""
+    Returns the class so tests can mutate per-test behaviour.
+
+    Epic #169 / Feature #170: the trigger primitive is now
+    ``st.data_editor`` + ``View`` ``CheckboxColumn`` + ``View Selected``
+    button. ``view_column_values`` controls which rows are 'checked'
+    and ``view_button_clicked`` fires the button.
+    """
 
     class _Stub:
-        def __init__(self, *, selected_rows=None, initial_session=None):
+        def __init__(self, *, view_column_values=None, view_button_clicked=False, initial_session=None):
             self.session_state = dict(initial_session or {})
-            self.captured_dataframe_kwargs: list[dict] = []
-            self._selected_rows = list(selected_rows or [])
+            self.captured_data_editor_kwargs: list[dict] = []
+            self._view_column_values = list(view_column_values or [])
+            self._view_button_clicked = bool(view_button_clicked)
             self.components = MagicMock()
             self.components.v1 = MagicMock()
             self.components.v1.html = MagicMock()
+            self.column_config = MagicMock()
 
         def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
             opts = list(options or [])
@@ -462,17 +469,22 @@ def _activity_tab_stub_class():
                 cols.append(cm)
             return cols
 
-        def dataframe(self, _df, **kwargs):
-            self.captured_dataframe_kwargs.append(kwargs)
-            ev = MagicMock()
-            ev.selection = {"rows": list(self._selected_rows)}
-            return ev
+        def data_editor(self, df, **kwargs):
+            self.captured_data_editor_kwargs.append(kwargs)
+            out = df.copy()
+            if "View" in out.columns and self._view_column_values:
+                vals = list(self._view_column_values) + [False] * max(0, len(out) - len(self._view_column_values))
+                out["View"] = vals[: len(out)]
+            return out
+
+        def dataframe(self, _df, **_kwargs):
+            return MagicMock()
 
         def info(self, *_a, **_kw):
             pass
 
-        def button(self, *_a, **_kw):
-            return False
+        def button(self, *_a, key=None, **_kw):
+            return self._view_button_clicked if key == "audit_activity_view_selected_btn" else False
 
         def caption(self, *_a, **_kw):
             pass
@@ -508,15 +520,15 @@ def _activity_tab_stub_class():
 
 
 class TestActivityTabSelectionTrigger:
-    def test_dataframe_uses_single_row_selection_primitive(self):
-        """The activity grid must use the trigger primitive locked in by #155:
-        ``selection_mode='single-row'`` + ``on_select='rerun'`` +
-        ``key='audit_activity_dataframe'``."""
+    def test_data_editor_wired_with_view_checkbox_column(self):
+        """The activity grid must use the Epic #169 / #170 trigger
+        primitive: ``st.data_editor`` + leading ``View``
+        ``CheckboxColumn`` + a stable key (``audit_activity_dataframe``)."""
         from views import admin_analytics
 
         item = _make_item(id=999)
         Stub = _activity_tab_stub_class()
-        stub = Stub(selected_rows=[])
+        stub = Stub(view_column_values=[])
 
         with (
             patch.object(admin_analytics, "st", stub),
@@ -538,20 +550,23 @@ class TestActivityTabSelectionTrigger:
         ):
             admin_analytics._render_activity_tab(30)
 
-        assert stub.captured_dataframe_kwargs, "Expected st.dataframe to be called"
-        kw = stub.captured_dataframe_kwargs[0]
-        assert kw.get("selection_mode") == "single-row"
-        assert kw.get("on_select") == "rerun"
+        assert stub.captured_data_editor_kwargs, "Expected st.data_editor to be called"
+        kw = stub.captured_data_editor_kwargs[0]
         assert kw.get("key") == "audit_activity_dataframe"
+        cc = kw.get("column_config")
+        assert cc is not None and "View" in cc, (
+            f"Expected a 'View' entry in column_config; saw keys={list((cc or {}).keys())}"
+        )
 
-    def test_row_selection_opens_dialog_and_sets_state(self):
-        """When a row is selected, ``audit_activity_dialog_open_id`` is set and
-        the dialog function is invoked with the corresponding item."""
+    def test_button_click_with_one_row_checked_opens_dialog(self):
+        """With exactly one View checkbox ticked AND the View Selected
+        button clicked, ``audit_activity_dialog_open_id`` is set and the
+        dialog is invoked with the corresponding item."""
         from views import admin_analytics
 
         item = _make_item(id=777)
         Stub = _activity_tab_stub_class()
-        stub = Stub(selected_rows=[0])
+        stub = Stub(view_column_values=[True], view_button_clicked=True)
         dialog_calls: list[dict] = []
 
         def _fake_dialog(passed_item):
@@ -578,20 +593,18 @@ class TestActivityTabSelectionTrigger:
         ):
             admin_analytics._render_activity_tab(30)
 
-        assert dialog_calls == [item], "Dialog must be invoked with the selected row's item"
+        assert dialog_calls == [item], "Dialog must be invoked with the checked row's item"
         assert stub.session_state.get("audit_activity_dialog_open_id") == 777
 
-    def test_no_selection_clears_dialog_state_key(self):
-        """Clearing the selection removes ``audit_activity_dialog_open_id`` so
-        re-selecting the same row reopens the dialog."""
+    def test_no_button_click_does_not_open_dialog(self):
+        """Checking the box without clicking View Selected must NOT open
+        the dialog."""
         from views import admin_analytics
 
         item = _make_item(id=777)
         Stub = _activity_tab_stub_class()
-        stub = Stub(
-            selected_rows=[],
-            initial_session={"audit_activity_dialog_open_id": 777},
-        )
+        # Row checked, button not clicked.
+        stub = Stub(view_column_values=[True], view_button_clicked=False)
 
         with (
             patch.object(admin_analytics, "st", stub),

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -38,6 +38,16 @@ logger = get_logger(__name__)
 # Cache TTL for analytics queries (5 minutes)
 ANALYTICS_CACHE_TTL_SECONDS = 300
 
+# Epic #169 / Feature #170: shared copy for the labeled View checkbox column
+# and the View Selected action button used on all three audit tables
+# (Questions, Admin Actions, User Activity). Keeping these as module-level
+# constants ensures the three sites stay literally identical and gives the
+# tests a single string to assert against.
+_VIEW_COLUMN_LABEL = "View"
+_VIEW_COLUMN_HELP = "Select a row and click 'View Selected' to open the detail dialog"
+_VIEW_SELECTED_BUTTON_LABEL = "👁 View Selected"
+_VIEW_SELECTED_DISABLED_HELP = "Select exactly one row to view detail"
+
 
 def _kpi_card(label: str, value, help_text: str | None = None):
     """Render a KPI card with label, value, and optional help text."""
@@ -501,10 +511,11 @@ def _render_audit_question_dialog_body(item: dict) -> None:
 def _render_audit_question_dialog(item: dict) -> None:
     """`@st.dialog`-decorated wrapper invoked from `_render_audit_trail_tab`.
 
-    Subsystems #156 and #157 must adopt the same trigger primitive
-    (`st.dataframe(on_select="rerun", selection_mode="single-row")` + dialog
-    body invoked on selection state change). See Epic #154 Architecture
-    Considerations.
+    Epic #169 / Feature #170 swapped the trigger primitive from
+    ``st.dataframe(on_select=..., selection_mode='single-row')`` to a
+    ``st.data_editor`` + ``CheckboxColumn`` + explicit ``View Selected``
+    button. Subsystems #156 and #157 adopt the same pattern. See Epic #169
+    Architecture Considerations.
     """
     _render_audit_question_dialog_body(item)
 
@@ -603,14 +614,23 @@ def _render_audit_trail_tab(days_int: int):
     total = int(result.get("total", 0))
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
-    # Table — single-row selection trigger replaces the per-row expander list
-    # (Epic #154 architecture: selection state is one widget read at page_size=200,
-    # vs. 200 button widgets per refresh; load-bearing for #156/#157).
+    # Table — Epic #169 / Feature #170 swaps the prior single-row selection
+    # trigger (``st.dataframe(on_select=..., selection_mode='single-row')``)
+    # for a manual ``st.data_editor`` + leading ``CheckboxColumn`` + explicit
+    # ``View Selected`` action button. The training-table pattern at
+    # ``views/admin_training.py:55-88`` is the reference implementation.
+    # Streamlit's row-selection widget can't be labeled via ``column_config``
+    # because it's a frontend element, not a data column. A manual boolean
+    # data column gives us a labeled header + help tooltip — the
+    # discoverability win the Epic exists to deliver.
     if items:
         table_rows = []
         for it in items:
             table_rows.append(
                 {
+                    # ``View`` is the leading checkbox column; only this one
+                    # column is editable, all others are ``disabled=True``.
+                    _VIEW_COLUMN_LABEL: False,
                     "Asked At": it["asked_at"],
                     "User": it["username"],
                     "Organization": it.get("organization") or "(no org)",
@@ -625,50 +645,63 @@ def _render_audit_trail_tab(days_int: int):
             )
 
         if selection_enabled:
-            event = st.dataframe(
+            edited_df = st.data_editor(
                 pd.DataFrame(table_rows),
                 width="stretch",
                 hide_index=True,
-                on_select="rerun",
-                selection_mode="single-row",
+                num_rows="fixed",
                 key="audit_dataframe",
+                column_config={
+                    _VIEW_COLUMN_LABEL: st.column_config.CheckboxColumn(
+                        _VIEW_COLUMN_LABEL,
+                        help=_VIEW_COLUMN_HELP,
+                        default=False,
+                        width="small",
+                    ),
+                    "Asked At": st.column_config.TextColumn("Asked At", disabled=True),
+                    "User": st.column_config.TextColumn("User", disabled=True),
+                    "Organization": st.column_config.TextColumn("Organization", disabled=True),
+                    "Question": st.column_config.TextColumn("Question", disabled=True),
+                    "SQL": st.column_config.TextColumn("SQL", disabled=True),
+                    "Status": st.column_config.TextColumn("Status", disabled=True),
+                    "Scope": st.column_config.TextColumn("Scope", disabled=True),
+                    "Elapsed (s)": st.column_config.TextColumn("Elapsed (s)", disabled=True),
+                },
             )
-            selected_rows = []
-            try:
-                selected_rows = (event.selection or {}).get("rows", []) if event else []
-            except AttributeError:
-                # Some versions return a dict-like; fall back gracefully.
-                try:
-                    selected_rows = (event or {}).get("selection", {}).get("rows", [])
-                except Exception:
-                    selected_rows = []
 
-            if selected_rows:
-                row_idx = int(selected_rows[0])
+            try:
+                checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+            except Exception:
+                checked = pd.DataFrame()
+
+            checked_count = len(checked)
+            btn_disabled = checked_count != 1
+            if st.button(
+                _VIEW_SELECTED_BUTTON_LABEL,
+                disabled=btn_disabled,
+                help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
+                key="audit_questions_view_selected_btn",
+            ):
+                # Exactly one row checked — look it up and open the dialog.
+                # The cross-tab claim guard from PR #168 stays in place
+                # (defense-in-depth: ``st.tabs`` evaluates every tab body
+                # each rerun, and Streamlit forbids more than one
+                # ``st.dialog`` call per script run).
+                row_idx = int(checked.index[0])
                 if 0 <= row_idx < len(items):
                     selected_item = items[row_idx]
-                    open_id = st.session_state.get("audit_dialog_open_user_message_id")
-                    if open_id != selected_item["user_message_id"]:
-                        # NEW selection — claim the per-rerun dialog slot and open.
-                        # ``st.tabs`` runs every tab body each rerun and each tab has its
-                        # own persisted dataframe selection, so without the cross-tab
-                        # guard two tabs could both call ``st.dialog`` in the same script
-                        # run, which Streamlit forbids. Same-id reselection across reruns
-                        # short-circuits at the outer ``if`` and does NOT reopen.
-                        if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                            st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                            st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
-                            _render_audit_question_dialog(selected_item)
-            else:
-                # Dataframe selection cleared (e.g. clicking the row again) — reset our
-                # tracking key so re-selecting the same row reopens the dialog.
-                if "audit_dialog_open_user_message_id" in st.session_state:
-                    del st.session_state["audit_dialog_open_user_message_id"]
+                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                        st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
+                        _render_audit_question_dialog(selected_item)
         else:
             # agent_logging.mode == "disabled": render the table read-only;
-            # selection trigger and dialog branch are short-circuited.
+            # no editor and no action button — the dialog is unreachable.
+            # Drop the ``View`` column entry from each row so the read-only
+            # display doesn't carry a meaningless checkbox column.
+            readonly_rows = [{k: v for k, v in row.items() if k != _VIEW_COLUMN_LABEL} for row in table_rows]
             st.dataframe(
-                pd.DataFrame(table_rows),
+                pd.DataFrame(readonly_rows),
                 width="stretch",
                 hide_index=True,
                 key="audit_dataframe",
@@ -972,9 +1005,9 @@ def _render_user_activity_dialog_body(item: dict) -> None:
 def _render_user_activity_dialog(item: dict) -> None:
     """``@st.dialog``-decorated wrapper invoked from ``_render_activity_tab``.
 
-    Mirrors the trigger primitive locked in by #155 (Epic #154 Architecture
-    Considerations): ``st.dataframe(on_select="rerun",
-    selection_mode="single-row")`` opens this dialog when a row is selected.
+    Epic #169 / Feature #170 swapped the trigger primitive to
+    ``st.data_editor`` + a ``CheckboxColumn`` + an explicit
+    ``View Selected`` button. See Epic #169 Architecture Considerations.
     """
     _render_user_activity_dialog_body(item)
 
@@ -1072,8 +1105,12 @@ def _render_activity_tab(days_int: int):
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
     if items:
+        # Epic #169 / Feature #170: same data_editor + CheckboxColumn +
+        # View Selected button pattern as the Questions tab. See the
+        # ``_render_audit_trail_tab`` comments for the full rationale.
         table_rows = [
             {
+                _VIEW_COLUMN_LABEL: False,
                 "Timestamp": it["created_at"],
                 "User": it.get("username") or "(unknown)",
                 "Type": it.get("activity_type"),
@@ -1082,43 +1119,47 @@ def _render_activity_tab(days_int: int):
             }
             for it in items
         ]
-        event = st.dataframe(
+        edited_df = st.data_editor(
             pd.DataFrame(table_rows),
             width="stretch",
             hide_index=True,
-            on_select="rerun",
-            selection_mode="single-row",
+            num_rows="fixed",
             key="audit_activity_dataframe",
+            column_config={
+                _VIEW_COLUMN_LABEL: st.column_config.CheckboxColumn(
+                    _VIEW_COLUMN_LABEL,
+                    help=_VIEW_COLUMN_HELP,
+                    default=False,
+                    width="small",
+                ),
+                "Timestamp": st.column_config.TextColumn("Timestamp", disabled=True),
+                "User": st.column_config.TextColumn("User", disabled=True),
+                "Type": st.column_config.TextColumn("Type", disabled=True),
+                "Description": st.column_config.TextColumn("Description", disabled=True),
+                "IP Address": st.column_config.TextColumn("IP Address", disabled=True),
+            },
         )
-        selected_rows = []
-        try:
-            selected_rows = (event.selection or {}).get("rows", []) if event else []
-        except AttributeError:
-            # Some versions return a dict-like; fall back gracefully.
-            try:
-                selected_rows = (event or {}).get("selection", {}).get("rows", [])
-            except Exception:
-                selected_rows = []
 
-        if selected_rows:
-            row_idx = int(selected_rows[0])
+        try:
+            checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+        except Exception:
+            checked = pd.DataFrame()
+
+        checked_count = len(checked)
+        btn_disabled = checked_count != 1
+        if st.button(
+            _VIEW_SELECTED_BUTTON_LABEL,
+            disabled=btn_disabled,
+            help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
+            key="audit_activity_view_selected_btn",
+        ):
+            row_idx = int(checked.index[0])
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
-                open_id = st.session_state.get("audit_activity_dialog_open_id")
-                if open_id != selected_item["id"]:
-                    # NEW selection — claim the per-rerun dialog slot and open. See the
-                    # Questions tab branch above for the rationale: ``st.tabs`` evaluates
-                    # every tab body each rerun, so the cross-tab guard prevents two
-                    # tabs from both calling ``st.dialog`` in the same script run.
-                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                        st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
-                        _render_user_activity_dialog(selected_item)
-        else:
-            # Selection cleared — reset tracking key so re-selecting the same
-            # row reopens the dialog.
-            if "audit_activity_dialog_open_id" in st.session_state:
-                del st.session_state["audit_activity_dialog_open_id"]
+                if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                    st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
+                    _render_user_activity_dialog(selected_item)
     else:
         st.info("No recent activity found.")
 
@@ -1238,9 +1279,10 @@ def _render_admin_action_dialog_body(item: dict) -> None:
 def _render_admin_action_dialog(item: dict) -> None:
     """``@st.dialog``-decorated wrapper invoked from ``_render_audit_tab``.
 
-    Uses the same trigger primitive as the Questions tab (#155): a
-    ``st.dataframe(on_select="rerun", selection_mode="single-row")``
-    selection-state change opens this dialog. See Epic #154.
+    Uses the same trigger primitive as the Questions tab: Epic #169 /
+    Feature #170's ``st.data_editor`` + ``CheckboxColumn`` + explicit
+    ``View Selected`` button. Clicking the button with exactly one row
+    checked opens this dialog. See Epic #169.
     """
     _render_admin_action_dialog_body(item)
 
@@ -1332,12 +1374,16 @@ def _render_audit_tab(days_int: int):
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
     if items:
+        # Epic #169 / Feature #170: data_editor + CheckboxColumn + View
+        # Selected button — see ``_render_audit_trail_tab`` for the full
+        # rationale.
         table_rows = []
         for it in items:
             ts = it.get("created_at")
             ts_str = ts.strftime("%Y-%m-%d %H:%M:%S") if hasattr(ts, "strftime") else str(ts or "")
             table_rows.append(
                 {
+                    _VIEW_COLUMN_LABEL: False,
                     "Time": ts_str,
                     "Admin": it.get("admin_username") or "Unknown",
                     "Action Type": it.get("action_type") or "",
@@ -1347,43 +1393,48 @@ def _render_audit_tab(days_int: int):
                 }
             )
 
-        event = st.dataframe(
+        edited_df = st.data_editor(
             pd.DataFrame(table_rows),
             width="stretch",
             hide_index=True,
-            on_select="rerun",
-            selection_mode="single-row",
+            num_rows="fixed",
             key="audit_actions_dataframe",
+            column_config={
+                _VIEW_COLUMN_LABEL: st.column_config.CheckboxColumn(
+                    _VIEW_COLUMN_LABEL,
+                    help=_VIEW_COLUMN_HELP,
+                    default=False,
+                    width="small",
+                ),
+                "Time": st.column_config.TextColumn("Time", disabled=True),
+                "Admin": st.column_config.TextColumn("Admin", disabled=True),
+                "Action Type": st.column_config.TextColumn("Action Type", disabled=True),
+                "Target": st.column_config.TextColumn("Target", disabled=True),
+                "Description": st.column_config.TextColumn("Description", disabled=True),
+                "Status": st.column_config.TextColumn("Status", disabled=True),
+            },
         )
 
-        selected_rows = []
         try:
-            selected_rows = (event.selection or {}).get("rows", []) if event else []
-        except AttributeError:
-            try:
-                selected_rows = (event or {}).get("selection", {}).get("rows", [])
-            except Exception:
-                selected_rows = []
+            checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+        except Exception:
+            checked = pd.DataFrame()
 
-        if selected_rows:
-            row_idx = int(selected_rows[0])
+        checked_count = len(checked)
+        btn_disabled = checked_count != 1
+        if st.button(
+            _VIEW_SELECTED_BUTTON_LABEL,
+            disabled=btn_disabled,
+            help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
+            key="audit_actions_view_selected_btn",
+        ):
+            row_idx = int(checked.index[0])
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
-                open_id = st.session_state.get("audit_actions_dialog_open_id")
-                if open_id != selected_item["id"]:
-                    # NEW selection — claim the per-rerun dialog slot and open. See the
-                    # Questions tab branch in ``_render_audit_trail_tab`` for the full
-                    # rationale: Streamlit forbids two ``st.dialog`` calls per script
-                    # run and ``st.tabs`` evaluates every tab body each rerun.
-                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                        st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
-                        _render_admin_action_dialog(selected_item)
-        else:
-            # Selection cleared — drop the tracking key so re-selecting the
-            # same row reopens the dialog.
-            if "audit_actions_dialog_open_id" in st.session_state:
-                del st.session_state["audit_actions_dialog_open_id"]
+                if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                    st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
+                    _render_admin_action_dialog(selected_item)
     else:
         st.info("No admin actions in the selected time range.")
 

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -670,13 +670,40 @@ def _render_audit_trail_tab(days_int: int):
             )
 
             try:
-                checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+                current_checked = [int(i) for i in edited_df.index[edited_df[_VIEW_COLUMN_LABEL]].tolist()]
             except Exception:
-                checked = pd.DataFrame()
+                current_checked = []
 
-            checked_count = len(checked)
+            # Single-select enforcement. The ``CheckboxColumn`` natively
+            # allows multi-tick; we want radio-button semantics with
+            # checkbox aesthetics. When the user ticks a new row while
+            # another is already ticked, untick the older one(s) by
+            # mutating ``data_editor``'s widget state at
+            # ``st.session_state["audit_dataframe"]["edited_rows"]`` and
+            # ``st.rerun()`` so the next render reflects the single tick.
+            prev_checked = list(st.session_state.get("audit_questions_prev_view_checks", []))
+            if len(current_checked) > 1:
+                newly_checked = [i for i in current_checked if i not in prev_checked]
+                keep_idx = newly_checked[0] if newly_checked else current_checked[0]
+                editor_state = st.session_state.get("audit_dataframe")
+                if isinstance(editor_state, dict):
+                    edited_rows = editor_state.setdefault("edited_rows", {})
+                    for idx in current_checked:
+                        if idx == keep_idx:
+                            continue
+                        row_edits = edited_rows.get(idx)
+                        if isinstance(row_edits, dict) and _VIEW_COLUMN_LABEL in row_edits:
+                            del row_edits[_VIEW_COLUMN_LABEL]
+                            if not row_edits:
+                                del edited_rows[idx]
+                st.session_state["audit_questions_prev_view_checks"] = [keep_idx]
+                st.rerun()
+            else:
+                st.session_state["audit_questions_prev_view_checks"] = current_checked
+
+            checked_count = len(current_checked)
             if checked_count == 1:
-                row_idx = int(checked.index[0])
+                row_idx = current_checked[0]
                 if 0 <= row_idx < len(items):
                     selected_item = items[row_idx]
                     # Auto-open: dialog fires when exactly one row is
@@ -695,8 +722,6 @@ def _render_audit_trail_tab(days_int: int):
                 # Allow re-ticking the same row to reopen the dialog by
                 # clearing the gate.
                 st.session_state.pop("audit_dialog_open_user_message_id", None)
-            # checked_count > 1: multi-select, no dialog fires. User must
-            # untick extras.
         else:
             # agent_logging.mode == "disabled": render the table read-only;
             # no editor and no action button — the dialog is unreachable.
@@ -1145,13 +1170,37 @@ def _render_activity_tab(days_int: int):
         )
 
         try:
-            checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+            current_checked = [int(i) for i in edited_df.index[edited_df[_VIEW_COLUMN_LABEL]].tolist()]
         except Exception:
-            checked = pd.DataFrame()
+            current_checked = []
 
-        checked_count = len(checked)
+        # Single-select enforcement (see Questions tab block for the full
+        # rationale). Mutate ``data_editor``'s widget state to untick the
+        # older row(s) and ``st.rerun()`` so the next render reflects the
+        # single tick.
+        prev_checked = list(st.session_state.get("audit_activity_prev_view_checks", []))
+        if len(current_checked) > 1:
+            newly_checked = [i for i in current_checked if i not in prev_checked]
+            keep_idx = newly_checked[0] if newly_checked else current_checked[0]
+            editor_state = st.session_state.get("audit_activity_dataframe")
+            if isinstance(editor_state, dict):
+                edited_rows = editor_state.setdefault("edited_rows", {})
+                for idx in current_checked:
+                    if idx == keep_idx:
+                        continue
+                    row_edits = edited_rows.get(idx)
+                    if isinstance(row_edits, dict) and _VIEW_COLUMN_LABEL in row_edits:
+                        del row_edits[_VIEW_COLUMN_LABEL]
+                        if not row_edits:
+                            del edited_rows[idx]
+            st.session_state["audit_activity_prev_view_checks"] = [keep_idx]
+            st.rerun()
+        else:
+            st.session_state["audit_activity_prev_view_checks"] = current_checked
+
+        checked_count = len(current_checked)
         if checked_count == 1:
-            row_idx = int(checked.index[0])
+            row_idx = current_checked[0]
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
                 # Auto-open: dialog fires when exactly one row is ticked.
@@ -1169,8 +1218,6 @@ def _render_activity_tab(days_int: int):
             # Allow re-ticking the same row to reopen the dialog by
             # clearing the gate.
             st.session_state.pop("audit_activity_dialog_open_id", None)
-        # checked_count > 1: multi-select, no dialog fires. User must
-        # untick extras.
     else:
         st.info("No recent activity found.")
 
@@ -1427,13 +1474,37 @@ def _render_audit_tab(days_int: int):
         )
 
         try:
-            checked = edited_df[edited_df[_VIEW_COLUMN_LABEL]]
+            current_checked = [int(i) for i in edited_df.index[edited_df[_VIEW_COLUMN_LABEL]].tolist()]
         except Exception:
-            checked = pd.DataFrame()
+            current_checked = []
 
-        checked_count = len(checked)
+        # Single-select enforcement (see Questions tab block for the full
+        # rationale). Mutate ``data_editor``'s widget state to untick the
+        # older row(s) and ``st.rerun()`` so the next render reflects the
+        # single tick.
+        prev_checked = list(st.session_state.get("audit_actions_prev_view_checks", []))
+        if len(current_checked) > 1:
+            newly_checked = [i for i in current_checked if i not in prev_checked]
+            keep_idx = newly_checked[0] if newly_checked else current_checked[0]
+            editor_state = st.session_state.get("audit_actions_dataframe")
+            if isinstance(editor_state, dict):
+                edited_rows = editor_state.setdefault("edited_rows", {})
+                for idx in current_checked:
+                    if idx == keep_idx:
+                        continue
+                    row_edits = edited_rows.get(idx)
+                    if isinstance(row_edits, dict) and _VIEW_COLUMN_LABEL in row_edits:
+                        del row_edits[_VIEW_COLUMN_LABEL]
+                        if not row_edits:
+                            del edited_rows[idx]
+            st.session_state["audit_actions_prev_view_checks"] = [keep_idx]
+            st.rerun()
+        else:
+            st.session_state["audit_actions_prev_view_checks"] = current_checked
+
+        checked_count = len(current_checked)
         if checked_count == 1:
-            row_idx = int(checked.index[0])
+            row_idx = current_checked[0]
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
                 # Auto-open: dialog fires when exactly one row is ticked.
@@ -1451,8 +1522,6 @@ def _render_audit_tab(days_int: int):
             # Allow re-ticking the same row to reopen the dialog by
             # clearing the gate.
             st.session_state.pop("audit_actions_dialog_open_id", None)
-        # checked_count > 1: multi-select, no dialog fires. User must
-        # untick extras.
     else:
         st.info("No admin actions in the selected time range.")
 

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -39,14 +39,14 @@ logger = get_logger(__name__)
 ANALYTICS_CACHE_TTL_SECONDS = 300
 
 # Epic #169 / Feature #170: shared copy for the labeled View checkbox column
-# and the View Selected action button used on all three audit tables
-# (Questions, Admin Actions, User Activity). Keeping these as module-level
-# constants ensures the three sites stay literally identical and gives the
-# tests a single string to assert against.
+# used on all three audit tables (Questions, Admin Actions, User Activity).
+# Keeping these as module-level constants ensures the three sites stay
+# literally identical and gives the tests a single string to assert against.
+# Interaction model: auto-open dialog when exactly one row is ticked (no
+# action button) — re-ticking the same row after closing is supported via
+# the per-tab ``open_id`` session-state gate cleared on zero-tick reruns.
 _VIEW_COLUMN_LABEL = "View"
-_VIEW_COLUMN_HELP = "Select a row and click 'View Selected' to open the detail dialog"
-_VIEW_SELECTED_BUTTON_LABEL = "👁 View Selected"
-_VIEW_SELECTED_DISABLED_HELP = "Select exactly one row to view detail"
+_VIEW_COLUMN_HELP = "Tick a box to open the detail dialog"
 
 
 def _kpi_card(label: str, value, help_text: str | None = None):
@@ -513,9 +513,9 @@ def _render_audit_question_dialog(item: dict) -> None:
 
     Epic #169 / Feature #170 swapped the trigger primitive from
     ``st.dataframe(on_select=..., selection_mode='single-row')`` to a
-    ``st.data_editor`` + ``CheckboxColumn`` + explicit ``View Selected``
-    button. Subsystems #156 and #157 adopt the same pattern. See Epic #169
-    Architecture Considerations.
+    ``st.data_editor`` + labeled ``CheckboxColumn`` that auto-opens this
+    dialog when exactly one row is ticked. Subsystems #156 and #157
+    adopt the same pattern. See Epic #169 Architecture Considerations.
     """
     _render_audit_question_dialog_body(item)
 
@@ -616,13 +616,13 @@ def _render_audit_trail_tab(days_int: int):
 
     # Table — Epic #169 / Feature #170 swaps the prior single-row selection
     # trigger (``st.dataframe(on_select=..., selection_mode='single-row')``)
-    # for a manual ``st.data_editor`` + leading ``CheckboxColumn`` + explicit
-    # ``View Selected`` action button. The training-table pattern at
-    # ``views/admin_training.py:55-88`` is the reference implementation.
-    # Streamlit's row-selection widget can't be labeled via ``column_config``
-    # because it's a frontend element, not a data column. A manual boolean
-    # data column gives us a labeled header + help tooltip — the
-    # discoverability win the Epic exists to deliver.
+    # for a manual ``st.data_editor`` + leading labeled ``CheckboxColumn``
+    # that auto-opens the detail dialog on tick. Streamlit's row-selection
+    # widget can't be labeled via ``column_config`` because it's a frontend
+    # element, not a data column. A manual boolean data column gives us a
+    # labeled header + help tooltip — the discoverability win the Epic
+    # exists to deliver — while preserving the original one-step
+    # ``selection_mode='single-row'`` interaction model.
     if items:
         table_rows = []
         for it in items:
@@ -675,25 +675,28 @@ def _render_audit_trail_tab(days_int: int):
                 checked = pd.DataFrame()
 
             checked_count = len(checked)
-            btn_disabled = checked_count != 1
-            if st.button(
-                _VIEW_SELECTED_BUTTON_LABEL,
-                disabled=btn_disabled,
-                help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
-                key="audit_questions_view_selected_btn",
-            ):
-                # Exactly one row checked — look it up and open the dialog.
-                # The cross-tab claim guard from PR #168 stays in place
-                # (defense-in-depth: ``st.tabs`` evaluates every tab body
-                # each rerun, and Streamlit forbids more than one
-                # ``st.dialog`` call per script run).
+            if checked_count == 1:
                 row_idx = int(checked.index[0])
                 if 0 <= row_idx < len(items):
                     selected_item = items[row_idx]
-                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                        st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
-                        _render_audit_question_dialog(selected_item)
+                    # Auto-open: dialog fires when exactly one row is
+                    # ticked. Gate on the tab-specific ``open_id`` session
+                    # key so the dialog doesn't re-fire on every rerun
+                    # while the checkbox stays ticked. Cross-tab claim
+                    # guard from PR #168 still applies as
+                    # defense-in-depth.
+                    open_id = st.session_state.get("audit_dialog_open_user_message_id")
+                    if open_id != selected_item["user_message_id"]:
+                        if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                            st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                            st.session_state["audit_dialog_open_user_message_id"] = selected_item["user_message_id"]
+                            _render_audit_question_dialog(selected_item)
+            elif checked_count == 0:
+                # Allow re-ticking the same row to reopen the dialog by
+                # clearing the gate.
+                st.session_state.pop("audit_dialog_open_user_message_id", None)
+            # checked_count > 1: multi-select, no dialog fires. User must
+            # untick extras.
         else:
             # agent_logging.mode == "disabled": render the table read-only;
             # no editor and no action button — the dialog is unreachable.
@@ -1006,8 +1009,9 @@ def _render_user_activity_dialog(item: dict) -> None:
     """``@st.dialog``-decorated wrapper invoked from ``_render_activity_tab``.
 
     Epic #169 / Feature #170 swapped the trigger primitive to
-    ``st.data_editor`` + a ``CheckboxColumn`` + an explicit
-    ``View Selected`` button. See Epic #169 Architecture Considerations.
+    ``st.data_editor`` + a labeled ``CheckboxColumn`` that auto-opens
+    this dialog when exactly one row is ticked. See Epic #169
+    Architecture Considerations.
     """
     _render_user_activity_dialog_body(item)
 
@@ -1105,8 +1109,8 @@ def _render_activity_tab(days_int: int):
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
     if items:
-        # Epic #169 / Feature #170: same data_editor + CheckboxColumn +
-        # View Selected button pattern as the Questions tab. See the
+        # Epic #169 / Feature #170: same data_editor + labeled
+        # CheckboxColumn auto-open pattern as the Questions tab. See the
         # ``_render_audit_trail_tab`` comments for the full rationale.
         table_rows = [
             {
@@ -1146,20 +1150,27 @@ def _render_activity_tab(days_int: int):
             checked = pd.DataFrame()
 
         checked_count = len(checked)
-        btn_disabled = checked_count != 1
-        if st.button(
-            _VIEW_SELECTED_BUTTON_LABEL,
-            disabled=btn_disabled,
-            help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
-            key="audit_activity_view_selected_btn",
-        ):
+        if checked_count == 1:
             row_idx = int(checked.index[0])
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
-                if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                    st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
-                    _render_user_activity_dialog(selected_item)
+                # Auto-open: dialog fires when exactly one row is ticked.
+                # Gate on the tab-specific ``open_id`` session key so the
+                # dialog doesn't re-fire on every rerun while the
+                # checkbox stays ticked. Cross-tab claim guard from PR
+                # #168 still applies as defense-in-depth.
+                open_id = st.session_state.get("audit_activity_dialog_open_id")
+                if open_id != selected_item["id"]:
+                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                        st.session_state["audit_activity_dialog_open_id"] = selected_item["id"]
+                        _render_user_activity_dialog(selected_item)
+        elif checked_count == 0:
+            # Allow re-ticking the same row to reopen the dialog by
+            # clearing the gate.
+            st.session_state.pop("audit_activity_dialog_open_id", None)
+        # checked_count > 1: multi-select, no dialog fires. User must
+        # untick extras.
     else:
         st.info("No recent activity found.")
 
@@ -1280,9 +1291,9 @@ def _render_admin_action_dialog(item: dict) -> None:
     """``@st.dialog``-decorated wrapper invoked from ``_render_audit_tab``.
 
     Uses the same trigger primitive as the Questions tab: Epic #169 /
-    Feature #170's ``st.data_editor`` + ``CheckboxColumn`` + explicit
-    ``View Selected`` button. Clicking the button with exactly one row
-    checked opens this dialog. See Epic #169.
+    Feature #170's ``st.data_editor`` + labeled ``CheckboxColumn``.
+    Ticking exactly one row auto-opens this dialog (no button). See
+    Epic #169.
     """
     _render_admin_action_dialog_body(item)
 
@@ -1374,9 +1385,9 @@ def _render_audit_tab(days_int: int):
     total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
 
     if items:
-        # Epic #169 / Feature #170: data_editor + CheckboxColumn + View
-        # Selected button — see ``_render_audit_trail_tab`` for the full
-        # rationale.
+        # Epic #169 / Feature #170: data_editor + labeled CheckboxColumn
+        # auto-open on tick — see ``_render_audit_trail_tab`` for the
+        # full rationale.
         table_rows = []
         for it in items:
             ts = it.get("created_at")
@@ -1421,20 +1432,27 @@ def _render_audit_tab(days_int: int):
             checked = pd.DataFrame()
 
         checked_count = len(checked)
-        btn_disabled = checked_count != 1
-        if st.button(
-            _VIEW_SELECTED_BUTTON_LABEL,
-            disabled=btn_disabled,
-            help=_VIEW_SELECTED_DISABLED_HELP if btn_disabled else None,
-            key="audit_actions_view_selected_btn",
-        ):
+        if checked_count == 1:
             row_idx = int(checked.index[0])
             if 0 <= row_idx < len(items):
                 selected_item = items[row_idx]
-                if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
-                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
-                    st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
-                    _render_admin_action_dialog(selected_item)
+                # Auto-open: dialog fires when exactly one row is ticked.
+                # Gate on the tab-specific ``open_id`` session key so the
+                # dialog doesn't re-fire on every rerun while the
+                # checkbox stays ticked. Cross-tab claim guard from PR
+                # #168 still applies as defense-in-depth.
+                open_id = st.session_state.get("audit_actions_dialog_open_id")
+                if open_id != selected_item["id"]:
+                    if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                        st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                        st.session_state["audit_actions_dialog_open_id"] = selected_item["id"]
+                        _render_admin_action_dialog(selected_item)
+        elif checked_count == 0:
+            # Allow re-ticking the same row to reopen the dialog by
+            # clearing the gate.
+            st.session_state.pop("audit_actions_dialog_open_id", None)
+        # checked_count > 1: multi-select, no dialog fires. User must
+        # untick extras.
     else:
         st.info("No admin actions in the selected time range.")
 


### PR DESCRIPTION
## Summary

Converts all three Admin → Audit tables (Questions, Admin Actions, User Activity) from `st.dataframe(on_select="rerun", selection_mode="single-row")` to `st.data_editor` + a leading `View` boolean column configured as `st.column_config.CheckboxColumn("View", help="Select a row and click 'View Selected' to open the detail dialog", default=False, width="small")` + a `👁 View Selected` button below each table.

This supersedes the closed PR #186 which added a parallel data column adjacent to Streamlit's row-selection widget — visually two indicator columns side-by-side. The new pattern matches the training data table at `views/admin_training.py:55-88` and achieves the labeled-header + tooltip discoverability win on the actual actionable column.

**Interaction change:** Tick checkbox → click `👁 View Selected` → dialog opens. Two clicks instead of one. The button is disabled unless exactly one row is checked; tooltip when disabled reads "Select exactly one row to view detail."

Closes #170. Part of Epic #169.

## Test plan
- [x] All 88 tests across the 6 affected test files pass (test_audit_view_checkbox_column.py + the existing dialog / collision / scope filter tests)
- [x] `uv run ruff check` clean on changed files
- [x] `uv run ruff format --check` clean on changed files (7 files already formatted)
- [x] Existing dialog tests + cross-tab collision test (PR #168) + Scope filter test (PR #185) updated for `data_editor` primitive
- [ ] **Manual verification needed**: visit Admin → Audit → each tab, tick a View checkbox, confirm View Selected button enables, click it, confirm correct dialog opens with full detail