### PR TITLE
fix(agent): absorb transient LLM timeouts + clearer error UX (closes #198)

### DIFF
--- a/agent/models.py
+++ b/agent/models.py
@@ -18,6 +18,8 @@ import json
 from typing import Any, Literal
 
 import httpx
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
 from pydantic_ai.models.openai import OpenAIChatModel, OpenAIChatModelSettings
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.anthropic import AnthropicModel
@@ -27,6 +29,25 @@ from pydantic_ai.providers.bedrock import BedrockProvider
 
 
 ModelProvider = Literal["ollama", "anthropic", "bedrock"]
+
+
+# Default 2 in both the openai and anthropic SDKs. Bumped to 3 to absorb one
+# more transient blip from a busy Ollama / Anthropic endpoint without
+# letting wall-clock balloon — see issue #198 for the production timeout
+# pattern (14 user runs killed by a single API timeout each in one week).
+# Overridable via `agent.model_max_retries` in secrets.toml for ops tuning.
+_DEFAULT_MODEL_MAX_RETRIES = 3
+
+
+def _model_max_retries(secrets: dict) -> int:
+    """Read `agent.model_max_retries` from secrets, defaulting to 3."""
+    agent_cfg = secrets.get("agent", {}) or {}
+    raw = agent_cfg.get("model_max_retries", _DEFAULT_MODEL_MAX_RETRIES)
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MODEL_MAX_RETRIES
+    return max(0, n)
 
 
 def _read_secrets() -> dict:
@@ -142,21 +163,32 @@ def build_model() -> Any:
             think_enabled = bool(agent_cfg.get("ollama_think", True))
         reasoning_effort = "high" if think_enabled else "none"
         settings = OpenAIChatModelSettings(extra_body={"reasoning_effort": reasoning_effort})
+        # Build the AsyncOpenAI client directly so we can pass max_retries —
+        # OpenAIProvider's (base_url, http_client) path leaves the SDK on its
+        # default of 2. Ollama doesn't authenticate /v1, but the SDK requires
+        # *some* api_key to construct the client.
+        openai_client = AsyncOpenAI(
+            base_url=f"{host.rstrip('/')}/v1",
+            api_key="api-key-not-set",
+            http_client=_ollama_http_client(),
+            max_retries=_model_max_retries(secrets),
+        )
         return OpenAIChatModel(
             model_name,
-            provider=OpenAIProvider(
-                base_url=f"{host.rstrip('/')}/v1",
-                http_client=_ollama_http_client(),
-            ),
+            provider=OpenAIProvider(openai_client=openai_client),
             settings=settings,
         )
 
     if provider == "anthropic":
         api_key = ai_keys.get("anthropic_api_key") or ai_keys.get("anthropic_api")
         model_name = ai_keys.get("anthropic_model", "claude-sonnet-4-6")
+        anthropic_client = AsyncAnthropic(
+            api_key=api_key,
+            max_retries=_model_max_retries(secrets),
+        )
         return AnthropicModel(
             model_name,
-            provider=AnthropicProvider(api_key=api_key),
+            provider=AnthropicProvider(anthropic_client=anthropic_client),
         )
 
     if provider == "bedrock":

--- a/tests/agent/test_models_factory.py
+++ b/tests/agent/test_models_factory.py
@@ -156,3 +156,102 @@ def test_build_model_ollama_per_model_miss_falls_back_to_global(monkeypatch):
     )
     model = build_model()
     assert model.settings == {"extra_body": {"reasoning_effort": "none"}}
+
+
+# --- Issue #198: model client retry config -----------------------------------
+
+
+def _ollama_underlying_openai_client(model):
+    """Drill into the OpenAIChatModel returned by build_model and surface the
+    AsyncOpenAI instance underneath. Keeps the retry-config tests independent
+    of how pydantic-ai wires its `_client` attribute on a given version."""
+    # OpenAIChatModel -> Provider -> AsyncOpenAI via `.client`
+    return model.client
+
+
+def test_build_model_ollama_sets_default_max_retries(monkeypatch):
+    """Default raises the SDK floor from 2 to 3 — absorbs one transient
+    Ollama hiccup without runaway latency. See agent/models._DEFAULT_MODEL_MAX_RETRIES."""
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {"provider": "ollama", "ollama_model": "qwen3.6:27b"},
+        },
+    )
+    model = build_model()
+    client = _ollama_underlying_openai_client(model)
+    assert client.max_retries == 3
+
+
+def test_build_model_ollama_max_retries_overridable_via_secrets(monkeypatch):
+    """Ops can override the default via `[agent].model_max_retries` without
+    touching code — matches the existing `max_tool_calls` / `max_wall_clock_s` pattern."""
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {"provider": "ollama", "ollama_model": "qwen3.6:27b"},
+            "agent": {"model_max_retries": 5},
+        },
+    )
+    model = build_model()
+    client = _ollama_underlying_openai_client(model)
+    assert client.max_retries == 5
+
+
+def test_build_model_ollama_max_retries_invalid_falls_back_to_default(monkeypatch):
+    """A misconfigured secret (e.g. a string) must not crash startup."""
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {"provider": "ollama", "ollama_model": "qwen3.6:27b"},
+            "agent": {"model_max_retries": "not a number"},
+        },
+    )
+    model = build_model()
+    assert _ollama_underlying_openai_client(model).max_retries == 3
+
+
+def test_build_model_ollama_max_retries_negative_clamped_to_zero(monkeypatch):
+    """Negative is meaningless; clamp to 0 (no retries) rather than letting
+    the underlying SDK barf on a contract violation."""
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {"provider": "ollama", "ollama_model": "qwen3.6:27b"},
+            "agent": {"model_max_retries": -1},
+        },
+    )
+    model = build_model()
+    assert _ollama_underlying_openai_client(model).max_retries == 0
+
+
+def test_build_model_anthropic_sets_default_max_retries(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {
+                "provider": "anthropic",
+                "anthropic_api_key": "sk-test",
+                "anthropic_model": "claude-sonnet-4-6",
+            },
+        },
+    )
+    model = build_model()
+    # AnthropicModel -> Provider.client is an AsyncAnthropic instance.
+    assert model.client.max_retries == 3
+
+
+def test_build_model_anthropic_max_retries_overridable(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {
+                "provider": "anthropic",
+                "anthropic_api_key": "sk-test",
+                "anthropic_model": "claude-sonnet-4-6",
+            },
+            "agent": {"model_max_retries": 1},
+        },
+    )
+    model = build_model()
+    assert model.client.max_retries == 1

--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -574,3 +574,103 @@ def test_new_question_after_error_clears_pending_state(monkeypatch):
     assert fake_st.session_state.get("pending_sql_error") is False
     assert fake_st.session_state.get("last_failed_sql") in (None, "")
     assert fake_st.session_state.get("last_run_sql_error") in (None, "")
+
+
+
+# --- Issue #198: model-timeout error UX --------------------------------------
+
+
+def test_looks_like_model_timeout_by_class_name():
+    """Direct class-name match for each backend SDK's timeout/transport
+    exception. Class-name comparison (not isinstance) lets the helper stay
+    decoupled from pydantic_ai/openai/anthropic — the legacy Vanna flow
+    pulls chat_bot_helper without those installed."""
+    import utils.chat_bot_helper as cbh
+
+    cases = [
+        ("ModelAPIError", "Request timed out."),
+        ("APITimeoutError", "Request timed out."),
+        ("APIConnectionError", "Connection error."),
+        ("AnthropicAPITimeoutError", "Request timed out."),
+        ("ReadTimeout", "timed out"),
+        ("ConnectTimeout", "timed out"),
+        ("TimeoutException", "timed out"),
+    ]
+    for klass_name, msg in cases:
+        # Dynamic class with the matching name; inherits Exception so the
+        # safety-net path (which checks `isinstance(e, Exception)`) is happy.
+        exc = type(klass_name, (Exception,), {})(msg)
+        assert cbh.looks_like_model_timeout(exc), f"expected match for {klass_name}"
+
+
+def test_looks_like_model_timeout_walks_exception_chain():
+    """ModelAPIError wraps APITimeoutError via `raise ... from err`; we need
+    to recognize it even when the outer exception's class is generic."""
+    import utils.chat_bot_helper as cbh
+
+    inner = type("APITimeoutError", (Exception,), {})("Request timed out.")
+    try:
+        try:
+            raise inner
+        except Exception as e:
+            raise RuntimeError("wrapped") from e
+    except RuntimeError as e:
+        outer = e
+
+    assert cbh.looks_like_model_timeout(outer)
+
+
+def test_looks_like_model_timeout_string_fallback():
+    """A re-raise pattern that lost the original class still gets recognized
+    by message substring — last-resort defense."""
+    import utils.chat_bot_helper as cbh
+
+    assert cbh.looks_like_model_timeout(RuntimeError("Request timed out."))
+
+
+def test_looks_like_model_timeout_negative():
+    """Unrelated exceptions must NOT be misclassified — otherwise every
+    bug gets the 'model is slow' message and the user can't tell when
+    something is actually broken."""
+    import utils.chat_bot_helper as cbh
+
+    assert not cbh.looks_like_model_timeout(ValueError("bad arg"))
+    assert not cbh.looks_like_model_timeout(KeyError("missing"))
+    assert not cbh.looks_like_model_timeout(RuntimeError("kaboom from generate_sql"))
+
+
+class _RaisesModelAPIError:
+    """Mock VannaService that raises a pydantic-ai-shaped timeout."""
+
+    def is_sql_valid(self, sql):
+        return True
+
+    def generate_sql(self, question):
+        raise type("ModelAPIError", (Exception,), {})("Request timed out.")
+
+
+def test_safety_net_renders_model_slow_message_for_timeout(monkeypatch):
+    """The 14-of-15 ModelAPIErrors in the last week's logs were the user
+    re-sending after a single timeout dropped the first attempt — the
+    generic 'Something went wrong' message gave no signal to wait. The
+    new copy must explicitly call out the model server."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh, "get_ethical_guideline", lambda q: ("", 1))
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    monkeypatch.setattr(cbh, "get_vn", lambda: _RaisesModelAPIError())
+
+    cbh.set_question("Q timing out", render=False)
+    cbh.normal_message_flow("Q timing out")  # must not raise
+
+    error_msgs = [m for m in fake_st.session_state["messages"] if getattr(m, "type", None) == "error"]
+    assert error_msgs, "expected a friendly ERROR message"
+    body = error_msgs[-1].content
+    assert "model" in body.lower() and "try again" in body.lower(), (
+        f"timeout error body should call out the model + ask user to retry; got: {body!r}"
+    )
+    # Must NOT leak the raw exception text into the user-facing message —
+    # the whole point is to replace "Request timed out." with actionable copy.
+    assert "Request timed out" not in body

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1281,6 +1281,44 @@ def add_acknowledgement():
         st.write(random_acknowledgment)
 
 
+_MODEL_TIMEOUT_EXCEPTION_NAMES = frozenset(
+    {
+        # pydantic-ai wraps every backend timeout/transport error as ModelAPIError.
+        "ModelAPIError",
+        # openai SDK surface (when retries are exhausted).
+        "APITimeoutError",
+        "APIConnectionError",
+        # anthropic SDK surface.
+        "AnthropicAPITimeoutError",
+        # raw httpx transports (defense in depth — usually wrapped above).
+        "ReadTimeout",
+        "ConnectTimeout",
+        "TimeoutException",
+    }
+)
+
+
+def looks_like_model_timeout(e: BaseException) -> bool:
+    """Return True for transient LLM-backend timeout / connection failures.
+
+    Detected by class-name match so importing pydantic_ai / openai /
+    anthropic at module load is unnecessary — this helper is on the hot
+    path for the legacy Vanna flow too, which has no pydantic-ai dependency.
+    Walks the cause/context chain because ModelAPIError typically surfaces
+    a wrapped APITimeoutError, and Streamlit error boundaries sometimes
+    rewrap once more on the way up.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = e
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if type(cur).__name__ in _MODEL_TIMEOUT_EXCEPTION_NAMES:
+            return True
+        cur = cur.__cause__ or cur.__context__
+    # String fallback for re-raise patterns that lose the original class.
+    return "request timed out" in str(e).lower()
+
+
 def normal_message_flow(my_question: str):
     """Top-level entry point — wraps the flow in a safety net so that any
     unexpected exception surfaces as a friendly ERROR card instead of
@@ -1297,11 +1335,23 @@ def normal_message_flow(my_question: str):
         if not isinstance(e, Exception):
             raise
         logger.exception("Unexpected error in chat flow")
+        # The 14-of-15 ModelAPIErrors in last week's logs were the user
+        # re-sending the same question 4–5 times after one timeout dropped
+        # the first attempt — the generic "Something went wrong" message
+        # gave them no signal to wait. Branch the wording so a known-
+        # transient cause reads as "wait, then retry" instead of "broken".
+        if looks_like_model_timeout(e):
+            body = (
+                "The AI model is slow or temporarily unreachable. "
+                "Please wait a moment and try again."
+            )
+        else:
+            body = f"Something went wrong while processing your question.\n\n{e}"
         try:
             add_message(
                 Message(
                     RoleType.ASSISTANT,
-                    f"Something went wrong while processing your question.\n\n{e}",
+                    body,
                     MessageType.ERROR,
                     "",
                     my_question,
@@ -1314,7 +1364,7 @@ def normal_message_flow(my_question: str):
             logger.exception("Failed to persist friendly error message")
             try:
                 with st.chat_message(RoleType.ASSISTANT.value):
-                    render_friendly_error(str(e))
+                    render_friendly_error(body)
             except Exception:
                 logger.exception("Failed to render fallback friendly error")
         try:


### PR DESCRIPTION
## Summary

Two layered changes target the 15 `ModelAPIError`/`ReadTimeout` failures in last week's production logs (14 OpenAI/Ollama timeouts + 1 raw httpx `ReadTimeout`). Most were the same user re-sending the same question 4–5 times because the generic "Something went wrong" message didn't tell them the LLM server was slow.

Closes #198.

## Changes

### `agent/models.py` — bump SDK `max_retries`

OpenAI and Anthropic SDKs both default to `max_retries=2` and already retry on `httpx.TimeoutException` with exponential backoff. We were passing `(base_url, http_client)` to the providers, which builds the SDK client implicitly and leaves the default in place. Switched to constructing `AsyncOpenAI` / `AsyncAnthropic` ourselves so we can pass `max_retries`:

```python
openai_client = AsyncOpenAI(
    base_url=f"{host.rstrip('/')}/v1",
    api_key="api-key-not-set",  # ollama doesn't auth
    http_client=_ollama_http_client(),
    max_retries=_model_max_retries(secrets),  # default 3
)
```

Default raised to **3**. Configurable via `[agent].model_max_retries` for ops tuning. Negative/non-numeric values fall back to the default rather than crashing startup (`int("not a number")` would).

Bedrock left alone — boto3 has its own retry config with different semantics, deserves a separate PR.

### `utils/chat_bot_helper.py` — distinguish "model slow" from "broken"

`normal_message_flow`'s safety-net catches every exception and renders a friendly ERROR card. The card body now branches:

| Cause | Old copy | New copy |
|---|---|---|
| ModelAPIError, APITimeoutError, ReadTimeout, … | `Something went wrong while processing your question.\n\nRequest timed out.` | `The AI model is slow or temporarily unreachable. Please wait a moment and try again.` |
| Anything else | `Something went wrong while processing your question.\n\n{e}` | unchanged |

Detection is by class-name lookup against a frozenset of known timeout/connection exception names, plus a walk through `__cause__`/`__context__` (ModelAPIError wraps APITimeoutError via `raise ... from err`), plus a "request timed out" substring fallback. Class-name (not `isinstance`) keeps the helper decoupled from pydantic_ai/openai/anthropic — the legacy Vanna flow doesn't import them.

The exception text itself is dropped from the message body for the timeout case — the whole point is to replace "Request timed out." with actionable copy.

## Why not a runner-level retry loop?

The issue described an option for a bounded retry inside `runner.py::stream`. I considered it and chose against it:

- The OpenAI/Anthropic SDKs already retry inside the same logical "model call." Adding another retry layer on top would just multiply latency.
- Once `stream()` has yielded events to the UI (thinking deltas, tool calls), we can't "unyield" them. A runner-level retry that fires after a tool call would have to either restart the whole agent run (losing tool-call history) or replay events to the UI (visually duplicated).

Bumping the SDK-internal retry is the right layer.

## Out of scope

Item 3 from the issue ("drop reasoning_effort=high heuristic for short factoid questions") was deliberately left out. It's speculative — measurement-dependent — and would change agent behavior in ways unrelated to the timeout fix. Worth a separate ticket if the timeouts persist after this lands.

## Test plan

- [x] `tests/agent/test_models_factory.py` — 6 new (Ollama: default / overridable / invalid-falls-back / negative-clamped; Anthropic: default / overridable). 20 total pass.
- [x] `tests/utils/test_friendly_errors.py` — 4 new (class-name match per backend, `__cause__` chain walk, string fallback, negative cases + integration via `normal_message_flow`). 23 total pass.
- [x] Full `tests/agent/` + `tests/utils/` — 1015 passed, 3 skipped, 1 pre-existing Ollama-localhost failure unrelated to this PR (`test_streams_include_thinking_tokens_if_present`, requires a local Ollama with the `gpt-oss` model pulled; confirmed failing on plain main with the same 404).
- [x] `ruff check` — clean on touched files. (One pre-existing F401 in `chat_bot_helper.py` is unrelated.)
- [ ] Manual: under the next sustained Ollama slow-period in dev, confirm fewer raw ModelAPIError surfaces and the new "model is slow" copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)