### PR TITLE
fix(agent): pool_pre_ping for analytics DB (closes #197)

### DIFF
--- a/agent/db/analytics_adapter.py
+++ b/agent/db/analytics_adapter.py
@@ -218,6 +218,17 @@ class AnalyticsDbAdapter:
         url = analytics.get("url")
         if not url:
             raise RuntimeError("secrets.analytics_db.url is required (postgres:// or redshift://)")
-        engine = create_engine(url)
+        # Redshift (and the AWS ELB in front of it) close idle TCP sockets
+        # well before SQLAlchemy's pool decides a connection is stale. Without
+        # pool_pre_ping we hand the dead socket to the next caller, and the
+        # very first statement after checkout — SET statement_timeout in
+        # fetch_all/run_arbitrary_sql — raises "SSL connection has been
+        # closed unexpectedly". pool_recycle bounds the worst case by
+        # forcing periodic reconnects under the typical idle cutoff.
+        engine_kwargs: dict = {}
+        if dialect in ("postgres", "redshift"):
+            engine_kwargs["pool_pre_ping"] = True
+            engine_kwargs["pool_recycle"] = 1800
+        engine = create_engine(url, **engine_kwargs)
         schema = analytics.get("schema", "") or ""
         return cls(engine=engine, dialect=dialect, schema=schema)

--- a/tests/agent/db/test_analytics_adapter.py
+++ b/tests/agent/db/test_analytics_adapter.py
@@ -55,3 +55,71 @@ def test_adapter_sqlite_engine_rejects_write_inside_explicit_transaction(tmp_pat
     with engine.connect() as conn:
         rows = conn.execute(_text("SELECT COUNT(*) FROM t")).scalar()
     assert rows == 1
+
+
+def _capture_engine_kwargs(dialect: str, url: str, monkeypatch) -> dict:
+    """Patch create_engine + streamlit.secrets to capture how
+    from_streamlit_secrets configures the SQLAlchemy engine for `dialect`."""
+    import sqlalchemy as _sqla
+
+    real_create_engine = _sqla.create_engine  # bind BEFORE patching to avoid recursion
+    captured: dict = {}
+
+    def fake_create_engine(passed_url, **kwargs):
+        captured["url"] = passed_url
+        captured["kwargs"] = kwargs
+        # Return a SQLite engine so AnalyticsDbAdapter.__post_init__ can
+        # install its guards without needing a live Postgres/Redshift.
+        return real_create_engine("sqlite:///:memory:")
+
+    fake_secrets = {"analytics_db": {"dialect": dialect, "url": url, "schema": "dw"}}
+
+    class _FakeSt:
+        secrets = fake_secrets
+
+    monkeypatch.setattr("sqlalchemy.create_engine", fake_create_engine)
+    import sys
+
+    monkeypatch.setitem(sys.modules, "streamlit", _FakeSt)
+
+    # Force the sqlite branch in __post_init__ regardless of the captured
+    # dialect — we're only testing how from_streamlit_secrets wires the pool,
+    # not the dialect-specific session guards (covered elsewhere). Without
+    # this, dialect="postgres" would try SET SESSION CHARACTERISTICS against
+    # our in-memory SQLite stand-in.
+    original_init = AnalyticsDbAdapter.__post_init__
+
+    def fake_init(self):
+        self.dialect = "sqlite"
+        original_init(self)
+
+    monkeypatch.setattr(AnalyticsDbAdapter, "__post_init__", fake_init)
+
+    AnalyticsDbAdapter.from_streamlit_secrets()
+    return captured
+
+
+def test_from_streamlit_secrets_enables_pool_pre_ping_for_redshift(monkeypatch):
+    """Regression: Redshift idle-killed sockets must be detected before use,
+    or the first SET statement_timeout after pool checkout dies with
+    'SSL connection has been closed unexpectedly'."""
+    captured = _capture_engine_kwargs(
+        "redshift", "redshift+psycopg2://u:p@h:5439/db", monkeypatch
+    )
+    assert captured["kwargs"].get("pool_pre_ping") is True
+    assert captured["kwargs"].get("pool_recycle") == 1800
+
+
+def test_from_streamlit_secrets_enables_pool_pre_ping_for_postgres(monkeypatch):
+    captured = _capture_engine_kwargs(
+        "postgres", "postgresql+psycopg2://u:p@h:5432/db", monkeypatch
+    )
+    assert captured["kwargs"].get("pool_pre_ping") is True
+    assert captured["kwargs"].get("pool_recycle") == 1800
+
+
+def test_from_streamlit_secrets_skips_pool_kwargs_for_sqlite(monkeypatch):
+    """SQLite has no remote connection to drop; pool flags would be noise."""
+    captured = _capture_engine_kwargs("sqlite", "sqlite:///:memory:", monkeypatch)
+    assert "pool_pre_ping" not in captured["kwargs"]
+    assert "pool_recycle" not in captured["kwargs"]


### PR DESCRIPTION
## Summary

- Adds `pool_pre_ping=True` + `pool_recycle=1800` to `AnalyticsDbAdapter.from_streamlit_secrets` for `postgres` and `redshift` dialects.
- Skips the flags for `sqlite` (no remote socket to drop).
- Tests assert the wiring per dialect.

Closes #197.

## Why

Production error logs show 7 failures over the past week (6 `OperationalError` + 1 `DatabaseError`) with this exact fingerprint:

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) SSL connection has been closed unexpectedly
[SQL: SET statement_timeout = 240000]
```

Every failure is on the **first** statement issued after pool checkout — the `SET statement_timeout` housekeeping call in `fetch_all` / `run_arbitrary_sql`. The user's actual query never runs. Classic stale-pool-connection fingerprint: Redshift (or the AWS ELB in front of it) closed the idle TCP socket; SQLAlchemy's pool didn't know, handed out the dead connection, and the SET surfaced it as a hard error.

`grep -rn "pool_pre_ping\|pool_recycle"` across the repo returned nothing, confirming it was never configured.

## Change

`agent/db/analytics_adapter.py` — `from_streamlit_secrets`:

```python
engine_kwargs: dict = {}
if dialect in ("postgres", "redshift"):
    engine_kwargs["pool_pre_ping"] = True
    engine_kwargs["pool_recycle"] = 1800
engine = create_engine(url, **engine_kwargs)
```

`pool_pre_ping` issues a cheap `SELECT 1` before checkout — stale sockets are detected and silently replaced. `pool_recycle=1800` (30 min) is a belt — it forces reconnection under the typical idle cutoffs even if pre_ping somehow misses.

## Test plan

- [x] New unit tests assert the kwargs reach `create_engine` for `postgres` and `redshift`, and are absent for `sqlite`.
- [x] Existing `tests/agent/db/test_analytics_adapter.py` cases still pass (read-only enforcement, param binding, SQLite query_only PRAGMA).
- [x] Full `tests/agent/db/` suite: 161 passed.
- [ ] Manual: deploy to dev, watch for `OperationalError: SSL connection closed` on `SET statement_timeout` over the next ~7 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)