### PR TITLE
fix(agent): admissions tool joins isr instead of filtering federated_adt_v.source_id (closes #196)

### DIFF
--- a/agent/db/queries/adt.py
+++ b/agent/db/queries/adt.py
@@ -3,6 +3,11 @@
 Supports filtering by facility type (inpatient, ltc/snf, ed, outpatient, any),
 date range, and discharge detail inclusion. The clean_setting column
 normalizes setting values to INPATIENT, OUTPATIENT, EMERGENCY, etc.
+
+Unlike every other federated_*_v view, federated_adt_v exposes only
+`patient_id` (no `source_id`). The agent's identity model is source_id-based,
+so we resolve source_id → patient_id through internal_source_reference_v
+at empi_rank = 1 — same pattern as patient.find_patient_sql.
 """
 
 from __future__ import annotations
@@ -27,41 +32,46 @@ def admissions_sql(
     include_discharge_details: bool = True,
     schema_prefix: str = "",
 ) -> Tuple[str, dict]:
-    where: list[str] = ["source_id = :source_id"]
+    where: list[str] = ["isr.source_id = :source_id", "isr.empi_rank = 1"]
     params: dict = {"source_id": source_id}
 
     if facility_type and facility_type != "any":
         settings = _FACILITY_TYPE_SETTINGS.get(facility_type)
         if settings:
             placeholders = ", ".join(f":ft_{i}" for i in range(len(settings)))
-            where.append(f"UPPER(clean_setting) IN ({placeholders})")
+            where.append(f"UPPER(adt.clean_setting) IN ({placeholders})")
             for i, s in enumerate(settings):
                 params[f"ft_{i}"] = s
 
     if start_date:
-        where.append("event_date >= :start_date")
+        where.append("adt.event_date >= :start_date")
         params["start_date"] = start_date
     if end_date:
-        where.append("event_date <= :end_date")
+        where.append("adt.event_date <= :end_date")
         params["end_date"] = end_date
 
     discharge_cols = ""
     if include_discharge_details:
         discharge_cols = """,
-            discharge_disposition,
-            discharge_location"""
+            adt.discharge_disposition,
+            adt.discharge_location"""
 
+    # `isr.source_id AS source_id` echoes the input identifier into each row
+    # so _build_admissions_result can populate AdmissionItem.source_id without
+    # special-casing this query.
     sql = f"""
         SELECT
-            source_id,
-            event_date,
-            event_location,
-            location_type,
-            clean_setting AS setting,
-            status,
-            admit_from{discharge_cols}
-        FROM {schema_prefix}federated_adt_v
+            isr.source_id AS source_id,
+            adt.event_date,
+            adt.event_location,
+            adt.location_type,
+            adt.clean_setting AS setting,
+            adt.status,
+            adt.admit_from{discharge_cols}
+        FROM {schema_prefix}federated_adt_v adt
+        JOIN {schema_prefix}internal_source_reference_v isr
+          ON isr.patient_id = adt.patient_id
         WHERE {" AND ".join(where)}
-        ORDER BY event_date DESC
+        ORDER BY adt.event_date DESC
     """
     return sql, params

--- a/agent/rag/seed.py
+++ b/agent/rag/seed.py
@@ -135,7 +135,8 @@ SCHEMA_DOCS: List[_Doc] = [
         "view": "federated_adt_v",
         "kind": "schema",
         "text": (
-            "federated_adt_v: admit/discharge/transfer events. Columns: source_id, "
+            "federated_adt_v: admit/discharge/transfer events. Columns: patient_id "
+            "(no source_id — join internal_source_reference_v at empi_rank=1), "
             "event_date, event_location, location_type, clean_setting (normalized "
             "setting: INPATIENT, OUTPATIENT, EMERGENCY, LONG TERM CARE, SNF), "
             "status, admit_from, discharge_disposition, discharge_location. "

--- a/tests/agent/db/test_adt_queries.py
+++ b/tests/agent/db/test_adt_queries.py
@@ -81,3 +81,44 @@ def test_admissions_facility_type_any(synthetic_db):
     sql, params = admissions_sql(source_id="src-john-1962", facility_type="any")
     rows = adapter.fetch_all(sql, params)
     assert len(rows) == 4
+
+
+def test_admissions_resolves_source_id_via_isr_join():
+    """Regression for #196: production federated_adt_v has no `source_id`
+    column — only `patient_id`. The agent's identity model is source_id-based,
+    so admissions_sql must JOIN internal_source_reference_v at empi_rank=1
+    instead of filtering federated_adt_v directly on a non-existent column."""
+    sql, _ = admissions_sql(source_id="any-cid", schema_prefix="dw.")
+    normalized = " ".join(sql.split())
+    # Must NOT filter federated_adt_v on source_id (the column doesn't exist).
+    assert "WHERE source_id" not in normalized
+    assert "adt.source_id" not in normalized
+    # Must JOIN through internal_source_reference_v at empi_rank=1.
+    assert "JOIN dw.internal_source_reference_v isr" in normalized
+    assert "isr.patient_id = adt.patient_id" in normalized
+    assert "isr.empi_rank = 1" in normalized
+    assert "isr.source_id = :source_id" in normalized
+    # The result must still echo source_id into each row so the tool layer
+    # can populate AdmissionItem.source_id.
+    assert "isr.source_id AS source_id" in normalized
+
+
+def test_admissions_source_id_returned_in_rows(synthetic_db):
+    """The SELECT echoes the input source_id back into each row so the
+    tool layer's row-shaping code stays uniform across domains."""
+    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
+    sql, params = admissions_sql(source_id="src-john-1962")
+    rows = adapter.fetch_all(sql, params)
+    assert rows, "expected admissions rows for src-john-1962"
+    assert all(r["source_id"] == "src-john-1962" for r in rows)
+
+
+def test_admissions_does_not_leak_other_patients(synthetic_db):
+    """Defense check: the JOIN must scope rows to the requested source_id.
+    src-john-1971 (patient_id=2) has exactly one ADT row in the fixture;
+    it must not contaminate src-john-1962's (patient_id=1) result set."""
+    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
+    sql, params = admissions_sql(source_id="src-john-1971")
+    rows = adapter.fetch_all(sql, params)
+    assert len(rows) == 1
+    assert rows[0]["event_location"] == "Kaleida Methodist"

--- a/tests/agent/redshift_synthetic.sql
+++ b/tests/agent/redshift_synthetic.sql
@@ -231,8 +231,11 @@ CREATE TABLE federated_vitals_v (
 INSERT INTO federated_vitals_v VALUES
     ('src-john-1962', '8480-6', 'LOINC', 'Systolic BP', '128', '128', 'mmHg', '2026-04-01 09:30');
 
+-- Production federated_adt_v exposes patient_id only (no source_id, unlike
+-- every other federated_*_v view). Identity is resolved by joining
+-- internal_source_reference_v at empi_rank = 1.
 CREATE TABLE federated_adt_v (
-    source_id TEXT,
+    patient_id INTEGER,
     event_date TIMESTAMP,
     event_location TEXT,
     location_type TEXT,
@@ -242,12 +245,14 @@ CREATE TABLE federated_adt_v (
     discharge_disposition TEXT,
     discharge_location TEXT
 );
+-- patient_id 1 maps to source_id 'src-john-1962' (empi_rank=1) per
+-- internal_source_reference_v above. patient_id 2 maps to 'src-john-1971'.
 INSERT INTO federated_adt_v VALUES
-    ('src-john-1962', '2026-01-10 08:00', 'Buffalo General Hospital', 'Hospital', 'INPATIENT', 'Discharged', 'Home', 'Discharged to home', 'Home'),
-    ('src-john-1962', '2025-06-15 07:30', 'Buffalo General Hospital', 'Hospital', 'INPATIENT', 'Discharged', 'Emergency Dept', 'Discharged to SNF', 'Sunrise SNF'),
-    ('src-john-1962', '2025-06-20 10:00', 'Sunrise SNF', 'Skilled Nursing', 'SNF', 'Discharged', 'Buffalo General Hospital', 'Discharged to home', 'Home'),
-    ('src-john-1962', '2024-11-05 14:00', 'ECMC Emergency', 'Emergency', 'EMERGENCY', 'Discharged', 'Self', 'Discharged to home', 'Home'),
-    ('src-john-1971', '2026-03-15 14:00', 'Kaleida Methodist', 'Hospital', 'INPATIENT', 'Discharged', 'Home', 'Discharged to home', 'Home');
+    (1, '2026-01-10 08:00', 'Buffalo General Hospital', 'Hospital', 'INPATIENT', 'Discharged', 'Home', 'Discharged to home', 'Home'),
+    (1, '2025-06-15 07:30', 'Buffalo General Hospital', 'Hospital', 'INPATIENT', 'Discharged', 'Emergency Dept', 'Discharged to SNF', 'Sunrise SNF'),
+    (1, '2025-06-20 10:00', 'Sunrise SNF', 'Skilled Nursing', 'SNF', 'Discharged', 'Buffalo General Hospital', 'Discharged to home', 'Home'),
+    (1, '2024-11-05 14:00', 'ECMC Emergency', 'Emergency', 'EMERGENCY', 'Discharged', 'Self', 'Discharged to home', 'Home'),
+    (2, '2026-03-15 14:00', 'Kaleida Methodist', 'Hospital', 'INPATIENT', 'Discharged', 'Home', 'Discharged to home', 'Home');
 
 CREATE TABLE metric_federated_data_v (
     patient_id INTEGER,


### PR DESCRIPTION
## Summary

`federated_adt_v` is the **only** federated_*_v view in the warehouse that doesn't expose `source_id` — it has `patient_id` only. Every other federated view has both. The admissions tool was filtering on the non-existent `source_id`, producing a hard `ProgrammingError` on every patient admissions question.

Fix routes identity through `internal_source_reference_v` at `empi_rank = 1` — same pattern `find_patient_sql` already uses.

Closes #196.

## Why

Confirmed against the actual production DDL captured by vanna training and stored in ChromaDB. A 1-second comparison across all federated_*_v tables:

| view | `source_id` | `patient_id` |
|---|---|---|
| federated_adt_v | ❌ | ✅ |
| federated_allergies_v | ✅ | ✅ |
| federated_demographic_v | ✅ | ✅ |
| federated_encounters_v | ✅ | ✅ |
| federated_orders_v | ✅ | ✅ |
| federated_problems_v | ✅ | ✅ |
| federated_results_v | ✅ | ✅ |
| federated_vaccination_v | ✅ | ✅ |
| federated_vitals_v | ✅ | ✅ |

Production error logs show 8 failures in 2 days, all on the admissions query template, all on patient-context questions:

- "Has she ever been in the ICU?"
- "Did karen go to the emergency room in 2025?"
- "Has patient been admitted to long term care facility/hospital/other healthcare facilities during 2024?"
- ...

```
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedColumn)
column "source_id" does not exist in federated_adt_v
```

## Change

**`agent/db/queries/adt.py`** — JOIN through `internal_source_reference_v`:

```sql
SELECT
    isr.source_id AS source_id,    -- echo input through so the tool layer's
                                   -- row-shape stays uniform across domains
    adt.event_date,
    adt.event_location,
    ...
FROM dw.federated_adt_v adt
JOIN dw.internal_source_reference_v isr
  ON isr.patient_id = adt.patient_id
WHERE isr.source_id = :source_id
  AND isr.empi_rank = 1
  AND adt.event_date >= :start_date
  ...
```

`empi_rank = 1` is the canonical-CID-per-person rule that the find_patient pipeline already enforces — so the row scoping matches the rest of the agent's identity model.

**`agent/rag/seed.py`** — schema doc now says `patient_id` (with an inline isr-join hint) instead of falsely claiming `source_id`. Tightened to stay under the run_sql description budget.

**`tests/agent/redshift_synthetic.sql`** — synthetic `federated_adt_v` mirrors prod (patient_id INTEGER, not source_id TEXT). Existing rows re-keyed to patient_id 1/2, which already resolve to `src-john-1962` / `src-john-1971` via the isr table.

**`tests/agent/db/test_adt_queries.py`** — 3 new regression tests:
- `test_admissions_resolves_source_id_via_isr_join` — the generated SQL must JOIN isr at empi_rank=1, must NOT filter `adt.source_id`, and must echo `isr.source_id AS source_id`.
- `test_admissions_source_id_returned_in_rows` — result rows still carry source_id.
- `test_admissions_does_not_leak_other_patients` — the JOIN scopes rows correctly; src-john-1971 (patient_id=2) does not contaminate src-john-1962's (patient_id=1) result set.

## Test plan

- [x] `tests/agent/db/test_adt_queries.py` — 12 passed (9 existing + 3 new)
- [x] `tests/agent/` full suite — 567 passed
- [x] `ruff check` — clean
- [ ] Manual: run an admissions question against the live warehouse from dev; confirm no `UndefinedColumn` and a real ADT row set comes back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)