### PR TITLE
feat(ux): hide Reset Agent for legacy users; promote Agentic section in Settings (Epic #171)

### DIFF
--- a/tests/views/test_chat_sidebar_agentic_gates.py
+++ b/tests/views/test_chat_sidebar_agentic_gates.py
@@ -13,16 +13,27 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-def _make_st_stub(*, agentic_mode):
+def _make_st_stub(*, agentic_mode=None, checkbox_state=None):
     """MagicMock-based stub for ``views.chat_bot.st``.
 
     ``session_state`` is a real dict (so ``get`` / ``setdefault`` work),
     everything else is a MagicMock so any attribute access (e.g.
     ``st.sidebar.container``, ``st.button``, ``st.caption`` …) yields a
     spy we can introspect later.
+
+    ``agentic_mode`` seeds the persisted-preference key
+    (``st.session_state["agentic_mode"]``). ``checkbox_state`` seeds the
+    dialog checkbox widget-state key
+    (``st.session_state["agentic_mode_dialog_checkbox"]``) which the
+    sidebar gate prefers when present.
     """
     stub = MagicMock()
-    stub.session_state = {} if agentic_mode is None else {"agentic_mode": agentic_mode}
+    session = {}
+    if agentic_mode is not None:
+        session["agentic_mode"] = agentic_mode
+    if checkbox_state is not None:
+        session["agentic_mode_dialog_checkbox"] = checkbox_state
+    stub.session_state = session
     # Make ``with st.sidebar.container():`` work as a context manager.
     stub.sidebar.container.return_value.__enter__ = MagicMock(return_value=MagicMock())
     stub.sidebar.container.return_value.__exit__ = MagicMock(return_value=False)
@@ -77,6 +88,55 @@ def test_reset_agent_visible_when_agentic_mode_absent():
         chat_bot._render_reset_agent_sidebar()
 
     stub.sidebar.container.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Live-update tests — the sidebar reads the dialog checkbox's widget
+# state so toggling reflects on the same rerun (no page refresh needed).
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_prefers_checkbox_widget_state_when_set():
+    """Even if ``agentic_mode`` persists as True, an unchecked dialog
+    checkbox (``agentic_mode_dialog_checkbox = False``) must hide the
+    sidebar on the same rerun. This is the bug fix: toggling the
+    checkbox in an open dialog updates the sidebar live."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=True, checkbox_state=False)
+    with patch.object(chat_bot, "st", stub):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_not_called()
+
+
+def test_sidebar_prefers_checkbox_widget_state_when_on():
+    """``agentic_mode_dialog_checkbox = True`` shows the sidebar even
+    when ``agentic_mode`` mirror hasn't been refreshed yet (e.g., the
+    DB hasn't been re-read this rerun)."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=False, checkbox_state=True)
+    with (
+        patch.object(chat_bot, "st", stub),
+        patch.object(chat_bot.time, "time", return_value=1000.0),
+    ):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_called_once()
+
+
+def test_sidebar_falls_back_to_agentic_mode_when_checkbox_absent():
+    """Before the Settings dialog has been opened in this session, the
+    checkbox widget key doesn't exist. Fall back to the persisted
+    ``agentic_mode`` value."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=False, checkbox_state=None)
+    with patch.object(chat_bot, "st", stub):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/views/test_chat_sidebar_agentic_gates.py
+++ b/tests/views/test_chat_sidebar_agentic_gates.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-def _make_st_stub(*, agentic_mode=None, checkbox_state=None):
+def _make_st_stub(*, agentic_mode):
     """MagicMock-based stub for ``views.chat_bot.st``.
 
     ``session_state`` is a real dict (so ``get`` / ``setdefault`` work),
@@ -22,18 +22,15 @@ def _make_st_stub(*, agentic_mode=None, checkbox_state=None):
     spy we can introspect later.
 
     ``agentic_mode`` seeds the persisted-preference key
-    (``st.session_state["agentic_mode"]``). ``checkbox_state`` seeds the
-    dialog checkbox widget-state key
-    (``st.session_state["agentic_mode_dialog_checkbox"]``) which the
-    sidebar gate prefers when present.
+    (``st.session_state["agentic_mode"]``) which the sidebar gate reads
+    directly. Commit-on-close semantics: the gate only reads this key
+    (NOT the dialog checkbox's widget-state key), so the sidebar
+    doesn't update live while the dialog is open — it picks up the
+    new value on the next rerun (which fires when the dialog closes
+    and ``set_user_preferences_in_session_state`` re-reads from DB).
     """
     stub = MagicMock()
-    session = {}
-    if agentic_mode is not None:
-        session["agentic_mode"] = agentic_mode
-    if checkbox_state is not None:
-        session["agentic_mode_dialog_checkbox"] = checkbox_state
-    stub.session_state = session
+    stub.session_state = {} if agentic_mode is None else {"agentic_mode": agentic_mode}
     # Make ``with st.sidebar.container():`` work as a context manager.
     stub.sidebar.container.return_value.__enter__ = MagicMock(return_value=MagicMock())
     stub.sidebar.container.return_value.__exit__ = MagicMock(return_value=False)
@@ -91,52 +88,36 @@ def test_reset_agent_visible_when_agentic_mode_absent():
 
 
 # ---------------------------------------------------------------------------
-# Live-update tests — the sidebar reads the dialog checkbox's widget
-# state so toggling reflects on the same rerun (no page refresh needed).
+# Commit-on-close guarantee — the sidebar ignores the dialog checkbox's
+# widget-state key. It reads only ``agentic_mode``, which gets refreshed
+# from the DB on the next rerun (which fires when the dialog closes).
 # ---------------------------------------------------------------------------
 
 
-def test_sidebar_prefers_checkbox_widget_state_when_set():
-    """Even if ``agentic_mode`` persists as True, an unchecked dialog
-    checkbox (``agentic_mode_dialog_checkbox = False``) must hide the
-    sidebar on the same rerun. This is the bug fix: toggling the
-    checkbox in an open dialog updates the sidebar live."""
+def test_sidebar_does_not_read_dialog_checkbox_widget_state():
+    """If the dialog checkbox's widget state disagrees with the
+    persisted ``agentic_mode`` (e.g., user toggled checkbox in an open
+    dialog but the rerun hasn't yet propagated through DB), the
+    sidebar must reflect the PERSISTED value, not the in-flight
+    checkbox state. This enforces commit-on-close: sidebar updates
+    only after the dialog closes and ``set_user_preferences_in_session_state``
+    refreshes ``agentic_mode`` from the DB."""
     from views import chat_bot
 
-    stub = _make_st_stub(agentic_mode=True, checkbox_state=False)
-    with patch.object(chat_bot, "st", stub):
-        chat_bot._render_reset_agent_sidebar()
-
-    stub.sidebar.container.assert_not_called()
-
-
-def test_sidebar_prefers_checkbox_widget_state_when_on():
-    """``agentic_mode_dialog_checkbox = True`` shows the sidebar even
-    when ``agentic_mode`` mirror hasn't been refreshed yet (e.g., the
-    DB hasn't been re-read this rerun)."""
-    from views import chat_bot
-
-    stub = _make_st_stub(agentic_mode=False, checkbox_state=True)
+    # Persisted preference says True (sidebar should be visible). The
+    # in-flight checkbox state says False (user toggled but hasn't
+    # closed the dialog yet).
+    stub = _make_st_stub(agentic_mode=True)
+    stub.session_state["agentic_mode_dialog_checkbox"] = False
     with (
         patch.object(chat_bot, "st", stub),
         patch.object(chat_bot.time, "time", return_value=1000.0),
     ):
         chat_bot._render_reset_agent_sidebar()
 
+    # Sidebar still renders because the persisted value is True, even
+    # though the in-flight checkbox state disagrees.
     stub.sidebar.container.assert_called_once()
-
-
-def test_sidebar_falls_back_to_agentic_mode_when_checkbox_absent():
-    """Before the Settings dialog has been opened in this session, the
-    checkbox widget key doesn't exist. Fall back to the persisted
-    ``agentic_mode`` value."""
-    from views import chat_bot
-
-    stub = _make_st_stub(agentic_mode=False, checkbox_state=None)
-    with patch.object(chat_bot, "st", stub):
-        chat_bot._render_reset_agent_sidebar()
-
-    stub.sidebar.container.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/views/test_chat_sidebar_agentic_gates.py
+++ b/tests/views/test_chat_sidebar_agentic_gates.py
@@ -1,0 +1,123 @@
+"""Tests for Epic #171 / Feature #172.
+
+Covers:
+  - ``_render_reset_agent_sidebar`` early-returns when ``agentic_mode``
+    is off, renders normally when on or absent (default True).
+  - ``_settings_dialog_body`` renders the LLM / Agentic / Display
+    sections in the order LLM → Agentic → Display (with matching
+    subheader labels in the same order).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_st_stub(*, agentic_mode):
+    """MagicMock-based stub for ``views.chat_bot.st``.
+
+    ``session_state`` is a real dict (so ``get`` / ``setdefault`` work),
+    everything else is a MagicMock so any attribute access (e.g.
+    ``st.sidebar.container``, ``st.button``, ``st.caption`` …) yields a
+    spy we can introspect later.
+    """
+    stub = MagicMock()
+    stub.session_state = {} if agentic_mode is None else {"agentic_mode": agentic_mode}
+    # Make ``with st.sidebar.container():`` work as a context manager.
+    stub.sidebar.container.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    stub.sidebar.container.return_value.__exit__ = MagicMock(return_value=False)
+    # Same for ``st.container()`` (used in unrelated paths but safe to wire).
+    stub.container.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    stub.container.return_value.__exit__ = MagicMock(return_value=False)
+    stub.button = MagicMock(return_value=False)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Reset Agent sidebar visibility tests
+# ---------------------------------------------------------------------------
+
+
+def test_reset_agent_hidden_when_agentic_mode_off():
+    """``agentic_mode = False`` must short-circuit before touching
+    ``st.sidebar.container``."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=False)
+    with patch.object(chat_bot, "st", stub):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_not_called()
+
+
+def test_reset_agent_visible_when_agentic_mode_on():
+    """``agentic_mode = True`` must reach ``st.sidebar.container``."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=True)
+    with (
+        patch.object(chat_bot, "st", stub),
+        patch.object(chat_bot.time, "time", return_value=1000.0),
+    ):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_called_once()
+
+
+def test_reset_agent_visible_when_agentic_mode_absent():
+    """Fresh session with no ``agentic_mode`` preference defaults to
+    True so the button still renders."""
+    from views import chat_bot
+
+    stub = _make_st_stub(agentic_mode=None)
+    with (
+        patch.object(chat_bot, "st", stub),
+        patch.object(chat_bot.time, "time", return_value=1000.0),
+    ):
+        chat_bot._render_reset_agent_sidebar()
+
+    stub.sidebar.container.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Settings dialog section order test
+# ---------------------------------------------------------------------------
+
+
+def test_settings_dialog_section_order_is_llm_then_agentic_then_display():
+    """``_settings_dialog_body`` renders LLM → Agentic → Display in that
+    order. We invoke the body directly (not the ``@st.dialog``-decorated
+    wrapper) to avoid Streamlit's dialog-open machinery at import time."""
+    from views import chat_bot
+
+    call_order: list[str] = []
+
+    def _record_llm():
+        call_order.append("llm")
+
+    def _record_agentic():
+        call_order.append("agentic")
+
+    def _record_display():
+        call_order.append("display")
+
+    st_stub = MagicMock()
+    st_stub.button = MagicMock(return_value=False)
+
+    with (
+        patch.object(chat_bot, "st", st_stub),
+        patch.object(chat_bot, "get_vn", return_value=None),
+        patch.object(chat_bot, "_render_llm_section", side_effect=_record_llm),
+        patch.object(chat_bot, "_render_agentic_section", side_effect=_record_agentic),
+        patch.object(chat_bot, "_render_display_form", side_effect=_record_display),
+    ):
+        chat_bot._settings_dialog_body()
+
+    assert call_order == ["llm", "agentic", "display"], (
+        f"Settings dialog body must render sections in LLM → Agentic → Display order; got {call_order}"
+    )
+
+    subheader_labels = [c.args[0] for c in st_stub.subheader.call_args_list if c.args]
+    assert subheader_labels == ["LLM", "Agentic", "Display"], (
+        f"Settings dialog subheaders must render in LLM → Agentic → Display order; got {subheader_labels}"
+    )

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -107,30 +107,6 @@ def _render_selected_patient_sidebar() -> None:
 _RESET_CONFIRM_WINDOW_SECONDS = 5.0
 
 
-def _agentic_mode_is_on() -> bool:
-    """Live ``agentic_mode`` state for sidebar gating.
-
-    Reads the dialog checkbox's widget state first (key
-    ``agentic_mode_dialog_checkbox``) so toggling the checkbox in an
-    open Settings dialog reflects in the sidebar on the SAME rerun.
-    Streamlit writes widget state before the rerun body executes, so
-    the sidebar — which renders earlier in the script than the dialog
-    body — sees the new value immediately.
-
-    Falls back to ``st.session_state["agentic_mode"]`` (populated by
-    :func:`orm.functions.set_user_preferences_in_session_state` from the
-    persisted user preference) when the checkbox hasn't been rendered
-    yet this session.
-
-    Default ``True`` — admins / fresh sessions with no preference see
-    the agentic surfaces by default.
-    """
-    widget_state = st.session_state.get("agentic_mode_dialog_checkbox")
-    if widget_state is not None:
-        return bool(widget_state)
-    return bool(st.session_state.get("agentic_mode", True))
-
-
 def _render_reset_agent_sidebar() -> None:
     """Sidebar container that clears all agent-side conversation state.
 
@@ -138,9 +114,17 @@ def _render_reset_agent_sidebar() -> None:
     is only rendered when the user has agentic mode enabled. Legacy
     Vanna users see nothing here — clearing agent state doesn't affect
     the Vanna pipeline, so showing the button would imply an
-    interaction that has no effect. The gate uses
-    :func:`_agentic_mode_is_on` so toggling the dialog checkbox updates
-    the sidebar live without needing a page refresh.
+    interaction that has no effect.
+
+    The gate reads ``st.session_state["agentic_mode"]`` directly. This is
+    populated from the persisted user preference by
+    :func:`orm.functions.set_user_preferences_in_session_state`, which
+    runs at the top of every script rerun. Commit-on-close semantics:
+    toggling the dialog checkbox writes to session_state inside the
+    dialog body, but the sidebar already rendered higher in the script
+    on the toggle's rerun, so the sidebar does NOT update live while
+    the dialog is open. When the dialog closes, the next rerun re-reads
+    the (now-saved) DB value and the sidebar updates.
 
     Two-state UX:
       - Idle: a single "Reset agent" button. Clicking it arms the
@@ -151,7 +135,9 @@ def _render_reset_agent_sidebar() -> None:
     The arming flag is checked lazily on each render and on click — no
     background timers. Expired arming silently returns to Idle.
     """
-    if not _agentic_mode_is_on():
+    # Default to True so admins / fresh sessions with no persisted
+    # preference still see the button.
+    if not st.session_state.get("agentic_mode", True):
         return
 
     armed_at = st.session_state.get("_pending_agent_reset_at")

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -107,14 +107,40 @@ def _render_selected_patient_sidebar() -> None:
 _RESET_CONFIRM_WINDOW_SECONDS = 5.0
 
 
+def _agentic_mode_is_on() -> bool:
+    """Live ``agentic_mode`` state for sidebar gating.
+
+    Reads the dialog checkbox's widget state first (key
+    ``agentic_mode_dialog_checkbox``) so toggling the checkbox in an
+    open Settings dialog reflects in the sidebar on the SAME rerun.
+    Streamlit writes widget state before the rerun body executes, so
+    the sidebar — which renders earlier in the script than the dialog
+    body — sees the new value immediately.
+
+    Falls back to ``st.session_state["agentic_mode"]`` (populated by
+    :func:`orm.functions.set_user_preferences_in_session_state` from the
+    persisted user preference) when the checkbox hasn't been rendered
+    yet this session.
+
+    Default ``True`` — admins / fresh sessions with no preference see
+    the agentic surfaces by default.
+    """
+    widget_state = st.session_state.get("agentic_mode_dialog_checkbox")
+    if widget_state is not None:
+        return bool(widget_state)
+    return bool(st.session_state.get("agentic_mode", True))
+
+
 def _render_reset_agent_sidebar() -> None:
     """Sidebar container that clears all agent-side conversation state.
 
-    Gated on ``agentic_mode`` (Epic #171 / Feature #172): the container is
-    only rendered when the user has agentic mode enabled. Legacy Vanna
-    users see nothing here — clearing agent state doesn't affect the
-    Vanna pipeline, so showing the button would imply an interaction
-    that has no effect.
+    Gated on ``agentic_mode`` (Epic #171 / Feature #172): the container
+    is only rendered when the user has agentic mode enabled. Legacy
+    Vanna users see nothing here — clearing agent state doesn't affect
+    the Vanna pipeline, so showing the button would imply an
+    interaction that has no effect. The gate uses
+    :func:`_agentic_mode_is_on` so toggling the dialog checkbox updates
+    the sidebar live without needing a page refresh.
 
     Two-state UX:
       - Idle: a single "Reset agent" button. Clicking it arms the
@@ -125,9 +151,7 @@ def _render_reset_agent_sidebar() -> None:
     The arming flag is checked lazily on each render and on click — no
     background timers. Expired arming silently returns to Idle.
     """
-    # Hide the entire container for legacy Vanna users. Default to True so
-    # admins / fresh sessions with no preference yet still see the button.
-    if not st.session_state.get("agentic_mode", True):
+    if not _agentic_mode_is_on():
         return
 
     armed_at = st.session_state.get("_pending_agent_reset_at")

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -110,6 +110,12 @@ _RESET_CONFIRM_WINDOW_SECONDS = 5.0
 def _render_reset_agent_sidebar() -> None:
     """Sidebar container that clears all agent-side conversation state.
 
+    Gated on ``agentic_mode`` (Epic #171 / Feature #172): the container is
+    only rendered when the user has agentic mode enabled. Legacy Vanna
+    users see nothing here — clearing agent state doesn't affect the
+    Vanna pipeline, so showing the button would imply an interaction
+    that has no effect.
+
     Two-state UX:
       - Idle: a single "Reset agent" button. Clicking it arms the
         confirmation by stamping st.session_state['_pending_agent_reset_at'].
@@ -119,6 +125,11 @@ def _render_reset_agent_sidebar() -> None:
     The arming flag is checked lazily on each render and on click — no
     background timers. Expired arming silently returns to Idle.
     """
+    # Hide the entire container for legacy Vanna users. Default to True so
+    # admins / fresh sessions with no preference yet still see the button.
+    if not st.session_state.get("agentic_mode", True):
+        return
+
     armed_at = st.session_state.get("_pending_agent_reset_at")
     now = time.time()
     is_armed = isinstance(armed_at, (int, float)) and (now - armed_at) <= _RESET_CONFIRM_WINDOW_SECONDS
@@ -380,8 +391,12 @@ def _render_agentic_section():
             pass
 
 
-@st.dialog("Settings")
-def settings_dialog():
+def _settings_dialog_body():
+    """Pure body of the Settings dialog. Split from the ``@st.dialog``-
+    decorated wrapper (Epic #171 / Feature #172) so unit tests can drive
+    the section-order logic without a Streamlit script context.
+    Production unchanged — :func:`settings_dialog` delegates here.
+    """
     try:
         vn_instance = get_vn()
         if vn_instance:
@@ -394,17 +409,22 @@ def settings_dialog():
 
     st.divider()
 
-    st.subheader("Display")
-    _render_display_form()
-
-    st.divider()
-
     st.subheader("Agentic")
     _render_agentic_section()
 
     st.divider()
+
+    st.subheader("Display")
+    _render_display_form()
+
+    st.divider()
     if st.button("Close", key="settings_dialog_close"):
         st.rerun()
+
+
+@st.dialog("Settings")
+def settings_dialog():
+    _settings_dialog_body()
 
 
 ######### Sidebar settings #########
@@ -446,8 +466,8 @@ if st.session_state.get("show_community_engagement", False):
 What is the average patient age?
 How many patients visited last month?
 What are the top diagnoses?""",
-            language="csv",
-        )
+                language="csv",
+            )
 
 # Display Community Questions in sidebar
 if st.session_state.get("community_questions"):
@@ -491,6 +511,7 @@ if st.session_state.get("show_question_history", True):
                 )
             try:
                 from views import admin_audit  # noqa: F401
+
                 if st.button("View all in audit →", key="qh_view_all_in_audit"):
                     import json as _json
 

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -432,7 +432,14 @@ def _settings_dialog_body():
         st.rerun()
 
 
-@st.dialog("Settings")
+# ``on_dismiss="rerun"`` is load-bearing for sidebar refresh: by default
+# Streamlit's ``@st.dialog`` decorator uses ``on_dismiss="ignore"``, so
+# when the user clicks off / X's out of the dialog NO rerun fires and the
+# sidebar (which reads ``st.session_state["agentic_mode"]`` from the
+# top-of-script ``set_user_preferences_in_session_state`` call) stays
+# stale. The explicit Close button below already calls ``st.rerun()``,
+# but dismissal-by-click-off needs this opt-in. Epic #171 / Feature #172.
+@st.dialog("Settings", on_dismiss="rerun")
 def settings_dialog():
     _settings_dialog_body()
 


### PR DESCRIPTION
## Summary

Two surgical UX edits in views/chat_bot.py per Epic #171:

1. **Gate the Reset Agent sidebar on agentic_mode.** Legacy Vanna users no longer see a Reset Agent button — clearing agent-side state has no effect on the Vanna pipeline, so showing the button implied an interaction that did nothing. The gate lives inside _render_reset_agent_sidebar() itself (defaults to True so admins / fresh sessions still see it).

2. **Reorder Settings dialog sections: LLM → Agentic → Display** (was LLM → Display → Agentic). Agentic mode is a conceptual mode-switch driving downstream behavior; promoting it just under LLM matches its weight.

Persistence and default-on for User.agentic_mode are NOT touched — that wiring already exists (orm/models.py:196 default=True, save/load at orm/functions.py:151 and views/chat_bot.py:378).

settings_dialog is split into wrapper + _settings_dialog_body (the #155 pattern) so the section-order test can drive it without a Streamlit script context.

Closes #172.

## Test plan
- [x] 4 new tests in tests/views/test_chat_sidebar_agentic_gates.py
- [x] Full regression: 428 passed, 3 pre-existing unrelated failures
- [x] ruff format --check clean
- [ ] Manual verification: toggle agentic_mode off in Settings → confirm Reset Agent button disappears from sidebar