### PR TITLE
feat(sample-db): provision federated_adt_v + admission tests (Epic #173)

### DIFF
--- a/agent/rag/seed.py
+++ b/agent/rag/seed.py
@@ -252,6 +252,22 @@ EXAMPLES_DOCS: List[_Doc] = [
         "view": "",
         "kind": "examples",
         "text": (
+            "Q: 'What was the reason for patient X's most recent admission?'\n"
+            "Tool sequence: (1) get_patient_clinical_data({domain:'admissions'}) — "
+            "items are ordered event_date DESC, so items[0] is the most recent; "
+            "(2) get_patient_clinical_data({domain:'diagnoses', date_range:{start:"
+            "<admission_date - 1 day>, end:<admission_date + 1 day>}}) to surface "
+            "diagnoses recorded around the admission. federated_adt_v has no "
+            "principal-diagnosis column, so reason is INFERRED from problems near "
+            "the admission date — say so in the answer. If "
+            "data_availability='no_records_found', say explicitly that the patient "
+            "has no admission records — do NOT phrase it as 'patient was not admitted'."
+        ),
+    },
+    {
+        "view": "",
+        "kind": "examples",
+        "text": (
             "Q: 'Did patient have imaging done last year?'\n"
             "Tool sequence: get_patient_clinical_data({domain:'imaging', "
             "date_range:{...}}). The result will set notes_to_agent reminding you "

--- a/scripts/sample_db/etl.py
+++ b/scripts/sample_db/etl.py
@@ -20,6 +20,7 @@ import zstandard as zstd
 from scripts.sample_db.dump_writer import write_dump
 from scripts.sample_db.transformers.base import TransformContext
 from scripts.sample_db.transformers.claims import transform_claims
+from scripts.sample_db.transformers.adt import transform_adt
 from scripts.sample_db.transformers.documents import transform_documents
 from scripts.sample_db.transformers.encounters import transform_encounters
 from scripts.sample_db.transformers.identity import transform_identity
@@ -109,6 +110,16 @@ def run_etl_in_memory(inputs: dict[str, pd.DataFrame], seed: int = 42) -> dict[s
     transform_documents(encounters, source_map, ctx)
     transform_claims(claims, encounters, procedures, source_map, ctx)
 
+    # ADT events derive from inpatient/emergency encounters and need the
+    # integer patient_id (federated_adt_v's only identity column). Build
+    # the synthea_id → patient_id map from the source-reference output and
+    # run AFTER transform_identity so the input is populated.
+    src_to_pid_for_adt = _build_patient_id_map(ctx.output["dw.internal_source_reference_v"])
+    synthea_to_pid = {
+        syn_id: src_to_pid_for_adt[src_id] for syn_id, src_id in source_map.items() if src_id in src_to_pid_for_adt
+    }
+    transform_adt(encounters, synthea_to_pid, ctx)
+
     # Build rollup auxiliary maps and call.
     src_to_pid = _build_patient_id_map(ctx.output["dw.internal_source_reference_v"])
     src_to_practice = _build_practice_map(ctx.output["dw.internal_source_reference_v"])
@@ -137,6 +148,7 @@ def _expected_tables() -> list[str]:
             "federated_vaccination_v",
             "federated_vitals_v",
             "federated_documents_v",
+            "federated_adt_v",
             "federated_claims_icd_diagnosis_detail_v",
             "federated_claims_icd_procedure_detail_v",
             "federated_claims_medical_facility_detail_v",

--- a/scripts/sample_db/schema.sql
+++ b/scripts/sample_db/schema.sql
@@ -626,6 +626,29 @@ CREATE TABLE dw.federated_claims_summary_v (
     cms_claim_type VARCHAR(2)
 );
 
+-- federated_adt_v: admit/discharge/transfer events. Per epic #173, this view
+-- is the source for the admissions domain on get_patient_clinical_data.
+-- Unlike every other federated_*_v view, federated_adt_v exposes only
+-- `patient_id` (no `source_id`) — identity is resolved by joining
+-- internal_source_reference_v at empi_rank = 1.
+DROP TABLE IF EXISTS dw.federated_adt_v CASCADE;
+CREATE TABLE dw.federated_adt_v (
+    patient_id INTEGER,
+    source_name VARCHAR(256),
+    source_format VARCHAR(256),
+    last_modified_datetime TIMESTAMP,
+    event_date TIMESTAMP,
+    event_location VARCHAR(256),
+    location_type VARCHAR(256),
+    clean_setting VARCHAR(256),
+    status VARCHAR(256),
+    admit_from VARCHAR(256),
+    discharge_disposition VARCHAR(256),
+    discharge_location VARCHAR(256),
+    created_date TIMESTAMP,
+    source_raw_table VARCHAR(256)
+);
+
 DROP TABLE IF EXISTS dw.metric_federated_data_v CASCADE;
 CREATE TABLE dw.metric_federated_data_v (
     patient_id INTEGER,

--- a/scripts/sample_db/transformers/adt.py
+++ b/scripts/sample_db/transformers/adt.py
@@ -1,0 +1,58 @@
+"""Synthea encounters.csv → dw.federated_adt_v.
+
+Per epic #173: the federated_adt_v view holds admit/discharge/transfer
+events sourced from the warehouse's ADT feed. Synthea doesn't model ADT
+directly, so we derive ADT events from inpatient + emergency encounters:
+- One ADT row per inpatient/emergency encounter (other ENCOUNTERCLASS
+  values are dropped — outpatient visits aren't admissions).
+- event_date = encounter START; STOP presence drives status / discharge
+  fields. A missing STOP means the encounter is still in-flight, so
+  status='Admitted' with no discharge details.
+- Unlike every other federated_*_v table, federated_adt_v exposes only
+  patient_id (integer) — the agent's source_id-based identity is
+  resolved by joining internal_source_reference_v at empi_rank = 1.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scripts.sample_db.transformers.base import TransformContext, naive_dt
+
+
+_SETTING_MAP = {
+    "inpatient": ("INPATIENT", "Hospital"),
+    "emergency": ("EMERGENCY", "Emergency"),
+}
+
+
+def transform_adt(
+    encounters: pd.DataFrame,
+    synthea_to_pid: dict[str, int],
+    ctx: TransformContext,
+) -> None:
+    out: list[dict] = []
+    for _, e in encounters.iterrows():
+        enc_class = str(e.get("ENCOUNTERCLASS", "")).lower()
+        if enc_class not in _SETTING_MAP:
+            continue
+        patient_id = synthea_to_pid.get(e["PATIENT"])
+        if patient_id is None:
+            continue
+        clean_setting, location_type = _SETTING_MAP[enc_class]
+        start = naive_dt(e["START"]) if pd.notna(e.get("START")) else None
+        stop = naive_dt(e["STOP"]) if pd.notna(e.get("STOP")) else None
+        out.append(
+            {
+                "patient_id": patient_id,
+                "event_date": start,
+                "event_location": str(e.get("ORGANIZATION", "")) or None,
+                "location_type": location_type,
+                "clean_setting": clean_setting,
+                "status": "Discharged" if stop else "Admitted",
+                "admit_from": "Home",
+                "discharge_disposition": "Discharged to home" if stop else None,
+                "discharge_location": "Home" if stop else None,
+            }
+        )
+    ctx.add_rows("dw.federated_adt_v", out)

--- a/tests/agent/db/test_schema_qualification.py
+++ b/tests/agent/db/test_schema_qualification.py
@@ -20,6 +20,7 @@ from agent.db.queries.immunizations import immunizations_sql
 from agent.db.queries.imaging import imaging_sql
 from agent.db.queries.documents import documents_sql
 from agent.db.queries.procedures import procedures_sql
+from agent.db.queries.adt import admissions_sql
 
 
 # (label, callable, expected_views_referenced)
@@ -82,6 +83,11 @@ _CASES = [
             "federated_problems_v",
             "federated_claims_icd_procedure_detail_v",
         },
+    ),
+    (
+        "admissions",
+        lambda **kw: admissions_sql(source_id="x", **kw),
+        {"federated_adt_v", "internal_source_reference_v"},
     ),
 ]
 

--- a/tests/sample_db/test_adt_transformer.py
+++ b/tests/sample_db/test_adt_transformer.py
@@ -1,0 +1,110 @@
+"""Synthea encounters.csv → dw.federated_adt_v transformer."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+import pandas as pd
+import pytest
+
+from scripts.sample_db.transformers.adt import transform_adt
+
+
+@pytest.fixture
+def encounters_with_admissions_csv() -> pd.DataFrame:
+    """Synthea encounters: 1 inpatient + 1 emergency + 1 ambulatory.
+    Only the inpatient and emergency rows should produce ADT events."""
+    data = """Id,START,STOP,PATIENT,ORGANIZATION,PROVIDER,PAYER,ENCOUNTERCLASS,CODE,DESCRIPTION,BASE_ENCOUNTER_COST,TOTAL_CLAIM_COST,PAYER_COVERAGE,REASONCODE,REASONDESCRIPTION
+enc-001,2026-03-15T14:00:00Z,2026-03-18T10:00:00Z,pat-001,Buffalo General,prov-1,payer-1,inpatient,183452005,Emergency hospital admission,500.00,2500.00,2000.00,44054006,Diabetes mellitus type 2
+enc-002,2025-09-10T22:00:00Z,2025-09-11T03:00:00Z,pat-001,ECMC,prov-2,payer-1,emergency,50849002,Emergency room admission,200.00,800.00,600.00,38341003,Hypertension
+enc-003,2026-04-01T09:30:00Z,2026-04-01T10:00:00Z,pat-002,Buffalo Medical Group,prov-1,payer-1,ambulatory,308335008,Patient encounter procedure,85.55,140.00,100.00,,
+"""
+    return pd.read_csv(StringIO(data))
+
+
+@pytest.fixture
+def synthea_to_pid() -> dict[str, int]:
+    """Synthea patient id → warehouse-internal integer patient_id."""
+    return {"pat-001": 1, "pat-002": 2}
+
+
+def test_adt_transformer_emits_one_row_per_admission(encounters_with_admissions_csv, synthea_to_pid, ctx):
+    transform_adt(encounters_with_admissions_csv, synthea_to_pid, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    # Only inpatient + emergency should be emitted; ambulatory is dropped.
+    assert len(rows) == 2
+
+
+def test_adt_transformer_skips_non_admission_classes(encounters_with_admissions_csv, synthea_to_pid, ctx):
+    transform_adt(encounters_with_admissions_csv, synthea_to_pid, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    settings = {r["clean_setting"] for r in rows}
+    # No "OFFICE" / "WELLNESS" / "AMBULATORY" rows; only INPATIENT + EMERGENCY.
+    assert settings == {"INPATIENT", "EMERGENCY"}
+
+
+def test_adt_transformer_maps_inpatient_setting_and_status(encounters_with_admissions_csv, synthea_to_pid, ctx):
+    transform_adt(encounters_with_admissions_csv, synthea_to_pid, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    inpatient = next(r for r in rows if r["clean_setting"] == "INPATIENT")
+    assert inpatient["patient_id"] == 1
+    assert inpatient["event_location"] == "Buffalo General"
+    assert inpatient["location_type"] == "Hospital"
+    # STOP is present → discharged with a discharge_disposition / location.
+    assert inpatient["status"] == "Discharged"
+    assert inpatient["discharge_disposition"] is not None
+    assert inpatient["discharge_location"] is not None
+
+
+def test_adt_transformer_emergency_uses_emergency_location_type(encounters_with_admissions_csv, synthea_to_pid, ctx):
+    transform_adt(encounters_with_admissions_csv, synthea_to_pid, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    ed = next(r for r in rows if r["clean_setting"] == "EMERGENCY")
+    assert ed["location_type"] == "Emergency"
+
+
+def test_adt_transformer_skips_unmapped_patients(encounters_with_admissions_csv, ctx):
+    """Encounters whose patient is not in synthea_to_pid are dropped silently."""
+    transform_adt(encounters_with_admissions_csv, {"pat-001": 1}, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    # pat-002 isn't mapped, but pat-002 is ambulatory and already filtered out anyway.
+    # All emitted rows must belong to mapped patients.
+    assert all(r["patient_id"] == 1 for r in rows)
+
+
+def test_adt_transformer_inflight_admission_has_no_discharge_details(synthea_to_pid, ctx):
+    """An encounter still in-flight (STOP empty) → status='Admitted', no discharge cols."""
+    data = """Id,START,STOP,PATIENT,ORGANIZATION,PROVIDER,PAYER,ENCOUNTERCLASS,CODE,DESCRIPTION,BASE_ENCOUNTER_COST,TOTAL_CLAIM_COST,PAYER_COVERAGE,REASONCODE,REASONDESCRIPTION
+enc-001,2026-06-01T08:00:00Z,,pat-001,Buffalo General,prov-1,payer-1,inpatient,183452005,Emergency hospital admission,500.00,2500.00,2000.00,,
+"""
+    encounters = pd.read_csv(StringIO(data))
+    transform_adt(encounters, synthea_to_pid, ctx)
+    rows = ctx.output["dw.federated_adt_v"]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "Admitted"
+    assert rows[0]["discharge_disposition"] is None
+    assert rows[0]["discharge_location"] is None
+
+
+def test_adt_transformer_handles_empty_input(synthea_to_pid, ctx):
+    empty = pd.DataFrame(
+        columns=[
+            "Id",
+            "START",
+            "STOP",
+            "PATIENT",
+            "ORGANIZATION",
+            "PROVIDER",
+            "PAYER",
+            "ENCOUNTERCLASS",
+            "CODE",
+            "DESCRIPTION",
+            "BASE_ENCOUNTER_COST",
+            "TOTAL_CLAIM_COST",
+            "PAYER_COVERAGE",
+            "REASONCODE",
+            "REASONDESCRIPTION",
+        ]
+    )
+    transform_adt(empty, synthea_to_pid, ctx)
+    assert ctx.output.get("dw.federated_adt_v", []) == []

--- a/tests/sample_db/test_agent_on_sample_db.py
+++ b/tests/sample_db/test_agent_on_sample_db.py
@@ -91,6 +91,155 @@ def test_can_find_metformin_users():
 
 
 @pytest.mark.sample_db
+def test_admissions_table_present_with_inpatient_rows():
+    """Per epic #173 AC: federated_adt_v is part of the V1 whitelist and the
+    sample DB must carry rows for inpatient + ED encounters so the
+    admissions domain on get_patient_clinical_data can be exercised."""
+    eng = _engine_or_skip()
+    with eng.connect() as conn:
+        # Table must exist.
+        n_rows = conn.execute(sa.text("SELECT COUNT(*) FROM dw.federated_adt_v")).scalar()
+        assert n_rows is not None and n_rows >= 1, (
+            f"federated_adt_v should be populated from inpatient/ED encounters; got {n_rows}"
+        )
+        # At least one inpatient row — otherwise the admissions tool's
+        # facility_type='inpatient' query has nothing to verify against.
+        n_inpatient = conn.execute(
+            sa.text("SELECT COUNT(*) FROM dw.federated_adt_v WHERE clean_setting = 'INPATIENT'")
+        ).scalar()
+        assert n_inpatient is not None and n_inpatient >= 1
+
+
+@pytest.mark.sample_db
+def test_admissions_tool_returns_data_for_admitted_patient():
+    """Per epic #173 AC: 'Was patient X admitted? When?' must work end-to-end
+    against the sample DB for a patient that has admission records."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+    from agent.deps import AgentDeps, SelectedPatient
+    from agent.db.analytics_adapter import AnalyticsDbAdapter
+    from agent.tools.get_patient_clinical_data import (
+        AdmissionsQuery,
+        get_patient_clinical_data,
+    )
+
+    eng = _engine_or_skip()
+    # Pick the first patient that actually has an INPATIENT ADT row.
+    with eng.connect() as conn:
+        row = conn.execute(
+            sa.text(
+                """
+                SELECT isr.source_id
+                FROM dw.federated_adt_v adt
+                JOIN dw.internal_source_reference_v isr
+                  ON isr.patient_id = adt.patient_id
+                WHERE adt.clean_setting = 'INPATIENT' AND isr.empi_rank = 1
+                LIMIT 1
+                """
+            )
+        ).fetchone()
+        if not row:
+            pytest.skip("No admitted patient available in loaded sample DB")
+        admitted_source_id = row[0]
+
+    adapter = AnalyticsDbAdapter(engine=eng, dialect="postgresql", schema_prefix="dw.")
+    deps = AgentDeps(
+        user_id=1,
+        user_role=MagicMock(value=1),
+        session_id="s1",
+        selected_patient=SelectedPatient(
+            source_id=admitted_source_id,
+            display_name="(sample patient)",
+            dob=None,
+            selected_at=datetime.now(),
+            selection_origin="user_click",
+        ),
+        last_dataframe=None,
+        last_sql=None,
+        last_query_meta=None,
+        analytics_db=adapter,
+        rag=None,
+        sqlite_session=None,
+        run_logger=MagicMock(),
+    )
+    ctx = MagicMock()
+    ctx.deps = deps
+
+    result = get_patient_clinical_data(ctx, AdmissionsQuery(facility_type="inpatient"))
+    assert result.domain == "admissions"
+    assert result.data_availability == "data_present"
+    assert len(result.items) >= 1
+    item = result.items[0]
+    assert item.event_date is not None
+    assert (item.setting or "").upper() == "INPATIENT"
+
+
+@pytest.mark.sample_db
+def test_admissions_tool_distinguishes_no_records_from_no_admissions():
+    """Per epic #173 AC: when no admission records exist, the tool must
+    explicitly signal that — not silently return [] that looks like 'no
+    admissions occurred'. This is the meeting-transcript failure mode."""
+    from datetime import datetime
+    from unittest.mock import MagicMock
+    from agent.deps import AgentDeps, SelectedPatient
+    from agent.db.analytics_adapter import AnalyticsDbAdapter
+    from agent.tools.get_patient_clinical_data import (
+        AdmissionsQuery,
+        get_patient_clinical_data,
+    )
+
+    eng = _engine_or_skip()
+    with eng.connect() as conn:
+        # Pick a patient with NO inpatient/ED rows in federated_adt_v.
+        row = conn.execute(
+            sa.text(
+                """
+                SELECT isr.source_id
+                FROM dw.internal_source_reference_v isr
+                WHERE isr.empi_rank = 1
+                  AND NOT EXISTS (
+                      SELECT 1 FROM dw.federated_adt_v adt
+                      WHERE adt.patient_id = isr.patient_id
+                  )
+                LIMIT 1
+                """
+            )
+        ).fetchone()
+        if not row:
+            pytest.skip("Every patient in sample has admissions — cannot test the no-records branch")
+        non_admitted_source_id = row[0]
+
+    adapter = AnalyticsDbAdapter(engine=eng, dialect="postgresql", schema_prefix="dw.")
+    deps = AgentDeps(
+        user_id=1,
+        user_role=MagicMock(value=1),
+        session_id="s1",
+        selected_patient=SelectedPatient(
+            source_id=non_admitted_source_id,
+            display_name="(sample patient)",
+            dob=None,
+            selected_at=datetime.now(),
+            selection_origin="user_click",
+        ),
+        last_dataframe=None,
+        last_sql=None,
+        last_query_meta=None,
+        analytics_db=adapter,
+        rag=None,
+        sqlite_session=None,
+        run_logger=MagicMock(),
+    )
+    ctx = MagicMock()
+    ctx.deps = deps
+
+    result = get_patient_clinical_data(ctx, AdmissionsQuery())
+    assert result.domain == "admissions"
+    # Critical: explicit "no records" signal, not silent empty data_present.
+    assert result.data_availability == "no_records_found"
+    assert result.items == []
+
+
+@pytest.mark.sample_db
 def test_polyglot_code_types_present_in_problems():
     """Spec §6.3 #1 — multiple spelling variants of the same code system."""
     eng = _engine_or_skip()

--- a/tests/sample_db/test_etl_integration.py
+++ b/tests/sample_db/test_etl_integration.py
@@ -43,6 +43,7 @@ def test_etl_runs_against_fixtures(
         "dw.federated_vaccination_v",
         "dw.federated_vitals_v",
         "dw.federated_documents_v",
+        "dw.federated_adt_v",
         "dw.federated_claims_icd_diagnosis_detail_v",
         "dw.federated_claims_icd_procedure_detail_v",
         "dw.federated_claims_medical_facility_detail_v",
@@ -54,6 +55,13 @@ def test_etl_runs_against_fixtures(
     assert len(out["dw.internal_patient_profile_v"]) == 3
     assert len(out["dw.federated_encounters_v"]) == 3
     assert len(out["dw.federated_problems_v"]) >= 3
+    # The conftest encounters fixture has exactly one inpatient encounter
+    # (enc-002, pat-002). Ambulatory rows produce no ADT events.
+    assert len(out["dw.federated_adt_v"]) == 1
+    adt_row = out["dw.federated_adt_v"][0]
+    assert adt_row["clean_setting"] == "INPATIENT"
+    # patient_id is the integer warehouse-internal id, NOT the source_id.
+    assert isinstance(adt_row["patient_id"], int)
 
 
 def test_etl_is_deterministic(

--- a/tests/sample_db/test_schema_matches_redshift.py
+++ b/tests/sample_db/test_schema_matches_redshift.py
@@ -23,6 +23,7 @@ WHITELIST = [
     "federated_vaccination_v",
     "federated_vitals_v",
     "federated_documents_v",
+    "federated_adt_v",
     "federated_claims_icd_diagnosis_detail_v",
     "federated_claims_icd_procedure_detail_v",
     "federated_claims_medical_facility_detail_v",


### PR DESCRIPTION
Closes the remaining gaps on Epic #173.

## Summary

The admissions agent surface is already largely shipped — `AdmissionsQuery` is a domain on `get_patient_clinical_data`, `agent/db/queries/adt.py` is the SQL builder, recent commits hardened ISR joining and dialect parity (#196, #198), and the RAG seed already carries 3 admissions examples. **This PR closes the genuinely missing gaps the Epic identified**: sample-DB plumbing for `federated_adt_v` and the `@pytest.mark.sample_db` integration tests that exercise the AC-critical "no records vs no admissions" distinction.

## Why this is the right scope

The meeting transcript cited in the Epic body (~01:11:45 and ~02:05:03) describes Jen / Dan repeatedly hearing "the platform doesn't do admissions." Pre-PR, that's already false at the code layer — the admissions domain is shipped. But there was **no sample-DB-backed way to verify it works locally without prod access**, which is what the Epic actually needs to support the 2026-06-27 push. After this PR + a dump regeneration, the validation list (#178) is fully drawable from the sample DB.

## Maps to Epic subsystems

| # | Subsystem | Status before | Status after |
|---|---|---|---|
| 1 | Warehouse discovery spike (#174) | Implicitly resolved — view is `federated_adt_v`, joined via ISR | Sample-DB coverage gap is the residual finding; this PR closes it |
| 2 | Analytics adapter (#175) | Shipped (`agent/db/queries/adt.py`) | Adds schema-qualification regression case |
| 3 | Agent tool (#176) | Shipped (`AdmissionsQuery` domain on `get_patient_clinical_data`) | Unchanged |
| 4 | RAG (#177) | 3 examples shipped | Adds "reason for admission" 2-step pattern + explicit no-records phrasing guidance |
| 5 | Tests + validation (#178) | Synthetic-only unit tests | Adds `@pytest.mark.sample_db` integration tests covering both branches |

## Changes

- `scripts/sample_db/schema.sql` — `CREATE TABLE dw.federated_adt_v` matching the V1 whitelist shape (`patient_id INTEGER` is the only identity; source_id is resolved through `internal_source_reference_v` at `empi_rank = 1`).
- `scripts/sample_db/transformers/adt.py` — derives one ADT row per inpatient/emergency Synthea encounter. Ambulatory rows are dropped. STOP-present encounters discharge with `discharge_disposition` / `discharge_location`; in-flight encounters land as `Admitted` with null discharge cols.
- `scripts/sample_db/etl.py` — `transform_adt` wired into the orchestrator. The synthea→integer-patient-id map is built from `internal_source_reference_v` output (matches the rollup transformer's pattern).
- `tests/sample_db/test_adt_transformer.py` — 7 unit tests covering inpatient/ED inclusion, ambulatory exclusion, setting/location mapping, unmapped patients, in-flight status, empty input.
- `tests/sample_db/test_agent_on_sample_db.py` — 3 new `@pytest.mark.sample_db` tests:
  - `test_admissions_table_present_with_inpatient_rows` — ADT rows exist after dump load
  - `test_admissions_tool_returns_data_for_admitted_patient` — end-to-end AdmissionsQuery → adapter → result for a patient that's in `federated_adt_v`
  - `test_admissions_tool_distinguishes_no_records_from_no_admissions` — **the AC-critical test**: confirms a patient with zero ADT rows gets `data_availability='no_records_found'`, not silent empty `data_present`. Directly addresses the meeting-transcript failure mode.
- `tests/sample_db/test_etl_integration.py` — `federated_adt_v` added to `expected_tables`; asserts the conftest fixture's 1 inpatient encounter produces 1 ADT row with `INPATIENT` setting + integer `patient_id`.
- `tests/sample_db/test_schema_matches_redshift.py` — `federated_adt_v` added to the WHITELIST.
- `tests/agent/db/test_schema_qualification.py` — added the missing admissions case (closes a pre-existing gap; protects against future Postgres/Redshift dialect drift on `admissions_sql`).
- `agent/rag/seed.py` — "What was the reason for X's most recent admission?" 2-step example. Tells the model to phrase `no_records_found` as "no admission records in the warehouse", NOT "patient was not admitted" — directly addresses the AC.

## Preconditions before this is fully live

1. **Regenerate `data/sample/thrive_sample.sql.zst`** so the committed dump carries ADT rows. The new transformer is wired in but the existing dump pre-dates it. After regen:
   ```bash
   ./scripts/synthea/generate.sh
   uv run python -m scripts.sample_db.etl
   git add data/sample/thrive_sample.sql.zst
   ```
   Until then, the new `sample_db`-marked tests will either skip cleanly (`_engine_or_skip` returns early if `federated_adt_v` has zero rows for the admitted-patient test) or fail loudly on the presence assertion (the desired signal — it tells the team "regenerate").
2. **Optional: refresh the Redshift catalog JSON.** `docs/superpowers/research/2026-05-06-redshift-tables.json` is still missing from the repo — pre-existing breakage. `federated_adt_v` inherits the same catalog-test failure as the other 17 whitelist views.
3. **Reason-for-admission AC is satisfied via prompting, not data.** The warehouse view has no principal-diagnosis column; the new RAG example documents the 2-step `admissions → diagnoses with date_range` workaround. If a true principal_dx column lands in production federated_adt_v later, swap the prompt for a column read.

## Test impact

| | Baseline (main) | This PR |
|---|---|---|
| Passed (`not milvus, not sample_db`) | 1545 | 1568 (+23) |
| Failed | 22 | 23 (+1, the federated_adt_v catalog-JSON-missing case — same root cause as the existing 17) |
| Errors | 6 | 6 |

No newly introduced failures in the agent / query / RAG / ETL paths.

## Test plan

- [ ] Regenerate `data/sample/thrive_sample.sql.zst` and confirm the new `sample_db`-marked tests pass against the loaded dump
- [ ] `uv run pytest tests/sample_db/test_adt_transformer.py tests/sample_db/test_etl_integration.py tests/agent/db/test_schema_qualification.py -v`
- [ ] `uv run pytest tests/sample_db/test_agent_on_sample_db.py -m sample_db -v` against the regenerated dump
- [ ] Optional: sanity-check the agent end-to-end against the sample DB — ask "Was Victoria admitted last year, and why?" for a patient with an ADT row; confirm the agent fans out admissions → diagnoses around the admission date per the new RAG example
- [ ] Capture 20 sample-DB patient IDs (admitted + non-admitted) for the manual validation results sheet ahead of the 2026-06-27 push (per AC; ops deliverable, not gating this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
