### PR TITLE
feat(agent): allergy SNOMED code set + search_codes intent shortcut (#203)

### DIFF
--- a/agent/codes/allergies.py
+++ b/agent/codes/allergies.py
@@ -1,0 +1,84 @@
+"""Curated allergy SNOMED code allow-list, grouped by clinical category.
+
+This module is the shared source of truth for allergy SNOMED codes used
+across the agent. It backs two consumers:
+
+1. `search_codes` — the allergy-intent shortcut (e.g., "penicillin allergy",
+   "any food allergy") routes through `synonyms.json` for the `snomed`
+   vocabulary to the curated subsets defined here.
+2. Future allergy-domain tooling on `get_patient_clinical_data` and the
+   `federated_problems_v` fallback path (Epic #201) — when the dedicated
+   `federated_allergies_v` view is unavailable, the agent identifies
+   allergies in the problem list via this allow-list.
+
+The categories follow Epic #203:
+
+- drug — antibiotic / analgesic class allergies
+- food — IgE-mediated food allergens
+- environmental — pollens, allergic rhinitis variants
+- contact — latex and other contact-route allergens
+- anaphylaxis — life-threatening / acute systemic reactions
+
+Hand-curated and intentionally small. Expand by category as concrete
+coverage gaps surface during agent evaluation rather than guessing at
+completeness.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+
+ALLERGY_SNOMED_BY_CATEGORY: Final[dict[str, list[str]]] = {
+    "drug": [
+        "91936005",   # Allergy to penicillin
+        "294505008",  # Allergy to amoxicillin
+        "91937001",   # Allergy to sulfonamide
+        "293584003",  # Allergy to aspirin
+        "293586001",  # Allergy to NSAID
+    ],
+    "food": [
+        "91934008",   # Allergy to peanut
+        "91935009",   # Allergy to nut
+        "300913006",  # Allergy to seafood
+        "417532002",  # Allergy to fish
+        "91938006",   # Allergy to dairy
+        "91930004",   # Allergy to eggs
+        "300915002",  # Allergy to wheat
+    ],
+    "environmental": [
+        "232347008",  # Allergic rhinitis due to pollen
+        "446096008",  # Perennial allergic rhinitis
+        "367498001",  # Seasonal allergic rhinitis
+        "232353008",  # Perennial allergic rhinitis with seasonal variation
+        "418689008",  # Allergy to grass pollen
+    ],
+    "contact": [
+        "300916003",  # Allergy to latex
+    ],
+    "anaphylaxis": [
+        "39579001",   # Anaphylaxis
+        "241929008",  # Acute allergic reaction
+    ],
+}
+
+
+ALLERGY_CATEGORIES: Final[tuple[str, ...]] = tuple(ALLERGY_SNOMED_BY_CATEGORY.keys())
+
+
+def codes_for_category(category: str) -> list[str]:
+    """Return the SNOMED codes for a single allergy category.
+
+    Raises ValueError on unknown category so callers don't silently
+    drop a typo into a successful empty lookup.
+    """
+    if category not in ALLERGY_SNOMED_BY_CATEGORY:
+        raise ValueError(
+            f"unknown allergy category {category!r}; expected one of {ALLERGY_CATEGORIES}"
+        )
+    return list(ALLERGY_SNOMED_BY_CATEGORY[category])
+
+
+def all_allergy_codes() -> list[str]:
+    """Return every curated allergy SNOMED code, in category order."""
+    return [code for codes in ALLERGY_SNOMED_BY_CATEGORY.values() for code in codes]

--- a/agent/codes/data/snomed.json
+++ b/agent/codes/data/snomed.json
@@ -1,0 +1,22 @@
+[
+    {"code": "91936005", "display_name": "Allergy to penicillin (finding)", "is_active": true},
+    {"code": "294505008", "display_name": "Allergy to amoxicillin (finding)", "is_active": true},
+    {"code": "91937001", "display_name": "Allergy to sulfonamide (finding)", "is_active": true},
+    {"code": "293584003", "display_name": "Allergy to aspirin (finding)", "is_active": true},
+    {"code": "293586001", "display_name": "Allergy to non-steroidal anti-inflammatory agent (finding)", "is_active": true},
+    {"code": "91934008", "display_name": "Allergy to peanut (finding)", "is_active": true},
+    {"code": "91935009", "display_name": "Allergy to nut (finding)", "is_active": true},
+    {"code": "300913006", "display_name": "Allergy to seafood (finding)", "is_active": true},
+    {"code": "417532002", "display_name": "Allergy to fish (finding)", "is_active": true},
+    {"code": "91938006", "display_name": "Allergy to dairy product (finding)", "is_active": true},
+    {"code": "91930004", "display_name": "Allergy to eggs (finding)", "is_active": true},
+    {"code": "300915002", "display_name": "Allergy to wheat (finding)", "is_active": true},
+    {"code": "232347008", "display_name": "Allergic rhinitis due to pollen (disorder)", "is_active": true},
+    {"code": "446096008", "display_name": "Perennial allergic rhinitis (disorder)", "is_active": true},
+    {"code": "367498001", "display_name": "Seasonal allergic rhinitis (disorder)", "is_active": true},
+    {"code": "232353008", "display_name": "Perennial allergic rhinitis with seasonal variation (disorder)", "is_active": true},
+    {"code": "418689008", "display_name": "Allergy to grass pollen (finding)", "is_active": true},
+    {"code": "300916003", "display_name": "Allergy to latex (finding)", "is_active": true},
+    {"code": "241929008", "display_name": "Acute allergic reaction (disorder)", "is_active": true},
+    {"code": "39579001", "display_name": "Anaphylaxis (disorder)", "is_active": true}
+]

--- a/agent/codes/data/synonyms.json
+++ b/agent/codes/data/synonyms.json
@@ -1754,5 +1754,190 @@
       ],
       "codes": ["80061"]
     }
+  },
+  "snomed": {
+    "drug allergy": {
+      "synonyms": [
+        "drug allergies",
+        "medication allergy",
+        "medication allergies",
+        "rx allergy",
+        "any drug allergy",
+        "any medication allergy",
+        "drug hypersensitivity"
+      ],
+      "codes": [
+        "91936005",
+        "294505008",
+        "91937001",
+        "293584003",
+        "293586001"
+      ]
+    },
+    "food allergy": {
+      "synonyms": [
+        "food allergies",
+        "food sensitivity",
+        "any food allergy",
+        "food hypersensitivity"
+      ],
+      "codes": [
+        "91934008",
+        "91935009",
+        "300913006",
+        "417532002",
+        "91938006",
+        "91930004",
+        "300915002"
+      ]
+    },
+    "environmental allergy": {
+      "synonyms": [
+        "environmental allergies",
+        "any environmental allergy",
+        "hay fever",
+        "allergic rhinitis",
+        "seasonal allergies",
+        "seasonal allergy",
+        "pollen allergy",
+        "pollen allergies"
+      ],
+      "codes": [
+        "232347008",
+        "446096008",
+        "367498001",
+        "232353008",
+        "418689008"
+      ]
+    },
+    "contact allergy": {
+      "synonyms": [
+        "contact allergies",
+        "any contact allergy",
+        "contact hypersensitivity"
+      ],
+      "codes": ["300916003"]
+    },
+    "anaphylaxis": {
+      "synonyms": [
+        "anaphylactic reaction",
+        "anaphylactic shock",
+        "severe allergic reaction",
+        "acute allergic reaction",
+        "systemic allergic reaction"
+      ],
+      "codes": ["39579001", "241929008"]
+    },
+    "penicillin allergy": {
+      "synonyms": [
+        "pcn allergy",
+        "allergic to penicillin",
+        "penicillin sensitivity",
+        "allergy to penicillin"
+      ],
+      "codes": ["91936005", "294505008"]
+    },
+    "amoxicillin allergy": {
+      "synonyms": [
+        "allergic to amoxicillin",
+        "amox allergy",
+        "allergy to amoxicillin"
+      ],
+      "codes": ["294505008"]
+    },
+    "sulfa allergy": {
+      "synonyms": [
+        "sulfonamide allergy",
+        "sulfa drugs allergy",
+        "allergic to sulfa",
+        "allergy to sulfonamide",
+        "sulfonamide hypersensitivity"
+      ],
+      "codes": ["91937001"]
+    },
+    "aspirin allergy": {
+      "synonyms": [
+        "asa allergy",
+        "allergic to aspirin",
+        "allergy to aspirin",
+        "salicylate allergy"
+      ],
+      "codes": ["293584003"]
+    },
+    "nsaid allergy": {
+      "synonyms": [
+        "nsaids allergy",
+        "non-steroidal anti-inflammatory allergy",
+        "allergic to nsaids",
+        "allergy to nsaid"
+      ],
+      "codes": ["293586001"]
+    },
+    "peanut allergy": {
+      "synonyms": [
+        "allergic to peanuts",
+        "allergy to peanut",
+        "peanut hypersensitivity"
+      ],
+      "codes": ["91934008"]
+    },
+    "nut allergy": {
+      "synonyms": [
+        "tree nut allergy",
+        "allergic to nuts",
+        "allergy to nuts",
+        "treenut allergy"
+      ],
+      "codes": ["91935009", "91934008"]
+    },
+    "seafood allergy": {
+      "synonyms": [
+        "shellfish allergy",
+        "allergic to seafood",
+        "allergy to seafood"
+      ],
+      "codes": ["300913006", "417532002"]
+    },
+    "fish allergy": {
+      "synonyms": [
+        "allergic to fish",
+        "allergy to fish"
+      ],
+      "codes": ["417532002"]
+    },
+    "dairy allergy": {
+      "synonyms": [
+        "milk allergy",
+        "allergic to dairy",
+        "allergic to milk",
+        "allergy to dairy",
+        "lactose allergy"
+      ],
+      "codes": ["91938006"]
+    },
+    "egg allergy": {
+      "synonyms": [
+        "allergic to eggs",
+        "allergy to eggs",
+        "egg white allergy"
+      ],
+      "codes": ["91930004"]
+    },
+    "wheat allergy": {
+      "synonyms": [
+        "allergic to wheat",
+        "allergy to wheat",
+        "gluten allergy"
+      ],
+      "codes": ["300915002"]
+    },
+    "latex allergy": {
+      "synonyms": [
+        "allergic to latex",
+        "allergy to latex",
+        "rubber allergy"
+      ],
+      "codes": ["300916003"]
+    }
   }
 }

--- a/agent/codes/loader.py
+++ b/agent/codes/loader.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from typing import List
 
 
-_VOCABS = ("loinc", "cvx", "rxnorm", "icd10", "cpt")
+_VOCABS = ("loinc", "cvx", "rxnorm", "icd10", "cpt", "snomed")
 _DATA_DIR = Path(__file__).parent / "data"
 
 

--- a/agent/tools/search_codes.py
+++ b/agent/tools/search_codes.py
@@ -1,7 +1,12 @@
-"""search_codes — vocabulary lookup for ICD-10 / LOINC / CVX / RxNorm / CPT.
+"""search_codes — vocabulary lookup for ICD-10 / LOINC / CVX / RxNorm / CPT / SNOMED.
 
 Per spec §7.4: backed by embedded code reference tables (see
 agent/codes/data/*.json).
+
+SNOMED coverage in this build is currently allergy-focused (Epic #203);
+the curated category buckets live in agent/codes/allergies.py and are
+reachable via `synonyms.json` entries like "penicillin allergy",
+"peanut allergy", and "any food allergy".
 """
 
 from __future__ import annotations
@@ -17,7 +22,7 @@ from agent.deps import AgentDeps
 class CodeSearchInput(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    vocabulary: Literal["icd10", "loinc", "cvx", "rxnorm", "cpt"]
+    vocabulary: Literal["icd10", "loinc", "cvx", "rxnorm", "cpt", "snomed"]
     query: str
     limit: int = Field(default=20, le=50)
 

--- a/tests/agent/codes/test_allergies.py
+++ b/tests/agent/codes/test_allergies.py
@@ -1,0 +1,88 @@
+# tests/agent/codes/test_allergies.py
+"""Tests for the curated allergy SNOMED code allow-list (Epic #203).
+
+The module is the shared source of truth for allergy SNOMED codes. These
+tests pin the categories the epic ships with, the contract of the helpers
+that other tools will consume, and the invariant that every curated code
+exists in agent/codes/data/snomed.json (drift guard).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.codes.allergies import (
+    ALLERGY_CATEGORIES,
+    ALLERGY_SNOMED_BY_CATEGORY,
+    all_allergy_codes,
+    codes_for_category,
+)
+from agent.codes.loader import VocabLoader
+
+
+EXPECTED_CATEGORIES = ("drug", "food", "environmental", "contact", "anaphylaxis")
+
+
+def test_categories_match_epic_203():
+    assert tuple(ALLERGY_SNOMED_BY_CATEGORY.keys()) == EXPECTED_CATEGORIES
+    assert ALLERGY_CATEGORIES == EXPECTED_CATEGORIES
+
+
+def test_every_category_is_non_empty():
+    for category, codes in ALLERGY_SNOMED_BY_CATEGORY.items():
+        assert codes, f"category {category!r} has no codes — empty buckets are not allowed"
+
+
+def test_codes_for_category_returns_independent_copy():
+    """codes_for_category must hand callers a mutable copy so they can
+    splice/filter without poisoning the module-level table."""
+    first = codes_for_category("drug")
+    first.append("FAKE")
+    second = codes_for_category("drug")
+    assert "FAKE" not in second
+
+
+def test_codes_for_category_unknown_raises():
+    with pytest.raises(ValueError, match="unknown allergy category"):
+        codes_for_category("not-a-category")
+
+
+def test_all_allergy_codes_is_union_in_category_order():
+    flat = all_allergy_codes()
+    expected = [c for codes in ALLERGY_SNOMED_BY_CATEGORY.values() for c in codes]
+    assert flat == expected
+
+
+def test_all_allergy_codes_have_no_cross_category_duplicates():
+    """If a code lands in two categories that's a curation mistake — pick
+    the primary category. Reviewers will rely on this invariant."""
+    flat = all_allergy_codes()
+    assert len(flat) == len(set(flat)), (
+        f"duplicate codes across categories: "
+        f"{[c for c in flat if flat.count(c) > 1]}"
+    )
+
+
+def test_drift_guard_every_curated_code_exists_in_snomed_data():
+    """Every code in ALLERGY_SNOMED_BY_CATEGORY must exist in the
+    snomed.json data file — otherwise search_codes will silently drop
+    it via its phantom-code filter and downstream tools will end up with
+    a quietly empty result."""
+    data_codes = {row["code"] for row in VocabLoader().entries("snomed")}
+    missing = [c for c in all_allergy_codes() if c not in data_codes]
+    assert not missing, f"curated codes missing from snomed.json: {missing}"
+
+
+def test_drug_category_includes_penicillin_and_amoxicillin():
+    """Spot-check: the drug bucket must include both penicillin (91936005)
+    and amoxicillin (294505008) — the agent uses this pairing for the
+    cross-reactive answer to 'penicillin allergy'."""
+    drug = codes_for_category("drug")
+    assert "91936005" in drug
+    assert "294505008" in drug
+
+
+def test_anaphylaxis_category_includes_systemic_codes():
+    anaph = codes_for_category("anaphylaxis")
+    assert "39579001" in anaph  # Anaphylaxis
+    assert "241929008" in anaph  # Acute allergic reaction

--- a/tests/agent/codes/test_loader.py
+++ b/tests/agent/codes/test_loader.py
@@ -3,9 +3,9 @@ import pytest
 from agent.codes.loader import VocabLoader, search
 
 
-def test_loader_loads_all_five_vocabularies():
+def test_loader_loads_all_vocabularies():
     loader = VocabLoader()
-    for vocab in ("loinc", "cvx", "rxnorm", "icd10", "cpt"):
+    for vocab in ("loinc", "cvx", "rxnorm", "icd10", "cpt", "snomed"):
         rows = loader.entries(vocab)
         assert len(rows) >= 20, f"{vocab} has only {len(rows)} entries"
 
@@ -138,9 +138,87 @@ def test_synonym_layer_case_insensitive():
 
 
 def test_synonym_layer_does_not_affect_other_vocabularies():
-    """The synonym map only has icd10 entries today. Other vocabularies
-    should behave exactly like before (substring search)."""
+    """Substring search must still work in any vocabulary that doesn't
+    have a synonym map entry for the given query."""
     results = search(vocabulary="loinc", query="hemoglobin a1c", limit=5)
     assert any("a1c" in r.display_name.lower() for r in results)
     results = search(vocabulary="cvx", query="mmr", limit=5)
     assert any(r.code == "03" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# SNOMED allergy intent shortcuts (Epic #203)
+# ---------------------------------------------------------------------------
+
+
+def test_snomed_penicillin_allergy_intent():
+    """'penicillin allergy' must hit the curated drug-allergy bucket and
+    return the penicillin + amoxicillin (cross-reactive) codes."""
+    results = search(vocabulary="snomed", query="penicillin allergy", limit=10)
+    codes = {r.code for r in results}
+    assert "91936005" in codes, f"expected 91936005 in {codes}"
+    assert "294505008" in codes, f"expected 294505008 (cross-reactive amoxicillin) in {codes}"
+
+
+def test_snomed_food_allergy_intent_returns_full_food_bucket():
+    """'any food allergy' must resolve to the curated food-allergy bucket."""
+    results = search(vocabulary="snomed", query="any food allergy", limit=20)
+    codes = {r.code for r in results}
+    expected = {"91934008", "91935009", "300913006", "417532002", "91938006", "91930004", "300915002"}
+    assert expected.issubset(codes), f"missing food allergy codes: {expected - codes}"
+
+
+def test_snomed_peanut_allergy_lay_term():
+    """'peanut allergy' resolves to the single peanut SNOMED code."""
+    results = search(vocabulary="snomed", query="peanut allergy", limit=5)
+    codes = {r.code for r in results}
+    assert codes == {"91934008"}, f"got {codes}"
+
+
+def test_snomed_hay_fever_resolves_to_environmental_bucket():
+    """Lay term 'hay fever' must reach environmental allergy codes."""
+    results = search(vocabulary="snomed", query="hay fever", limit=10)
+    codes = {r.code for r in results}
+    assert "232347008" in codes, f"expected pollen rhinitis 232347008 in {codes}"
+    assert any(c in codes for c in ("367498001", "446096008")), (
+        f"expected at least one allergic-rhinitis code in {codes}"
+    )
+
+
+def test_snomed_anaphylaxis_substring_fallback():
+    """Anaphylaxis is reachable through both the canonical key and via
+    plain substring match on the display name."""
+    by_canonical = search(vocabulary="snomed", query="anaphylaxis", limit=5)
+    assert any(r.code == "39579001" for r in by_canonical)
+
+
+def test_snomed_sulfa_allergy_synonym():
+    """'sulfa allergy' (lay shorthand) resolves to the sulfonamide code."""
+    results = search(vocabulary="snomed", query="sulfa allergy", limit=5)
+    codes = {r.code for r in results}
+    assert codes == {"91937001"}, f"got {codes}"
+
+
+def test_snomed_drug_allergy_intent_returns_full_drug_bucket():
+    """'drug allergy' / 'medication allergy' must surface the full
+    curated drug-allergy bucket."""
+    for needle in ("drug allergy", "medication allergy", "any drug allergy"):
+        results = search(vocabulary="snomed", query=needle, limit=10)
+        codes = {r.code for r in results}
+        expected = {"91936005", "294505008", "91937001", "293584003", "293586001"}
+        assert expected.issubset(codes), f"{needle!r} missing codes: {expected - codes}"
+
+
+def test_snomed_synonyms_codes_all_exist_in_data():
+    """Drift guard: every code listed in the synonyms.json snomed block
+    must exist in agent/codes/data/snomed.json. Catches typos before they
+    silently fall through the loader's phantom-code filter."""
+    from agent.codes.loader import _load, _load_synonyms
+
+    data_codes = {r["code"] for r in _load("snomed")}
+    snomed_block = _load_synonyms().get("snomed", {})
+    for canonical, entry in snomed_block.items():
+        for code in entry.get("codes", []):
+            assert code in data_codes, (
+                f"synonyms.json snomed[{canonical!r}] references {code!r} which is not in snomed.json"
+            )

--- a/tests/agent/tools/test_search_codes.py
+++ b/tests/agent/tools/test_search_codes.py
@@ -31,7 +31,7 @@ def test_search_codes_unknown_vocabulary_raises_validation():
     ctx = MagicMock()
     ctx.deps = MagicMock()
     with pytest.raises(Exception):
-        CodeSearchInput(vocabulary="snomed", query="anything")  # not in literal
+        CodeSearchInput(vocabulary="icd9", query="anything")  # not in literal
 
 
 def test_search_codes_cvx_mmr_returns_03():
@@ -39,3 +39,32 @@ def test_search_codes_cvx_mmr_returns_03():
     ctx.deps = MagicMock()
     result = search_codes(ctx, CodeSearchInput(vocabulary="cvx", query="mmr"))
     assert any(m.code == "03" for m in result)
+
+
+def test_search_codes_snomed_penicillin_allergy_returns_code_family():
+    """Epic #203 acceptance: 'penicillin allergy' through search_codes
+    must surface the curated drug-allergy SNOMED subset."""
+    ctx = MagicMock()
+    ctx.deps = MagicMock()
+    result = search_codes(ctx, CodeSearchInput(vocabulary="snomed", query="penicillin allergy"))
+    codes = {m.code for m in result}
+    assert "91936005" in codes, f"expected 91936005 in {codes}"
+    assert "294505008" in codes, f"expected 294505008 (amoxicillin cross-reactive) in {codes}"
+
+
+def test_search_codes_snomed_food_allergy_intent():
+    """'any food allergy' resolves to the food-allergy bucket per #203."""
+    ctx = MagicMock()
+    ctx.deps = MagicMock()
+    result = search_codes(ctx, CodeSearchInput(vocabulary="snomed", query="any food allergy"))
+    codes = {m.code for m in result}
+    assert "91934008" in codes, f"expected peanut 91934008 in {codes}"
+    assert "91930004" in codes, f"expected egg 91930004 in {codes}"
+
+
+def test_search_codes_snomed_peanut_allergy_specific():
+    """Specific lay term 'peanut allergy' resolves to a single code."""
+    ctx = MagicMock()
+    ctx.deps = MagicMock()
+    result = search_codes(ctx, CodeSearchInput(vocabulary="snomed", query="peanut allergy"))
+    assert [m.code for m in result] == ["91934008"]


### PR DESCRIPTION
## Summary
- Ship a curated SNOMED allergy code set under `agent/codes/allergies.py`, grouped by clinical category (drug, food, environmental, contact, anaphylaxis), as the shared source of truth for upcoming allergy tooling (Epic #201).
- Wire `search_codes` to recognize allergy-intent queries — `"penicillin allergy"`, `"any food allergy"`, `"peanut allergy"`, `"sulfa allergy"`, `"hay fever"`, `"latex allergy"`, etc. — by adding a `"snomed"` block to `agent/codes/data/synonyms.json` and extending the vocabulary `Literal` on `CodeSearchInput`.
- Add a 20-row `agent/codes/data/snomed.json` reference table so the existing loader (synonym layer + substring fallback + phantom-code filter) just works for SNOMED.

## Scope notes
This PR implements Feature #203 in isolation. Per the issue:
> This becomes the shared source of truth used by the allergies domain on `get_patient_clinical_data` and by any future allergy-related tools.

Out of scope here (handled in sibling features under Epic #201):
- #204 — allergies domain on `get_patient_clinical_data` (consumes `ALLERGY_SNOMED_BY_CATEGORY`)
- #206 — drug-allergy conflict signals
- #207 — sample-DB evaluation harness

## Categories shipped
Per the epic acceptance criterion:
- **drug** — penicillin, amoxicillin, sulfonamide, aspirin, NSAID
- **food** — peanut, nut, seafood, fish, dairy, eggs, wheat
- **environmental** — pollen, perennial/seasonal allergic rhinitis, grass pollen
- **contact** — latex
- **anaphylaxis** — anaphylaxis, acute allergic reaction

## Drift guards
Two pinned-invariant tests prevent silent code-list rot:
- `test_drift_guard_every_curated_code_exists_in_snomed_data` — every code in `ALLERGY_SNOMED_BY_CATEGORY` resolves in `snomed.json`.
- `test_snomed_synonyms_codes_all_exist_in_data` — every code referenced from `synonyms.json` resolves in `snomed.json`.

Together they ensure typos surface as test failures rather than falling through the loader's phantom-code filter into an empty result downstream.

## Test plan
- [x] `uv run pytest tests/agent/codes tests/agent/tools/test_search_codes.py -v` → 43 passed
- [x] `uv run pytest tests/agent -m "not milvus and not sample_db" -q` → 596 passed
- [x] `uv run ruff check agent/codes agent/tools/search_codes.py tests/agent/codes tests/agent/tools/test_search_codes.py` → all checks passed
- [ ] Reviewer spot-check: ask the agent `"what does it mean if a patient has a penicillin allergy?"` and confirm `search_codes(vocabulary="snomed", query="penicillin allergy")` surfaces 91936005 + 294505008

Closes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)