### PR TITLE
feat(audit): per-query view + by-patient pivot, retire Questions tab (Epic #190)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,4 @@ scripts/synthea/output/
 .vscode/
 .claude/
 mempalace.yaml
+.verify-evidence/

--- a/alembic/versions/9a4c12e7b001_per_query_audit_indexes.py
+++ b/alembic/versions/9a4c12e7b001_per_query_audit_indexes.py
@@ -1,0 +1,53 @@
+"""add composite (source_id, run_id) index on thrive_agent_patient_access
+
+Epic #190 (audit log parity for the agentic flow). Phase 1's per-query
+audit data-access layer joins ``AgentPatientAccess`` by ``source_id`` to
+support the By-Patient pivot ("every query that touched this patient")
+and decorates each row with the run's patient touches. The existing
+single-column ``ix_thrive_agent_patient_access_source`` covers the
+``source_id`` lookup but a composite index on ``(source_id, run_id)``
+covers the common pivot pattern (find runs that touched a patient, then
+deduplicate by run) without a separate join.
+
+The index is hygiene; safe to leave in place on rollback. Migration is
+symmetric (create / drop).
+
+Revision ID: 9a4c12e7b001
+Revises: 7b3a1f0c92d4
+Create Date: 2026-06-12 15:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import inspect
+
+# revision identifiers, used by Alembic.
+revision: str = "9a4c12e7b001"
+down_revision: Union[str, Sequence[str], None] = "7b3a1f0c92d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_INDEX_NAME = "ix_thrive_agent_patient_access_source_run"
+_TABLE_NAME = "thrive_agent_patient_access"
+_COLUMNS = ["source_id", "run_id"]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {ix["name"] for ix in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME not in existing:
+        op.create_index(_INDEX_NAME, _TABLE_NAME, _COLUMNS)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    existing = {ix["name"] for ix in inspector.get_indexes(_TABLE_NAME)}
+    if _INDEX_NAME in existing:
+        op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)

--- a/orm/agent_logging_functions.py
+++ b/orm/agent_logging_functions.py
@@ -202,6 +202,60 @@ def get_tool_breakdown(days: int = 30) -> list[dict]:
         return []
 
 
+def get_patient_audit_autocomplete(
+    days: int = 30,
+    limit: int = 500,
+    query: str | None = None,
+) -> list[dict]:
+    """Distinct ``(source_id, display_name)`` pairs touched by an agentic run.
+
+    Aggregates ``AgentPatientAccess`` rows within the last ``days`` and
+    returns one entry per distinct ``(source_id, display_name)`` ordered by
+    most-recently-touched first. The optional ``query`` argument is a
+    case-insensitive substring match against either ``source_id`` or
+    ``display_name`` — backs the By-Patient audit tab's autocomplete picker
+    (Epic #190, Phase 3).
+
+    Returns:
+        ``[{"source_id": str, "display_name": str | None,
+            "last_touched_at": datetime, "access_count": int}, ...]``
+    """
+    since = datetime.now() - timedelta(days=days)
+    try:
+        with SessionLocal() as s:
+            q = (
+                s.query(
+                    AgentPatientAccess.source_id.label("source_id"),
+                    AgentPatientAccess.display_name.label("display_name"),
+                    sqla_func.max(AgentPatientAccess.created_at).label("last_touched_at"),
+                    sqla_func.count(AgentPatientAccess.id).label("access_count"),
+                )
+                .filter(AgentPatientAccess.created_at >= since)
+                .group_by(AgentPatientAccess.source_id, AgentPatientAccess.display_name)
+            )
+            if query:
+                like = f"%{query.lower()}%"
+                # NULL display_name is fine — ``ilike`` against NULL returns
+                # NULL/false so we don't accidentally match every unnamed row.
+                q = q.filter(
+                    sqla_func.lower(AgentPatientAccess.source_id).like(like)
+                    | sqla_func.lower(AgentPatientAccess.display_name).like(like)
+                )
+            rows = q.order_by(sqla_func.max(AgentPatientAccess.created_at).desc()).limit(limit).all()
+            return [
+                {
+                    "source_id": r.source_id,
+                    "display_name": r.display_name,
+                    "last_touched_at": r.last_touched_at,
+                    "access_count": int(r.access_count),
+                }
+                for r in rows
+            ]
+    except Exception as e:
+        logger.warning("get_patient_audit_autocomplete failed: %s", e)
+        return []
+
+
 def get_patient_access(
     source_id: str | None = None, user_id: int | None = None, days: int = 30, limit: int = 200
 ) -> list[dict]:

--- a/orm/logging_functions.py
+++ b/orm/logging_functions.py
@@ -693,6 +693,538 @@ def get_question_audit_export(filters: dict) -> list[dict]:
         return []
 
 
+# ============== Per-Query Audit (Epic #190) ==============
+#
+# The legacy ``_question_audit_base_query`` produces one row per user question
+# even when that question kicked off an agentic run with N tool calls — the
+# only SQL surfaced is whichever assistant ``Message`` of type ``SQL`` happened
+# to be written. Per Epic #190 we expose one row per *query unit* instead:
+#   * Legacy question → 1 row (the assistant SQL Message).
+#   * Agentic question → 1 row per ``ToolCall`` for the run (0–N SQL statements
+#     decoded from ``ToolCall.sql_executed_json`` per row).
+#
+# Implementation is a SQL UNION ALL of two halves so ``COUNT(*)`` and
+# ``OFFSET/LIMIT`` stay honest under pagination. View-layer integration lives
+# in Phases 2–4 of Epic #190.
+
+# Sentinel surfaced to the view layer for agentic rows whose AgentRun was
+# logged in ``[agent_logging].mode = "disabled"``. The view renders this
+# verbatim under the SQL column.
+_DISABLED_LOGGING_SENTINEL = "(logging disabled)"
+
+# Pipeline labels — kept narrow so callers can ``in`` against a known set.
+PIPELINE_LEGACY = "legacy"
+PIPELINE_AGENTIC = "agentic"
+ALL_PIPELINES: tuple[str, ...] = (PIPELINE_LEGACY, PIPELINE_AGENTIC)
+
+# Keys present on every dict returned by ``get_per_query_audit_page`` /
+# ``get_per_query_audit_export``. Re-exported so callers and tests can sanity
+# check shape without duplicating the list.
+PER_QUERY_ROW_KEYS: tuple[str, ...] = (
+    "asked_at",
+    "user_id",
+    "username",
+    "organization",
+    "question",
+    "user_message_id",
+    "scope",
+    "pipeline",
+    "run_id",
+    "logging_mode",
+    "tool_call_id",
+    "tool_name",
+    "call_index",
+    "sql_statements",
+    "non_sql_summary",
+    "elapsed_ms",
+    "success",
+    "error",
+    "patients_touched",
+)
+
+
+def _per_query_base_subquery(session, filters: dict):
+    """Build the UNION ALL subquery underpinning the per-query audit view.
+
+    The returned object is a SQLAlchemy ``.subquery()`` so callers can both
+    ``SELECT COUNT(*)`` against it (for pagination) and ``SELECT`` the page
+    against the same shape.
+
+    Filter dict accepts every key ``_question_audit_base_query`` supports
+    (``days`` / ``usernames`` / ``orgs`` / ``search`` / ``scopes``) plus:
+      * ``pipelines``: list[str] — restrict to ``["legacy"]`` / ``["agentic"]``
+        / both (default).
+      * ``source_ids``: list[str] — restrict agentic rows to runs that touched
+        any of these patient ``source_id``s (via ``AgentPatientAccess``).
+        Legacy rows are excluded entirely when this filter is active (the
+        legacy pipeline has no structured patient-touch record).
+      * ``tool_names``: list[str] — restrict agentic rows to specific tool
+        names. Legacy rows pass through (subject to ``pipelines``).
+    """
+    from sqlalchemy import Boolean, Integer, String, case, exists, literal, or_
+    from sqlalchemy.orm import aliased
+
+    from orm.models import AgentPatientAccess, AgentRun, Message, ToolCall, User
+    from utils.enums import MessageType, RoleType
+
+    days = int(filters.get("days") or 30)
+    usernames = filters.get("usernames") or []
+    orgs = filters.get("orgs") or []
+    search = filters.get("search") or None
+    scopes = filters.get("scopes") or None
+    pipelines = filters.get("pipelines") or None
+    source_ids = filters.get("source_ids") or None
+    tool_names = filters.get("tool_names") or None
+
+    since = datetime.utcnow() - timedelta(days=days)
+
+    include_legacy = (not pipelines) or (PIPELINE_LEGACY in pipelines)
+    include_agentic = (not pipelines) or (PIPELINE_AGENTIC in pipelines)
+    # source_ids is a patient-touch filter sourced from AgentPatientAccess —
+    # legacy questions have no structured touch record so they cannot match.
+    if source_ids:
+        include_legacy = False
+    if tool_names:
+        # tool_names filter is a per-tool-call filter; legacy rows have no
+        # tool_call. Exclude legacy so the filter's intent is unambiguous.
+        include_legacy = False
+
+    # Reused per-run tool-family aggregate (matches _question_audit_base_query
+    # so per-row Patient/Pop Health classification stays consistent with the
+    # per-question view).
+    tool_agg_sq = (
+        session.query(
+            ToolCall.run_id.label("run_id"),
+            func.max(case((ToolCall.tool_name.in_(_PATIENT_INTENT_TOOLS), 1), else_=0)).label("has_patient_tool"),
+            func.max(case((ToolCall.tool_name.in_(_POP_HEALTH_TOOLS), 1), else_=0)).label("has_pop_tool"),
+        )
+        .filter(ToolCall.run_id.isnot(None))
+        .group_by(ToolCall.run_id)
+        .subquery()
+    )
+
+    # Same precedence as scope_case in _question_audit_base_query but without
+    # the Legacy branch — this CASE only fires on the agentic half.
+    scope_case_agentic = case(
+        (
+            or_(
+                AgentRun.selected_patient_source_id.isnot(None),
+                tool_agg_sq.c.has_patient_tool == 1,
+            ),
+            SCOPE_PATIENT,
+        ),
+        (tool_agg_sq.c.has_pop_tool == 1, SCOPE_POP_HEALTH),
+        else_=SCOPE_OTHER,
+    )
+
+    # ---- Common filters reused by both halves ----
+    common_filters = [
+        Message.role == RoleType.USER.value,
+        Message.created_at >= since,
+    ]
+    if usernames:
+        common_filters.append(User.username.in_(usernames))
+    if orgs:
+        org_clauses = []
+        concrete = [o for o in orgs if o != _NO_ORG_SENTINEL]
+        if _NO_ORG_SENTINEL in orgs:
+            org_clauses.append(User.organization.is_(None))
+            org_clauses.append(User.organization == "")
+        if concrete:
+            org_clauses.append(User.organization.in_(concrete))
+        if org_clauses:
+            common_filters.append(or_(*org_clauses))
+    if search:
+        s = f"%{search.lower()}%"
+        SqlMsg = aliased(Message)
+        sql_exists = exists().where(
+            (SqlMsg.role == RoleType.ASSISTANT.value)
+            & (SqlMsg.type == MessageType.SQL.value)
+            & (SqlMsg.question == Message.content)
+            & (SqlMsg.user_id == Message.user_id)
+            & (SqlMsg.content.ilike(s))
+        )
+        common_filters.append(or_(Message.content.ilike(s), sql_exists))
+
+    parts = []
+
+    # ---- Legacy half: one row per user-Message with no AgentRun ----
+    if include_legacy:
+        legacy_q = (
+            session.query(
+                Message.id.label("user_message_id"),
+                Message.content.label("question"),
+                Message.created_at.label("asked_at"),
+                User.id.label("user_id"),
+                User.username.label("username"),
+                User.organization.label("organization"),
+                literal(SCOPE_LEGACY).label("scope"),
+                literal(PIPELINE_LEGACY).label("pipeline"),
+                literal(None, String()).label("run_id"),
+                literal(None, String()).label("logging_mode"),
+                literal(None, Integer()).label("tool_call_pk"),
+                literal(None, String()).label("tool_call_uid"),
+                literal(None, String()).label("tool_name"),
+                literal(None, Integer()).label("call_index"),
+                literal(None, String()).label("sql_executed_json"),
+                literal(None, String()).label("non_sql_summary"),
+                literal(None, Integer()).label("elapsed_ms"),
+                literal(None, Boolean()).label("tool_success"),
+                literal(None, String()).label("tool_error"),
+            )
+            .join(User, User.id == Message.user_id)
+            .outerjoin(AgentRun, AgentRun.user_message_id == Message.id)
+            .filter(*common_filters, AgentRun.id.is_(None))
+        )
+        if scopes:
+            wanted = {s for s in scopes if s in ALL_SCOPES}
+            if SCOPE_LEGACY not in wanted:
+                # Drop this half entirely without producing rows.
+                legacy_q = legacy_q.filter(literal(False))
+        parts.append(legacy_q)
+
+    # ---- Agentic half: one row per ToolCall (outer join so zero-tool-call
+    # runs still produce a carrier row) ----
+    if include_agentic:
+        agentic_q = (
+            session.query(
+                Message.id.label("user_message_id"),
+                Message.content.label("question"),
+                Message.created_at.label("asked_at"),
+                User.id.label("user_id"),
+                User.username.label("username"),
+                User.organization.label("organization"),
+                scope_case_agentic.label("scope"),
+                literal(PIPELINE_AGENTIC).label("pipeline"),
+                AgentRun.run_id.label("run_id"),
+                AgentRun.logging_mode.label("logging_mode"),
+                ToolCall.id.label("tool_call_pk"),
+                ToolCall.tool_call_id.label("tool_call_uid"),
+                ToolCall.tool_name.label("tool_name"),
+                ToolCall.call_index.label("call_index"),
+                ToolCall.sql_executed_json.label("sql_executed_json"),
+                ToolCall.result_summary.label("non_sql_summary"),
+                ToolCall.elapsed_ms.label("elapsed_ms"),
+                ToolCall.success.label("tool_success"),
+                ToolCall.error.label("tool_error"),
+            )
+            .join(User, User.id == Message.user_id)
+            .join(AgentRun, AgentRun.user_message_id == Message.id)
+            .outerjoin(ToolCall, ToolCall.run_id == AgentRun.run_id)
+            .outerjoin(tool_agg_sq, tool_agg_sq.c.run_id == AgentRun.run_id)
+            .filter(*common_filters)
+        )
+        if scopes:
+            wanted = {s for s in scopes if s in ALL_SCOPES}
+            # Legacy/Unknown never matches the agentic CASE; filtering on the
+            # other three buckets is the correct intent.
+            agentic_wanted = wanted - {SCOPE_LEGACY}
+            if agentic_wanted:
+                agentic_q = agentic_q.filter(scope_case_agentic.in_(agentic_wanted))
+            else:
+                agentic_q = agentic_q.filter(literal(False))
+        if source_ids:
+            agentic_q = agentic_q.filter(
+                exists().where(
+                    (AgentPatientAccess.run_id == AgentRun.run_id) & (AgentPatientAccess.source_id.in_(source_ids))
+                )
+            )
+        if tool_names:
+            agentic_q = agentic_q.filter(ToolCall.tool_name.in_(tool_names))
+        parts.append(agentic_q)
+
+    if not parts:
+        # Both pipelines excluded — return an empty subquery of the right shape.
+        # We build one by reusing the legacy projection and filtering to False.
+        empty = (
+            session.query(
+                Message.id.label("user_message_id"),
+                Message.content.label("question"),
+                Message.created_at.label("asked_at"),
+                User.id.label("user_id"),
+                User.username.label("username"),
+                User.organization.label("organization"),
+                literal(SCOPE_LEGACY).label("scope"),
+                literal(PIPELINE_LEGACY).label("pipeline"),
+                literal(None, String()).label("run_id"),
+                literal(None, String()).label("logging_mode"),
+                literal(None, Integer()).label("tool_call_pk"),
+                literal(None, String()).label("tool_call_uid"),
+                literal(None, String()).label("tool_name"),
+                literal(None, Integer()).label("call_index"),
+                literal(None, String()).label("sql_executed_json"),
+                literal(None, String()).label("non_sql_summary"),
+                literal(None, Integer()).label("elapsed_ms"),
+                literal(None, Boolean()).label("tool_success"),
+                literal(None, String()).label("tool_error"),
+            )
+            .join(User, User.id == Message.user_id)
+            .filter(literal(False))
+        )
+        return empty.subquery()
+
+    if len(parts) == 1:
+        return parts[0].subquery()
+    return parts[0].union_all(parts[1]).subquery()
+
+
+def _decorate_per_query_rows(session, rows: list) -> list[dict]:
+    """Decode JSON, fetch legacy SQL Messages, attach patients_touched.
+
+    Batched so the cost is O(1) round-trips regardless of page size.
+    """
+    from orm.models import AgentPatientAccess, Message
+    from utils.enums import MessageType, RoleType
+
+    if not rows:
+        return []
+
+    # ---- Batched legacy enrichment: assistant SQL + assistant ERROR per
+    # (user_id, question) ----
+    legacy_keys: set[tuple[int, str]] = {(r.user_id, r.question) for r in rows if r.pipeline == PIPELINE_LEGACY}
+    legacy_sql_by_key: dict[tuple[int, str], dict[str, Any]] = {}
+    legacy_err_by_key: dict[tuple[int, str], str] = {}
+    if legacy_keys:
+        user_ids = {k[0] for k in legacy_keys}
+        contents = {k[1] for k in legacy_keys}
+        assistant_rows = (
+            session.query(
+                Message.user_id,
+                Message.question,
+                Message.type,
+                Message.content,
+                Message.created_at,
+                Message.elapsed_time,
+            )
+            .filter(
+                Message.role == RoleType.ASSISTANT.value,
+                Message.user_id.in_(user_ids),
+                Message.question.in_(contents),
+                Message.type.in_({MessageType.SQL.value, MessageType.ERROR.value}),
+            )
+            .order_by(Message.created_at.desc())
+            .all()
+        )
+        for ar in assistant_rows:
+            key = (ar.user_id, ar.question)
+            if ar.type == MessageType.SQL.value and key not in legacy_sql_by_key:
+                legacy_sql_by_key[key] = {
+                    "content": ar.content,
+                    "elapsed_time": ar.elapsed_time,
+                }
+            elif ar.type == MessageType.ERROR.value and key not in legacy_err_by_key:
+                legacy_err_by_key[key] = ar.content
+
+    # ---- Batched patient access lookup ----
+    # AgentPatientAccess.tool_call_id is the *string* tool_call_id (matches
+    # ToolCall.tool_call_id, not the PK). Fetch by tool_call_uid when present;
+    # otherwise fall back to run-level grouping for zero-tool-call carrier rows.
+    uids = {r.tool_call_uid for r in rows if r.tool_call_uid}
+    runs_without_uid = {r.run_id for r in rows if r.pipeline == PIPELINE_AGENTIC and r.run_id and not r.tool_call_uid}
+
+    patients_by_uid: dict[str, list[dict]] = {}
+    patients_by_run: dict[str, list[dict]] = {}
+    if uids:
+        pa_rows = (
+            session.query(
+                AgentPatientAccess.tool_call_id,
+                AgentPatientAccess.source_id,
+                AgentPatientAccess.display_name,
+            )
+            .filter(AgentPatientAccess.tool_call_id.in_(uids))
+            .order_by(AgentPatientAccess.id.asc())
+            .all()
+        )
+        seen_by_uid: dict[str, set[str]] = {}
+        for pa in pa_rows:
+            bucket = patients_by_uid.setdefault(pa.tool_call_id, [])
+            seen = seen_by_uid.setdefault(pa.tool_call_id, set())
+            if pa.source_id in seen:
+                continue
+            seen.add(pa.source_id)
+            bucket.append({"source_id": pa.source_id, "display_name": pa.display_name})
+    if runs_without_uid:
+        pa_rows = (
+            session.query(
+                AgentPatientAccess.run_id,
+                AgentPatientAccess.source_id,
+                AgentPatientAccess.display_name,
+            )
+            .filter(AgentPatientAccess.run_id.in_(runs_without_uid))
+            .order_by(AgentPatientAccess.id.asc())
+            .all()
+        )
+        seen_by_run: dict[str, set[str]] = {}
+        for pa in pa_rows:
+            bucket = patients_by_run.setdefault(pa.run_id, [])
+            seen = seen_by_run.setdefault(pa.run_id, set())
+            if pa.source_id in seen:
+                continue
+            seen.add(pa.source_id)
+            bucket.append({"source_id": pa.source_id, "display_name": pa.display_name})
+
+    items: list[dict] = []
+    for r in rows:
+        is_legacy = r.pipeline == PIPELINE_LEGACY
+        is_disabled = (r.logging_mode == "disabled") if not is_legacy else False
+        sql_statements: list[str]
+        non_sql_summary: str | None
+        elapsed_ms: int | None
+        success: bool | None
+        error: str | None
+
+        if is_legacy:
+            key = (r.user_id, r.question)
+            sql_row = legacy_sql_by_key.get(key)
+            err_text = legacy_err_by_key.get(key)
+            sql_statements = [sql_row["content"]] if sql_row and sql_row["content"] else []
+            non_sql_summary = None
+            # Legacy elapsed_time is seconds (Decimal). Normalise to int ms so
+            # the column type matches the agentic half.
+            if sql_row and sql_row["elapsed_time"] is not None:
+                try:
+                    elapsed_ms = int(float(sql_row["elapsed_time"]) * 1000)
+                except (TypeError, ValueError):
+                    elapsed_ms = None
+            else:
+                elapsed_ms = None
+            success = (err_text is None) if (sql_row or err_text) else None
+            error = err_text
+        elif is_disabled:
+            # Logging disabled — agentic rows still surface (so admins know
+            # something ran) but payload columns are sentinelled, not crashed.
+            sql_statements = []
+            non_sql_summary = _DISABLED_LOGGING_SENTINEL
+            elapsed_ms = r.elapsed_ms
+            success = r.tool_success
+            error = r.tool_error
+        else:
+            sql_statements = _decode_sql_executed_json(r.sql_executed_json, run_id=r.run_id)
+            non_sql_summary = None if sql_statements else r.non_sql_summary
+            elapsed_ms = r.elapsed_ms
+            success = r.tool_success
+            error = r.tool_error
+
+        # Patient touch list — per-tool-call when we have a uid, else run-level.
+        if is_legacy:
+            patients_touched: list[dict] = []
+        elif r.tool_call_uid:
+            patients_touched = list(patients_by_uid.get(r.tool_call_uid, ()))
+        elif r.run_id:
+            patients_touched = list(patients_by_run.get(r.run_id, ()))
+        else:
+            patients_touched = []
+
+        items.append(
+            {
+                "asked_at": r.asked_at,
+                "user_id": r.user_id,
+                "username": r.username,
+                "organization": r.organization,
+                "question": r.question,
+                "user_message_id": r.user_message_id,
+                "scope": r.scope or SCOPE_LEGACY,
+                "pipeline": r.pipeline,
+                "run_id": r.run_id,
+                "logging_mode": r.logging_mode,
+                "tool_call_id": r.tool_call_pk,
+                "tool_name": r.tool_name,
+                "call_index": r.call_index,
+                "sql_statements": sql_statements,
+                "non_sql_summary": non_sql_summary,
+                "elapsed_ms": elapsed_ms,
+                "success": success,
+                "error": error,
+                "patients_touched": patients_touched,
+            }
+        )
+    return items
+
+
+def _decode_sql_executed_json(raw: str | None, *, run_id: str | None = None) -> list[str]:
+    """Decode ``ToolCall.sql_executed_json`` (a JSON array of strings).
+
+    Defensive: returns ``[]`` on missing / malformed input and logs a warning
+    so audit surfaces never crash on a single bad row.
+    """
+    if raw is None or raw == "":
+        return []
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as e:
+        logger.warning("_decode_sql_executed_json: malformed JSON for run_id=%s: %s", run_id, e)
+        return []
+    if not isinstance(parsed, list):
+        logger.warning(
+            "_decode_sql_executed_json: expected list, got %s for run_id=%s",
+            type(parsed).__name__,
+            run_id,
+        )
+        return []
+    return [str(x) for x in parsed]
+
+
+def get_per_query_audit_page(filters: dict, page: int = 1, page_size: int = 50) -> dict:
+    """Paginated per-query audit (Epic #190). Returns ``{"items": [...], "total": int}``.
+
+    Each item is one *query unit*: a legacy assistant SQL Message, or one
+    agentic ``ToolCall`` (0–N SQL statements decoded inline). See
+    ``PER_QUERY_ROW_KEYS`` for the dict shape.
+    """
+    try:
+        with SessionLocal() as session:
+            sub = _per_query_base_subquery(session, filters)
+            total = session.query(func.count()).select_from(sub).scalar() or 0
+            offset = max(0, (int(page) - 1) * int(page_size))
+            rows = (
+                session.query(sub)
+                .order_by(
+                    sub.c.asked_at.desc(),
+                    sub.c.user_message_id.desc(),
+                    sub.c.run_id.asc(),
+                    sub.c.call_index.asc(),
+                    sub.c.tool_call_pk.asc(),
+                )
+                .offset(offset)
+                .limit(int(page_size))
+                .all()
+            )
+            items = _decorate_per_query_rows(session, rows)
+            return {"items": items, "total": int(total)}
+    except Exception as e:
+        logger.warning("get_per_query_audit_page failed: %s", e)
+        return {"items": [], "total": 0}
+
+
+def get_per_query_audit_export(filters: dict) -> list[dict]:
+    """Full filtered set with no pagination, capped at ``MAX_AUDIT_EXPORT_ROWS``."""
+    try:
+        with SessionLocal() as session:
+            sub = _per_query_base_subquery(session, filters)
+            rows = (
+                session.query(sub)
+                .order_by(
+                    sub.c.asked_at.desc(),
+                    sub.c.user_message_id.desc(),
+                    sub.c.run_id.asc(),
+                    sub.c.call_index.asc(),
+                    sub.c.tool_call_pk.asc(),
+                )
+                .limit(MAX_AUDIT_EXPORT_ROWS + 1)
+                .all()
+            )
+            if len(rows) > MAX_AUDIT_EXPORT_ROWS:
+                logger.warning(
+                    "get_per_query_audit_export hit MAX_AUDIT_EXPORT_ROWS=%s; truncating",
+                    MAX_AUDIT_EXPORT_ROWS,
+                )
+                rows = rows[:MAX_AUDIT_EXPORT_ROWS]
+            return _decorate_per_query_rows(session, rows)
+    except Exception as e:
+        logger.warning("get_per_query_audit_export failed: %s", e)
+        return []
+
+
 # ============== Error Logging ==============
 
 

--- a/orm/models.py
+++ b/orm/models.py
@@ -674,6 +674,9 @@ class AgentPatientAccess(Base):
         Index("ix_thrive_agent_patient_access_tool_call", "tool_call_id"),
         Index("ix_thrive_agent_patient_access_created", "created_at"),
         Index("ix_thrive_agent_patient_access_type", "access_type"),
+        # Backs Epic #190's per-query patient pivot. Matching migration:
+        # 9a4c12e7b001.
+        Index("ix_thrive_agent_patient_access_source_run", "source_id", "run_id"),
     )
 
     id = Column(Integer, primary_key=True)

--- a/tests/orm/test_patient_audit_autocomplete.py
+++ b/tests/orm/test_patient_audit_autocomplete.py
@@ -1,0 +1,174 @@
+"""Tests for ``orm.agent_logging_functions.get_patient_audit_autocomplete``
+(Epic #190, Phase 3).
+
+Backs the By-Patient audit tab's patient picker. One row per distinct
+``(source_id, display_name)`` pair touched within the time window, ordered
+by ``last_touched_at DESC``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import AgentPatientAccess, Base, RoleTypeEnum, User, UserRole
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    from orm import agent_logging_functions as alf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(alf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_user(session, *, id=10, username="alice"):
+    session.add(
+        UserRole(id=4, role_name="Patient", description="Patient", role=RoleTypeEnum.PATIENT),
+    )
+    session.commit()
+    session.add(
+        User(
+            id=id,
+            user_role_id=4,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+            organization="Acme",
+        )
+    )
+    session.commit()
+
+
+def _add_access(
+    session,
+    *,
+    source_id,
+    display_name=None,
+    created_at,
+    run_id="run-1",
+    user_id=10,
+    access_type="read",
+    access_origin="tool",
+):
+    session.add(
+        AgentPatientAccess(
+            run_id=run_id,
+            session_id=f"sess-{run_id}",
+            user_id=user_id,
+            source_id=source_id,
+            display_name=display_name,
+            access_type=access_type,
+            access_origin=access_origin,
+        )
+    )
+    session.commit()
+    row = (
+        session.query(AgentPatientAccess)
+        .filter_by(source_id=source_id, display_name=display_name)
+        .order_by(AgentPatientAccess.id.desc())
+        .first()
+    )
+    row.created_at = created_at
+    session.commit()
+
+
+def test_empty_database_returns_empty_list(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    session_factory()  # creates schema via the fixture's Base.metadata.create_all
+    assert get_patient_audit_autocomplete() == []
+
+
+def test_three_distinct_source_ids_ordered_by_last_touched_desc(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    _add_access(s, source_id="pat-1", display_name="Alice", created_at=base - timedelta(minutes=10))
+    _add_access(s, source_id="pat-2", display_name="Bob", created_at=base - timedelta(minutes=5))
+    _add_access(s, source_id="pat-3", display_name="Carol", created_at=base)
+
+    rows = get_patient_audit_autocomplete()
+    assert [r["source_id"] for r in rows] == ["pat-3", "pat-2", "pat-1"]
+    assert all(r["access_count"] == 1 for r in rows)
+
+
+def test_repeated_touches_aggregate_into_one_row(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(4):
+        _add_access(s, source_id="pat-1", display_name="Alice", created_at=base - timedelta(minutes=i))
+
+    rows = get_patient_audit_autocomplete()
+    assert len(rows) == 1
+    assert rows[0]["access_count"] == 4
+    # last_touched_at is the most recent (i=0).
+    assert rows[0]["last_touched_at"] == base
+
+
+def test_same_source_id_two_display_names_returns_two_rows(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    _add_access(s, source_id="pat-1", display_name="Alice A", created_at=base - timedelta(minutes=5))
+    _add_access(s, source_id="pat-1", display_name="Alice Anders", created_at=base)
+
+    rows = get_patient_audit_autocomplete()
+    assert len(rows) == 2
+    # Newest first.
+    assert rows[0]["display_name"] == "Alice Anders"
+    assert rows[1]["display_name"] == "Alice A"
+
+
+def test_older_than_days_window_is_excluded(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    now = datetime.now()
+    _add_access(s, source_id="recent", display_name="R", created_at=now - timedelta(days=1))
+    _add_access(s, source_id="ancient", display_name="A", created_at=now - timedelta(days=90))
+
+    rows = get_patient_audit_autocomplete(days=7)
+    assert {r["source_id"] for r in rows} == {"recent"}
+
+
+def test_query_filter_matches_source_id_substring(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    _add_access(s, source_id="pat-12-abc", display_name="X", created_at=base)
+    _add_access(s, source_id="pat-99-xyz", display_name="Y", created_at=base - timedelta(minutes=1))
+
+    rows = get_patient_audit_autocomplete(query="pat-12")
+    assert [r["source_id"] for r in rows] == ["pat-12-abc"]
+
+
+def test_query_filter_matches_display_name_substring(session_factory):
+    from orm.agent_logging_functions import get_patient_audit_autocomplete
+
+    s = session_factory()
+    _seed_user(s)
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    _add_access(s, source_id="pat-A", display_name="Alice Anders", created_at=base)
+    _add_access(s, source_id="pat-B", display_name="Bob Brown", created_at=base - timedelta(minutes=1))
+
+    rows = get_patient_audit_autocomplete(query="alice")
+    assert [r["source_id"] for r in rows] == ["pat-A"]

--- a/tests/orm/test_per_query_audit.py
+++ b/tests/orm/test_per_query_audit.py
@@ -1,0 +1,827 @@
+"""Tests for the per-query audit data-access layer (Epic #190, Phase 1).
+
+The per-query view unfolds each user question into one row per *query
+unit*:
+
+  * Legacy question (no AgentRun) → 1 row, sql from the assistant SQL Message
+  * Agentic question → 1 row per ToolCall (0–N SQL statements per row,
+    decoded from ToolCall.sql_executed_json)
+
+Shape and filter semantics covered here are the contract that Phases 2–4
+of Epic #190 build on.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from orm.models import (
+    AgentPatientAccess,
+    AgentRun,
+    Base,
+    Message,
+    RoleTypeEnum,
+    ToolCall,
+    User,
+    UserRole,
+)
+from utils.enums import MessageType, RoleType
+
+
+# ---------------------------------------------------------------------------
+# Fixtures & seed helpers (mirrors tests/orm/test_question_audit_scope.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def session_factory(monkeypatch):
+    """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
+    from orm import logging_functions as lf
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    monkeypatch.setattr(lf, "SessionLocal", Session)
+    return Session
+
+
+def _seed_roles(session):
+    session.add_all(
+        [
+            UserRole(id=1, role_name="Admin", description="Admin", role=RoleTypeEnum.ADMIN),
+            UserRole(id=4, role_name="Patient", description="Patient", role=RoleTypeEnum.PATIENT),
+        ]
+    )
+    session.commit()
+
+
+def _seed_user(session, *, id, username, org="TestOrg", role_id=4):
+    session.add(
+        User(
+            id=id,
+            user_role_id=role_id,
+            username=username,
+            first_name=username,
+            last_name="X",
+            password="hash:abc",
+            email=f"{username}@x.io",
+            organization=org,
+        )
+    )
+    session.commit()
+
+
+def _add_question(
+    session,
+    *,
+    user_id,
+    content,
+    when,
+    assistant_sql=None,
+    assistant_sql_elapsed=None,
+    assistant_error=None,
+):
+    """Seed a user-role Message with a clamped created_at and optional legacy
+    assistant SQL/error rows. Returns the user Message.id.
+    """
+    session.add(
+        Message(
+            role=RoleType.USER,
+            content=content,
+            type=MessageType.TEXT,
+            user_id=user_id,
+        )
+    )
+    session.commit()
+    last = session.query(Message).order_by(Message.id.desc()).first()
+    last.created_at = when
+    session.commit()
+    user_message_id = last.id
+
+    if assistant_sql is not None:
+        m = Message(
+            role=RoleType.ASSISTANT,
+            content=assistant_sql,
+            type=MessageType.SQL,
+            user_id=user_id,
+            question=content,
+            elapsed_time=assistant_sql_elapsed,
+        )
+        session.add(m)
+        session.commit()
+        # Bump created_at one second after the user message so ordering is
+        # deterministic in fixture results.
+        am = session.query(Message).order_by(Message.id.desc()).first()
+        am.created_at = when + timedelta(seconds=1)
+        session.commit()
+    if assistant_error is not None:
+        m = Message(
+            role=RoleType.ASSISTANT,
+            content=assistant_error,
+            type=MessageType.ERROR,
+            user_id=user_id,
+            question=content,
+        )
+        session.add(m)
+        session.commit()
+
+    return user_message_id
+
+
+def _add_agent_run(
+    session,
+    *,
+    run_id,
+    user_id,
+    user_message_id,
+    selected_patient_source_id=None,
+    logging_mode="full",
+    created_at=None,
+):
+    ar = AgentRun(
+        run_id=run_id,
+        session_id=f"sess-{run_id}",
+        user_id=user_id,
+        user_role=RoleTypeEnum.PATIENT.value,
+        user_message_id=user_message_id,
+        selected_patient_source_id=selected_patient_source_id,
+        tool_call_count=0,
+        event_count=0,
+        status="completed",
+        success=True,
+        review_status="unreviewed",
+        logging_mode=logging_mode,
+        schema_version=1,
+    )
+    session.add(ar)
+    session.commit()
+    if created_at is not None:
+        row = session.query(AgentRun).filter_by(run_id=run_id).first()
+        row.created_at = created_at
+        session.commit()
+
+
+def _add_tool_call(
+    session,
+    *,
+    run_id,
+    user_id,
+    tool_name,
+    call_index=0,
+    tool_call_uid=None,
+    sql_executed=None,
+    result_summary="{}",
+    elapsed_ms=42,
+    success=True,
+    error=None,
+):
+    """Seed a ToolCall. ``sql_executed`` may be a list[str] (encoded to JSON),
+    a raw JSON string, or None.
+    """
+    if isinstance(sql_executed, list):
+        sql_executed_json = json.dumps(sql_executed)
+    else:
+        sql_executed_json = sql_executed
+    tc = ToolCall(
+        session_id=f"sess-{run_id}",
+        user_id=user_id,
+        user_role=RoleTypeEnum.PATIENT.value,
+        tool_name=tool_name,
+        arguments_json="{}",
+        result_summary=result_summary,
+        elapsed_ms=elapsed_ms,
+        success=success,
+        error=error,
+        run_id=run_id,
+        tool_call_id=tool_call_uid,
+        call_index=call_index,
+        sql_executed_json=sql_executed_json,
+    )
+    session.add(tc)
+    session.commit()
+    return tc.id
+
+
+def _add_patient_access(
+    session,
+    *,
+    run_id,
+    user_id,
+    source_id,
+    display_name=None,
+    tool_call_uid=None,
+    access_type="read",
+    access_origin="tool",
+):
+    session.add(
+        AgentPatientAccess(
+            run_id=run_id,
+            tool_call_id=tool_call_uid,
+            session_id=f"sess-{run_id}",
+            user_id=user_id,
+            source_id=source_id,
+            display_name=display_name,
+            access_type=access_type,
+            access_origin=access_origin,
+        )
+    )
+    session.commit()
+
+
+def _filters(**overrides):
+    base = {"usernames": [], "orgs": [], "days": 30, "search": None}
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# (1) Row shape & per-pipeline emission
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_question_yields_one_row_with_assistant_sql(session_factory):
+    from orm.logging_functions import PER_QUERY_ROW_KEYS, get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _add_question(
+        s,
+        user_id=10,
+        content="legacy q",
+        when=datetime(2026, 6, 1, 12, 0, 0),
+        assistant_sql="SELECT 1",
+        assistant_sql_elapsed=Decimal("1.250000"),
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["total"] == 1
+    assert len(page["items"]) == 1
+    item = page["items"][0]
+    assert set(item.keys()) == set(PER_QUERY_ROW_KEYS)
+    assert item["pipeline"] == "legacy"
+    assert item["sql_statements"] == ["SELECT 1"]
+    assert item["tool_call_id"] is None
+    assert item["tool_name"] is None
+    assert item["run_id"] is None
+    assert item["scope"] == "Legacy/Unknown"
+    assert item["elapsed_ms"] == 1250
+    assert item["patients_touched"] == []
+    assert item["success"] is True
+
+
+def test_legacy_question_with_no_assistant_sql_still_emits_row(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _add_question(s, user_id=10, content="bare q", when=datetime(2026, 6, 1, 12, 0, 0))
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["total"] == 1
+    item = page["items"][0]
+    assert item["pipeline"] == "legacy"
+    assert item["sql_statements"] == []
+    assert item["non_sql_summary"] is None
+    assert item["elapsed_ms"] is None
+    assert item["success"] is None  # neither sql nor error → no status info
+
+
+def test_agentic_question_with_three_tool_calls_emits_three_rows(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="agentic q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-1", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s,
+        run_id="run-1",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tc-0",
+        sql_executed=["SELECT 1"],
+    )
+    _add_tool_call(
+        s,
+        run_id="run-1",
+        user_id=10,
+        tool_name="get_patient_clinical_data",
+        call_index=1,
+        tool_call_uid="tc-1",
+        sql_executed=["SELECT * FROM enc", "SELECT * FROM lab"],
+    )
+    _add_tool_call(
+        s,
+        run_id="run-1",
+        user_id=10,
+        tool_name="summarize_results",
+        call_index=2,
+        tool_call_uid="tc-2",
+        sql_executed=[],
+        result_summary="3 rows summarised",
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["total"] == 3
+    rows = page["items"]
+    # All three share the question + run + message id.
+    assert {r["user_message_id"] for r in rows} == {mid}
+    assert {r["run_id"] for r in rows} == {"run-1"}
+    assert {r["pipeline"] for r in rows} == {"agentic"}
+    # Ordering: call_index ascending within the run.
+    assert [r["call_index"] for r in rows] == [0, 1, 2]
+    # SQL counts per row.
+    assert [len(r["sql_statements"]) for r in rows] == [1, 2, 0]
+    # The non-SQL row carries its result summary; SQL rows do not.
+    assert rows[0]["non_sql_summary"] is None
+    assert rows[1]["non_sql_summary"] is None
+    assert rows[2]["non_sql_summary"] == "3 rows summarised"
+
+
+def test_agentic_sql_executed_json_preserves_order(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="multi-sql", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-2", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s,
+        run_id="run-2",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tc-0",
+        sql_executed=["SELECT A", "SELECT B", "SELECT C", "SELECT D"],
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["sql_statements"] == ["SELECT A", "SELECT B", "SELECT C", "SELECT D"]
+
+
+# ---------------------------------------------------------------------------
+# (2) Patient-touch decoration
+# ---------------------------------------------------------------------------
+
+
+def test_patients_touched_attached_per_tool_call(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="touch q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-3", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s,
+        run_id="run-3",
+        user_id=10,
+        tool_name="get_patient_clinical_data",
+        call_index=0,
+        tool_call_uid="tc-pa",
+        sql_executed=["SELECT 1"],
+    )
+    _add_patient_access(
+        s, run_id="run-3", user_id=10, source_id="pat-001", display_name="Alice A", tool_call_uid="tc-pa"
+    )
+    _add_patient_access(s, run_id="run-3", user_id=10, source_id="pat-002", display_name="Bob B", tool_call_uid="tc-pa")
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    pa = page["items"][0]["patients_touched"]
+    assert {p["source_id"] for p in pa} == {"pat-001", "pat-002"}
+    assert {p["display_name"] for p in pa} == {"Alice A", "Bob B"}
+
+
+def test_patients_touched_empty_for_legacy_rows(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _add_question(
+        s,
+        user_id=10,
+        content="legacy",
+        when=datetime(2026, 6, 1, 12, 0, 0),
+        assistant_sql="SELECT 1",
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["patients_touched"] == []
+
+
+# ---------------------------------------------------------------------------
+# (3) Filters
+# ---------------------------------------------------------------------------
+
+
+def _seed_mixed_pipelines(s):
+    """Seeds one legacy + one agentic question for the same user."""
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    _add_question(
+        s,
+        user_id=10,
+        content="legacy q",
+        when=datetime(2026, 6, 1, 12, 0, 0),
+        assistant_sql="SELECT legacy",
+    )
+    agentic_mid = _add_question(s, user_id=10, content="agentic q", when=datetime(2026, 6, 1, 12, 5, 0))
+    _add_agent_run(s, run_id="run-pip", user_id=10, user_message_id=agentic_mid)
+    _add_tool_call(
+        s,
+        run_id="run-pip",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tc-p0",
+        sql_executed=["SELECT agentic"],
+    )
+
+
+def test_pipelines_filter_agentic_only(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_mixed_pipelines(s)
+
+    page = get_per_query_audit_page(_filters(pipelines=["agentic"]), page=1, page_size=50)
+    assert all(r["pipeline"] == "agentic" for r in page["items"])
+    assert page["total"] == 1
+
+
+def test_pipelines_filter_legacy_only(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_mixed_pipelines(s)
+
+    page = get_per_query_audit_page(_filters(pipelines=["legacy"]), page=1, page_size=50)
+    assert all(r["pipeline"] == "legacy" for r in page["items"])
+    assert page["total"] == 1
+
+
+def test_source_ids_filter_excludes_legacy_and_other_runs(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    # Two agentic questions; only run-A touched pat-001.
+    mid_a = _add_question(s, user_id=10, content="qA", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-A", user_id=10, user_message_id=mid_a)
+    _add_tool_call(
+        s, run_id="run-A", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tcA", sql_executed=["SELECT 1"]
+    )
+    _add_patient_access(s, run_id="run-A", user_id=10, source_id="pat-001")
+
+    mid_b = _add_question(s, user_id=10, content="qB", when=datetime(2026, 6, 1, 12, 5, 0))
+    _add_agent_run(s, run_id="run-B", user_id=10, user_message_id=mid_b)
+    _add_tool_call(
+        s, run_id="run-B", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tcB", sql_executed=["SELECT 2"]
+    )
+    _add_patient_access(s, run_id="run-B", user_id=10, source_id="pat-999")
+
+    # Plus one legacy question that should never qualify under source_ids.
+    _add_question(
+        s,
+        user_id=10,
+        content="legacy q",
+        when=datetime(2026, 6, 1, 12, 10, 0),
+        assistant_sql="SELECT legacy",
+    )
+
+    page = get_per_query_audit_page(_filters(source_ids=["pat-001"]), page=1, page_size=50)
+    assert page["total"] == 1
+    assert page["items"][0]["run_id"] == "run-A"
+
+
+def test_tool_names_filter_restricts_to_named_tools(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="mixed tools", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-t", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s, run_id="run-t", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tc0", sql_executed=["SELECT 1"]
+    )
+    _add_tool_call(
+        s,
+        run_id="run-t",
+        user_id=10,
+        tool_name="search_knowledge_base",
+        call_index=1,
+        tool_call_uid="tc1",
+        sql_executed=[],
+        result_summary="kb hit",
+    )
+
+    page = get_per_query_audit_page(_filters(tool_names=["run_sql"]), page=1, page_size=50)
+    assert all(r["tool_name"] == "run_sql" for r in page["items"])
+    assert page["total"] == 1
+
+
+def test_scope_filter_patient_carries_over_to_per_row_view(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    # Patient-scope run (selected_patient_source_id set) with 2 tool calls.
+    mid_p = _add_question(s, user_id=10, content="patient q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-pat", user_id=10, user_message_id=mid_p, selected_patient_source_id="pat-001")
+    _add_tool_call(
+        s,
+        run_id="run-pat",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcp0",
+        sql_executed=["SELECT 1"],
+    )
+    _add_tool_call(
+        s,
+        run_id="run-pat",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=1,
+        tool_call_uid="tcp1",
+        sql_executed=["SELECT 2"],
+    )
+    # Pop-Health run.
+    mid_o = _add_question(s, user_id=10, content="cohort q", when=datetime(2026, 6, 1, 12, 5, 0))
+    _add_agent_run(s, run_id="run-pop", user_id=10, user_message_id=mid_o)
+    _add_tool_call(
+        s,
+        run_id="run-pop",
+        user_id=10,
+        tool_name="search_patients_by_criteria",
+        call_index=0,
+        tool_call_uid="tco0",
+        sql_executed=["SELECT cohort"],
+    )
+
+    page = get_per_query_audit_page(_filters(scopes=["Patient"]), page=1, page_size=50)
+    assert page["total"] == 2  # 2 tool calls in the Patient run
+    assert all(r["scope"] == "Patient" for r in page["items"])
+    assert {r["run_id"] for r in page["items"]} == {"run-pat"}
+
+
+# ---------------------------------------------------------------------------
+# (4) Pagination
+# ---------------------------------------------------------------------------
+
+
+def test_pagination_offset_limit_and_total(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    # 11 user questions; mix of legacy + agentic
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    n = 0
+    for i in range(7):
+        _add_question(
+            s,
+            user_id=10,
+            content=f"legacy-{i}",
+            when=base - timedelta(minutes=n),
+            assistant_sql=f"SELECT {i}",
+        )
+        n += 1
+    for i in range(4):
+        mid = _add_question(s, user_id=10, content=f"agentic-{i}", when=base - timedelta(minutes=n))
+        _add_agent_run(s, run_id=f"run-{i}", user_id=10, user_message_id=mid)
+        _add_tool_call(
+            s,
+            run_id=f"run-{i}",
+            user_id=10,
+            tool_name="run_sql",
+            call_index=0,
+            tool_call_uid=f"tc-{i}",
+            sql_executed=[f"SELECT a{i}"],
+        )
+        n += 1
+
+    page2 = get_per_query_audit_page(_filters(), page=2, page_size=5)
+    assert page2["total"] == 11
+    assert len(page2["items"]) == 5
+
+
+# ---------------------------------------------------------------------------
+# (5) Logging-mode handling (full / scrubbed / disabled)
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_logging_mode_emits_sentinel(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="disabled q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-d", user_id=10, user_message_id=mid, logging_mode="disabled")
+    # Even in disabled mode there can be carrier ToolCalls (the run_logger
+    # writes the row before short-circuiting payload columns). Seed one with
+    # NULL sql_executed_json to mimic that.
+    _add_tool_call(
+        s,
+        run_id="run-d",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcd",
+        sql_executed=None,
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    item = page["items"][0]
+    assert item["pipeline"] == "agentic"
+    assert item["logging_mode"] == "disabled"
+    assert item["sql_statements"] == []
+    assert item["non_sql_summary"] == "(logging disabled)"
+
+
+def test_scrubbed_mode_passes_logging_mode_through(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="scrubbed q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-sc", user_id=10, user_message_id=mid, logging_mode="scrubbed")
+    # In scrubbed mode the SQL literals are hashed by the writer; we pass
+    # through whatever the writer stored.
+    _add_tool_call(
+        s,
+        run_id="run-sc",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcs",
+        sql_executed=["SELECT * FROM t WHERE id = '<hash:abc>'"],
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    item = page["items"][0]
+    assert item["logging_mode"] == "scrubbed"
+    assert item["sql_statements"] == ["SELECT * FROM t WHERE id = '<hash:abc>'"]
+    assert item["non_sql_summary"] is None
+
+
+# ---------------------------------------------------------------------------
+# (6) Defensive decode + multi-run-per-message edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_sql_executed_json_returns_empty_list(session_factory, caplog):
+    import logging
+
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="bad json", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(s, run_id="run-bad", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s,
+        run_id="run-bad",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcbad",
+        sql_executed="not-json{[",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["items"][0]["sql_statements"] == []
+    assert any("malformed JSON" in rec.message for rec in caplog.records)
+
+
+def test_two_runs_same_user_message_id_both_appear_with_deterministic_order(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    mid = _add_question(s, user_id=10, content="retried q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_agent_run(
+        s,
+        run_id="run-first",
+        user_id=10,
+        user_message_id=mid,
+        created_at=datetime(2026, 6, 1, 12, 0, 5),
+    )
+    _add_tool_call(
+        s,
+        run_id="run-first",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcA",
+        sql_executed=["SELECT first"],
+    )
+    _add_agent_run(
+        s,
+        run_id="run-second",
+        user_id=10,
+        user_message_id=mid,
+        created_at=datetime(2026, 6, 1, 12, 0, 10),
+    )
+    _add_tool_call(
+        s,
+        run_id="run-second",
+        user_id=10,
+        tool_name="run_sql",
+        call_index=0,
+        tool_call_uid="tcB",
+        sql_executed=["SELECT second"],
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    assert page["total"] == 2
+    # Ordering: same asked_at, same user_message_id, so secondary sort is by
+    # run_id ascending — "run-first" then "run-second".
+    assert [r["run_id"] for r in page["items"]] == ["run-first", "run-second"]
+
+
+# ---------------------------------------------------------------------------
+# (7) Export cap
+# ---------------------------------------------------------------------------
+
+
+def test_export_caps_at_max_audit_export_rows(session_factory, monkeypatch):
+    from orm import logging_functions as lf
+    from orm.logging_functions import get_per_query_audit_export
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+
+    # Seed 60 legacy questions.
+    base = datetime(2026, 6, 1, 12, 0, 0)
+    for i in range(60):
+        _add_question(
+            s,
+            user_id=10,
+            content=f"q-{i}",
+            when=base - timedelta(minutes=i),
+            assistant_sql=f"SELECT {i}",
+        )
+
+    monkeypatch.setattr(lf, "MAX_AUDIT_EXPORT_ROWS", 50)
+    rows = get_per_query_audit_export(_filters())
+    assert len(rows) == 50
+
+
+# ---------------------------------------------------------------------------
+# (8) Ordering: question time desc, then call_index within an agentic question
+# ---------------------------------------------------------------------------
+
+
+def test_ordering_reverse_chronological_by_question_then_call_index(session_factory):
+    from orm.logging_functions import get_per_query_audit_page
+
+    s = session_factory()
+    _seed_roles(s)
+    _seed_user(s, id=10, username="alice")
+    older = datetime(2026, 6, 1, 11, 0, 0)
+    newer = datetime(2026, 6, 1, 13, 0, 0)
+    _add_question(s, user_id=10, content="older legacy", when=older, assistant_sql="SELECT old")
+    mid = _add_question(s, user_id=10, content="newer agentic", when=newer)
+    _add_agent_run(s, run_id="run-n", user_id=10, user_message_id=mid)
+    _add_tool_call(
+        s, run_id="run-n", user_id=10, tool_name="run_sql", call_index=2, tool_call_uid="tc2", sql_executed=["B"]
+    )
+    _add_tool_call(
+        s, run_id="run-n", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tc0", sql_executed=["A"]
+    )
+    _add_tool_call(
+        s, run_id="run-n", user_id=10, tool_name="run_sql", call_index=1, tool_call_uid="tc1", sql_executed=["AB"]
+    )
+
+    page = get_per_query_audit_page(_filters(), page=1, page_size=50)
+    # Newer question first; within it, call_index ascending; then legacy.
+    pipelines = [(r["pipeline"], r["call_index"]) for r in page["items"]]
+    assert pipelines == [
+        ("agentic", 0),
+        ("agentic", 1),
+        ("agentic", 2),
+        ("legacy", None),
+    ]

--- a/tests/views/test_admin_audit_by_patient.py
+++ b/tests/views/test_admin_audit_by_patient.py
@@ -1,0 +1,304 @@
+"""View-layer tests for the By-Patient audit sub-tab (Epic #190, Phase 3).
+
+Exercises the tab body in ``views.admin_audit_by_patient`` against a small
+streamlit stub. Asserts:
+  * autocomplete option formatting,
+  * paste-textarea parsing,
+  * source_ids wiring through to the Phase 1 data layer,
+  * Phase 2 helpers being called with ``key_prefix="by_patient"`` so the
+    new tab's widget state doesn't collide with the Queries tab.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from orm.models import RoleTypeEnum
+
+
+def _make_options() -> list[dict]:
+    return [
+        {
+            "source_id": "pat-1",
+            "display_name": "Alice Anders",
+            "last_touched_at": datetime(2026, 6, 1, 12, 0, 0),
+            "access_count": 3,
+        },
+        {
+            "source_id": "pat-2",
+            "display_name": None,
+            "last_touched_at": datetime(2026, 6, 1, 11, 0, 0),
+            "access_count": 1,
+        },
+    ]
+
+
+def _make_stub(
+    *,
+    multiselect_returns=None,
+    text_area_returns=None,
+    radio_value="Grouped",
+    selectbox_returns=None,
+):
+    captured_multiselect: list[dict] = []
+    captured_data_layer_calls: list[dict] = []
+    multiselect_returns = multiselect_returns or {}
+    text_area_returns = text_area_returns or {}
+    selectbox_returns = selectbox_returns or {}
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {"user_role": RoleTypeEnum.ADMIN.value}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.column_config = MagicMock()
+
+        def multiselect(self, label, options=None, key=None, format_func=None, **kw):
+            opts_list = list(options or [])
+            captured_multiselect.append(
+                {
+                    "label": label,
+                    "options": opts_list,
+                    "key": key,
+                    "format_func": format_func,
+                    "kwargs": kw,
+                }
+            )
+            val = multiselect_returns.get(key, [])
+            self.session_state.setdefault(key, val)
+            self.session_state[key] = val
+            return val
+
+        def text_area(self, label, key=None, **kw):
+            val = text_area_returns.get(key, "")
+            self.session_state.setdefault(key, val)
+            return val
+
+        def text_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = selectbox_returns.get(key, opts[index] if opts else None)
+            self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def radio(self, *_a, options=None, index=0, key=None, **_kw):
+            self.session_state.setdefault(key, radio_value)
+            return radio_value
+
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def data_editor(self, df, **_kw):
+            return df
+
+        def dataframe(self, *_a, **_kw):
+            return MagicMock()
+
+        def expander(self, *_a, **_kw):
+            return MagicMock()
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, key=None, **_kw):
+            return False
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def rerun(self):
+            pass
+
+        def cache_data(self, *_a, **_kw):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub(), {
+        "multiselect": captured_multiselect,
+        "data_layer_calls": captured_data_layer_calls,
+    }
+
+
+# ---------------------------------------------------------------------------
+# (1) Empty selection → info card, no data-layer call
+# ---------------------------------------------------------------------------
+
+
+def test_no_patients_selected_renders_info_card_and_skips_data_layer():
+    from views import admin_audit_by_patient
+
+    stub, _ = _make_stub()
+    page_calls: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        page_calls.append(filters)
+        return {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_audit_by_patient, "st", stub),
+        patch.object(admin_audit_by_patient, "_cached_patient_options", return_value=_make_options()),
+        patch.object(admin_audit_by_patient._q, "get_per_query_audit_page", side_effect=_fake_page),
+    ):
+        admin_audit_by_patient._render_by_patient_tab(30)
+
+    # No selection → no data-layer call.
+    assert page_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (2) format_func renders "<display> (<source_id>)" / "<source_id>"
+# ---------------------------------------------------------------------------
+
+
+def test_format_option_with_and_without_display_name():
+    from views.admin_audit_by_patient import _format_option
+
+    assert _format_option({"source_id": "pat-1", "display_name": "Alice"}) == "Alice (pat-1)"
+    assert _format_option({"source_id": "pat-2", "display_name": None}) == "pat-2"
+
+
+# ---------------------------------------------------------------------------
+# (3) Selected patient(s) plumbed to the data layer via source_ids
+# ---------------------------------------------------------------------------
+
+
+def test_selected_patients_reach_data_layer_via_source_ids():
+    from views import admin_audit_by_patient
+
+    options = _make_options()
+    stub, captures = _make_stub(
+        multiselect_returns={"by_patient_picker": [options[0]]},
+    )
+
+    page_calls: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        page_calls.append(filters)
+        return {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_audit_by_patient, "st", stub),
+        patch.object(admin_audit_by_patient, "_cached_patient_options", return_value=options),
+        patch.object(admin_audit_by_patient._q, "get_per_query_audit_page", side_effect=_fake_page),
+    ):
+        admin_audit_by_patient._render_by_patient_tab(30)
+
+    assert page_calls, "data layer must be called once a patient is selected"
+    assert page_calls[-1]["source_ids"] == ["pat-1"]
+    # Pipeline is pinned to agentic for the By-Patient tab.
+    assert page_calls[-1]["pipelines"] == ["agentic"]
+
+
+# ---------------------------------------------------------------------------
+# (4) Paste textarea contents merge into source_ids (deduped, trimmed)
+# ---------------------------------------------------------------------------
+
+
+def test_paste_textarea_appends_source_ids_deduped_and_trimmed():
+    from views import admin_audit_by_patient
+
+    options = _make_options()
+    stub, _ = _make_stub(
+        multiselect_returns={"by_patient_picker": [options[0]]},
+        text_area_returns={"by_patient_paste": "  pat-99  \npat-1\n\n  pat-100\n"},
+    )
+
+    page_calls: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        page_calls.append(filters)
+        return {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_audit_by_patient, "st", stub),
+        patch.object(admin_audit_by_patient, "_cached_patient_options", return_value=options),
+        patch.object(admin_audit_by_patient._q, "get_per_query_audit_page", side_effect=_fake_page),
+    ):
+        admin_audit_by_patient._render_by_patient_tab(30)
+
+    assert page_calls[-1]["source_ids"] == ["pat-1", "pat-99", "pat-100"]
+
+
+# ---------------------------------------------------------------------------
+# (5) Widget keys use the by_patient prefix
+# ---------------------------------------------------------------------------
+
+
+def test_tab_uses_by_patient_key_prefix_for_widgets():
+    from views import admin_audit_by_patient
+
+    options = _make_options()
+    stub, captures = _make_stub(
+        multiselect_returns={"by_patient_picker": [options[0]]},
+    )
+
+    with (
+        patch.object(admin_audit_by_patient, "st", stub),
+        patch.object(admin_audit_by_patient, "_cached_patient_options", return_value=options),
+        patch.object(
+            admin_audit_by_patient._q,
+            "get_per_query_audit_page",
+            return_value={"items": [], "total": 0},
+        ),
+    ):
+        admin_audit_by_patient._render_by_patient_tab(30)
+
+    picker_chip = next(
+        (m for m in captures["multiselect"] if m["key"] == "by_patient_picker"),
+        None,
+    )
+    assert picker_chip is not None
+    # No widget key from this tab should collide with the Queries tab's
+    # ``queries_*`` keys.
+    assert all(not str(k).startswith("queries_") for k in stub.session_state.keys())
+
+
+# ---------------------------------------------------------------------------
+# (6) Parser tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_paste_handles_blank_and_dedup():
+    from views.admin_audit_by_patient import _parse_paste
+
+    assert _parse_paste(None) == []
+    assert _parse_paste("") == []
+    assert _parse_paste("\n\n   \n") == []
+    assert _parse_paste("a\nb\na\n  c  \nb") == ["a", "b", "c"]

--- a/tests/views/test_admin_audit_dialog_collision.py
+++ b/tests/views/test_admin_audit_dialog_collision.py
@@ -2,26 +2,27 @@
 
 Background
 ----------
-``views/admin_audit.py:render`` builds an inner ``st.tabs`` with three child
-audit tabs (Questions, Admin Actions, User Activity). Epic #169 / #170
-swapped each tab's trigger primitive from
-``st.dataframe(on_select=..., selection_mode='single-row')`` to
-``st.data_editor`` + a leading labeled ``View`` ``CheckboxColumn`` that
-auto-opens the detail dialog when exactly one row is ticked.
-``st.tabs`` still evaluates *every* tab body on every rerun, and
-Streamlit still forbids more than one ``st.dialog`` call per script run
-— so the cross-tab claim guard remains as defense in depth.
+``views/admin_audit.py:render`` builds an inner ``st.tabs``. The inner tab
+list is (post-#190): Queries, By Patient, Admin Actions, User Activity.
+Each existing tab wires its grid as ``st.data_editor`` + a leading labeled
+``View`` ``CheckboxColumn`` that auto-opens the detail dialog when exactly
+one row is ticked. ``st.tabs`` still evaluates *every* tab body on every
+rerun, and Streamlit still forbids more than one ``st.dialog`` call per
+script run — so the cross-tab claim guard remains as defense in depth.
 
 The per-rerun guard, ``_audit_dialog_claimed_this_rerun``:
 
 * ``views/admin_audit.py:render`` resets the flag to ``False`` at the top of
   every rerun, before ``st.tabs`` is created.
-* Each of the three tab dialog branches checks-and-sets the flag *inside*
-  the auto-open-on-tick branch, so at most one tab opens a dialog per
-  rerun.
+* Each tab dialog branch checks-and-sets the flag *inside* the
+  auto-open-on-tick branch, so at most one tab opens a dialog per rerun.
 
 These tests pin both behaviours under the new (data_editor + auto-open)
-flow.
+flow. Epic #190 / Phase 4 retired the Questions tab from the umbrella;
+tests that previously used the Questions dialog as the "first tab that
+fires" now use the Admin Actions dialog (still in the umbrella) as the
+auto-open evidence. The behaviour under test — guard reset, external
+dialog detection — is unchanged.
 """
 
 from __future__ import annotations
@@ -438,24 +439,25 @@ class TestCrossTabCollision:
     def test_guard_resets_per_rerun(self):
         """The cross-tab claim guard must be cleared at the top of every
         rerun. Two consecutive ``render`` calls in which the user ticks
-        the Questions tab's ``View`` checkbox on a different row each
+        the Admin Actions tab's ``View`` checkbox on a different row each
         time must each fire exactly one dialog. (If the guard leaked
         across reruns, the second rerun would silently drop the dialog.)
         """
         from views import admin_audit
 
-        # Two distinct Questions items across the two reruns. Same
-        # data_editor key, different ``user_message_id``s — so the
-        # per-tab ``open_id`` gate naturally allows the second rerun's
-        # dialog to fire (different id → different gate value).
-        q_item_1 = _make_question_item(user_message_id=111)
-        q_item_2 = _make_question_item(user_message_id=222)
+        # Two distinct Admin Actions items across the two reruns. Same
+        # data_editor key, different ``id``s — so the per-tab
+        # ``audit_actions_dialog_open_id`` gate naturally allows the
+        # second rerun's dialog to fire (different id → different gate
+        # value).
+        a_item_1 = _make_admin_action_item(id=111)
+        a_item_2 = _make_admin_action_item(id=222)
 
         # A single shared stub across both reruns so session_state persists,
         # just like real Streamlit. Row 0 is ticked in both reruns; the
-        # second rerun's row has a different ``user_message_id``.
+        # second rerun's row has a different ``id``.
         stub = _SharedSessionStub(
-            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_view_checked={"audit_actions_dataframe": [True]},
         )
 
         # ---- Rerun 1 -----------------------------------------------------
@@ -483,14 +485,14 @@ class TestCrossTabCollision:
             stack.enter_context(
                 patch(
                     "orm.logging_functions.get_question_audit_page",
-                    return_value={"items": [q_item_1], "total": 1},
+                    return_value={"items": [], "total": 0},
                 )
             )
             stack.enter_context(patch("orm.functions.get_all_users", return_value=[]))
             stack.enter_context(
                 patch(
                     "orm.logging_functions.get_admin_actions_page",
-                    return_value={"items": [], "total": 0},
+                    return_value={"items": [a_item_1], "total": 1},
                 )
             )
             stack.enter_context(
@@ -522,8 +524,8 @@ class TestCrossTabCollision:
 
             admin_audit.render(30)
 
-        assert (len(q1), len(a1), len(u1)) == (1, 0, 0), (
-            f"Rerun 1 must open exactly one Questions dialog; got Q={len(q1)} A={len(a1)} U={len(u1)}"
+        assert (len(q1), len(a1), len(u1)) == (0, 1, 0), (
+            f"Rerun 1 must open exactly one Admin Actions dialog; got Q={len(q1)} A={len(a1)} U={len(u1)}"
         )
 
         # ---- Rerun 2 -----------------------------------------------------
@@ -548,14 +550,14 @@ class TestCrossTabCollision:
             stack.enter_context(
                 patch(
                     "orm.logging_functions.get_question_audit_page",
-                    return_value={"items": [q_item_2], "total": 1},
+                    return_value={"items": [], "total": 0},
                 )
             )
             stack.enter_context(patch("orm.functions.get_all_users", return_value=[]))
             stack.enter_context(
                 patch(
                     "orm.logging_functions.get_admin_actions_page",
-                    return_value={"items": [], "total": 0},
+                    return_value={"items": [a_item_2], "total": 1},
                 )
             )
             stack.enter_context(
@@ -587,8 +589,8 @@ class TestCrossTabCollision:
 
             admin_audit.render(30)
 
-        assert (len(q2), len(a2), len(u2)) == (1, 0, 0), (
-            f"Rerun 2 must also open exactly one Questions dialog (guard reset per rerun); "
+        assert (len(q2), len(a2), len(u2)) == (0, 1, 0), (
+            f"Rerun 2 must also open exactly one Admin Actions dialog (guard reset per rerun); "
             f"got Q={len(q2)} A={len(a2)} U={len(u2)}"
         )
 
@@ -600,10 +602,10 @@ class TestCrossTabCollision:
         """
         from views import admin_audit
 
-        q_item = _make_question_item(user_message_id=1)
+        a_item = _make_admin_action_item(id=1)
 
         stub = _SharedSessionStub(
-            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_view_checked={"audit_actions_dataframe": [True]},
             initial_session={"_audit_dialog_claimed_this_rerun": True},
         )
 
@@ -613,8 +615,8 @@ class TestCrossTabCollision:
 
         patchers = _patches_for_render(
             stub=stub,
-            questions_items=[q_item],
-            actions_items=[],
+            questions_items=[],
+            actions_items=[a_item],
             activity_items=[],
             spy_q=q_calls.append,
             spy_a=a_calls.append,
@@ -628,11 +630,11 @@ class TestCrossTabCollision:
                 stack.enter_context(p)
             admin_audit.render(30)
 
-        # If the guard had not been reset, the Questions dialog would have
-        # been silently dropped.
-        assert len(q_calls) == 1, (
+        # If the guard had not been reset, the Admin Actions dialog would
+        # have been silently dropped.
+        assert len(a_calls) == 1, (
             f"render() must reset _audit_dialog_claimed_this_rerun before tabs evaluate; "
-            f"saw {len(q_calls)} Q dialog call(s) (expected 1)"
+            f"saw {len(a_calls)} A dialog call(s) (expected 1)"
         )
 
 
@@ -800,8 +802,7 @@ class TestExternalDialogCollision:
             admin_audit.render(30)
 
         assert q_calls == [], (
-            f"Questions auto-open must defer to an already-claimed dialog slot; "
-            f"saw {len(q_calls)} Q dialog call(s)"
+            f"Questions auto-open must defer to an already-claimed dialog slot; saw {len(q_calls)} Q dialog call(s)"
         )
         assert a_calls == []
         assert u_calls == []
@@ -813,10 +814,10 @@ class TestExternalDialogCollision:
         happy path."""
         from views import admin_audit
 
-        q_item = _make_question_item(user_message_id=42)
+        a_item = _make_admin_action_item(id=42)
 
         stub = _SharedSessionStub(
-            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_view_checked={"audit_actions_dataframe": [True]},
         )
 
         q_calls: list = []
@@ -825,8 +826,8 @@ class TestExternalDialogCollision:
 
         patchers = _patches_for_render(
             stub=stub,
-            questions_items=[q_item],
-            actions_items=[],
+            questions_items=[],
+            actions_items=[a_item],
             activity_items=[],
             spy_q=q_calls.append,
             spy_a=a_calls.append,
@@ -850,9 +851,8 @@ class TestExternalDialogCollision:
             )
             admin_audit.render(30)
 
-        assert len(q_calls) == 1, (
-            f"With no external dialog claimed, Questions auto-open must still "
-            f"fire exactly once; saw {len(q_calls)}"
+        assert len(a_calls) == 1, (
+            f"With no external dialog claimed, Admin Actions auto-open must still fire exactly once; saw {len(a_calls)}"
         )
 
     def test_missing_script_run_ctx_does_not_crash(self):
@@ -861,10 +861,10 @@ class TestExternalDialogCollision:
         must treat that as "no claim" and not crash."""
         from views import admin_audit
 
-        q_item = _make_question_item(user_message_id=7)
+        a_item = _make_admin_action_item(id=7)
 
         stub = _SharedSessionStub(
-            per_key_view_checked={"audit_dataframe": [True]},
+            per_key_view_checked={"audit_actions_dataframe": [True]},
         )
 
         q_calls: list = []
@@ -873,8 +873,8 @@ class TestExternalDialogCollision:
 
         patchers = _patches_for_render(
             stub=stub,
-            questions_items=[q_item],
-            actions_items=[],
+            questions_items=[],
+            actions_items=[a_item],
             activity_items=[],
             spy_q=q_calls.append,
             spy_a=a_calls.append,
@@ -897,4 +897,4 @@ class TestExternalDialogCollision:
 
         # With ctx=None the guard treats it as "no external dialog", so the
         # normal auto-open path runs.
-        assert len(q_calls) == 1
+        assert len(a_calls) == 1

--- a/tests/views/test_admin_audit_queries.py
+++ b/tests/views/test_admin_audit_queries.py
@@ -1,0 +1,587 @@
+"""View-layer tests for the Queries audit sub-tab (Epic #190, Phase 2).
+
+The tab body in ``views.admin_audit_queries`` is exercised against a small
+streamlit stub so we can assert column shape, mode banners, and role-gated
+SQL visibility without spinning up the full Streamlit runtime.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from orm.models import RoleTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# Per-query item factory
+# ---------------------------------------------------------------------------
+
+
+def _make_legacy_item(*, user_message_id: int = 100, **overrides) -> dict:
+    base = {
+        "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+        "user_id": 7,
+        "username": "alice",
+        "organization": "Acme",
+        "question": "How many patients today?",
+        "user_message_id": user_message_id,
+        "scope": "Legacy/Unknown",
+        "pipeline": "legacy",
+        "run_id": None,
+        "logging_mode": None,
+        "tool_call_id": None,
+        "tool_name": None,
+        "call_index": None,
+        "sql_statements": ["SELECT count(*) FROM patient"],
+        "non_sql_summary": None,
+        "elapsed_ms": 1250,
+        "success": True,
+        "error": None,
+        "patients_touched": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_agentic_item(*, user_message_id: int = 200, tool_call_id: int = 1, **overrides) -> dict:
+    base = {
+        "asked_at": datetime(2026, 6, 1, 12, 5, 0),
+        "user_id": 7,
+        "username": "alice",
+        "organization": "Acme",
+        "question": "Patient X labs",
+        "user_message_id": user_message_id,
+        "scope": "Patient",
+        "pipeline": "agentic",
+        "run_id": "run-abc",
+        "logging_mode": "full",
+        "tool_call_id": tool_call_id,
+        "tool_name": "run_sql",
+        "call_index": 0,
+        "sql_statements": ["SELECT * FROM lab WHERE patient_id = 'pat-1'"],
+        "non_sql_summary": None,
+        "elapsed_ms": 87,
+        "success": True,
+        "error": None,
+        "patients_touched": [{"source_id": "pat-1", "display_name": "Alice A"}],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# (1)–(6) Row-component shape tests
+# ---------------------------------------------------------------------------
+
+
+def test_row_dict_legacy_item():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    row = _per_query_row_to_table_dict(_make_legacy_item())
+    assert row["Pipeline"] == "legacy"
+    assert row["Tool"] == "(legacy SQL)"
+    assert row["SQL"].startswith("SELECT count(*) FROM patient")
+    assert row["Patient(s)"] == ""
+    assert row["Status"] == "✅ Success"
+    assert row["Elapsed (ms)"] == 1250
+
+
+def test_row_dict_agentic_multi_sql_shows_statement_count():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    item = _make_agentic_item(
+        sql_statements=["SELECT a FROM t1", "SELECT b FROM t2", "SELECT c FROM t3"],
+        tool_name="run_sql",
+    )
+    row = _per_query_row_to_table_dict(item)
+    assert row["Tool"] == "run_sql"
+    assert row["SQL"].startswith("3 statements:")
+    assert "SELECT a FROM t1" in row["SQL"]
+
+
+def test_row_dict_agentic_non_sql_tool_call_uses_sentinel():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    item = _make_agentic_item(
+        tool_name="search_knowledge_base",
+        sql_statements=[],
+        non_sql_summary="3 KB hits",
+        call_index=2,
+    )
+    row = _per_query_row_to_table_dict(item)
+    assert row["Tool"] == "search_knowledge_base"
+    assert row["SQL"] == "(no SQL — tool result)"
+
+
+def test_row_dict_disabled_logging_mode_uses_disabled_sentinel():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    item = _make_agentic_item(
+        logging_mode="disabled",
+        sql_statements=[],
+        non_sql_summary="(logging disabled)",
+    )
+    row = _per_query_row_to_table_dict(item)
+    assert row["SQL"] == "(logging disabled)"
+
+
+def test_row_dict_scrubbed_mode_prefixes_sql_preview():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    item = _make_agentic_item(
+        logging_mode="scrubbed",
+        sql_statements=["SELECT * FROM t WHERE id = '<hash:abc>'"],
+    )
+    row = _per_query_row_to_table_dict(item)
+    assert row["SQL"].startswith("(scrubbed) ")
+
+
+def test_row_dict_patient_touched_joined_by_comma():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    item = _make_agentic_item(
+        patients_touched=[
+            {"source_id": "pat-1", "display_name": "Alice"},
+            {"source_id": "pat-2", "display_name": "Bob"},
+        ]
+    )
+    row = _per_query_row_to_table_dict(item)
+    assert "pat-1" in row["Patient(s)"]
+    assert "pat-2" in row["Patient(s)"]
+    assert "," in row["Patient(s)"]
+
+
+# ---------------------------------------------------------------------------
+# (7)–(9) Status derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_status_success():
+    from views.admin_audit_queries import _derive_status
+
+    assert _derive_status(_make_agentic_item(success=True)) == "✅ Success"
+
+
+def test_derive_status_error_takes_priority_over_payload():
+    from views.admin_audit_queries import _derive_status
+
+    item = _make_agentic_item(success=False, error="boom", sql_statements=["SELECT 1"])
+    assert _derive_status(item) == "❌ Error"
+
+
+def test_derive_status_empty_when_no_payload_no_error():
+    from views.admin_audit_queries import _derive_status
+
+    item = _make_agentic_item(
+        success=None,
+        sql_statements=[],
+        non_sql_summary=None,
+        error=None,
+    )
+    assert _derive_status(item) == "⚪ Empty"
+
+
+# ---------------------------------------------------------------------------
+# (10) Grouping by user_message_id
+# ---------------------------------------------------------------------------
+
+
+def test_group_items_by_question_clusters_by_message_id_in_order():
+    from views.admin_audit_queries import _group_items_by_question
+
+    items = [
+        _make_agentic_item(user_message_id=200, tool_call_id=1, elapsed_ms=10, call_index=0),
+        _make_agentic_item(user_message_id=200, tool_call_id=2, elapsed_ms=15, call_index=1),
+        _make_legacy_item(user_message_id=100),  # 1250 ms
+        _make_agentic_item(user_message_id=200, tool_call_id=3, elapsed_ms=5, call_index=2),
+        _make_legacy_item(user_message_id=101, asked_at=datetime(2026, 6, 1, 11, 0, 0)),
+    ]
+
+    groups = _group_items_by_question(items)
+    # Three distinct questions, order preserved.
+    assert [hdr["user_message_id"] for hdr, _ in groups] == [200, 100, 101]
+    # First group has 3 units; total_elapsed_ms sums.
+    hdr200, units200 = groups[0]
+    assert hdr200["query_count"] == 3
+    assert hdr200["total_elapsed_ms"] == 30
+    assert len(units200) == 3
+
+
+def test_group_inherits_most_alarming_logging_mode():
+    from views.admin_audit_queries import _group_items_by_question
+
+    items = [
+        _make_agentic_item(user_message_id=300, tool_call_id=1, logging_mode="full"),
+        _make_agentic_item(user_message_id=300, tool_call_id=2, logging_mode="scrubbed"),
+        _make_agentic_item(user_message_id=300, tool_call_id=3, logging_mode="full"),
+    ]
+
+    groups = _group_items_by_question(items)
+    assert groups[0][0]["logging_mode"] == "scrubbed"
+
+
+# ---------------------------------------------------------------------------
+# (11)–(15) Detail dialog body rendering (role gating + mode banners)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingStub:
+    """Minimal Streamlit stub recording the calls dialog bodies make."""
+
+    def __init__(self, *, role: int = RoleTypeEnum.ADMIN.value, button_returns: dict | None = None):
+        self.session_state = {"user_role": role}
+        self.code_calls: list[tuple[str, dict]] = []
+        self.warning_calls: list[str] = []
+        self.markdown_calls: list[str] = []
+        self.write_calls: list[str] = []
+        self.caption_calls: list[str] = []
+        self.button_calls: list[dict] = []
+        self.switch_page_calls: list[str] = []
+        self.button_returns = dict(button_returns or {})
+        self.components = MagicMock()
+        self.components.v1 = MagicMock()
+        self.components.v1.html = MagicMock()
+
+    def markdown(self, text, *_a, **_kw):
+        self.markdown_calls.append(text)
+
+    def write(self, text, *_a, **_kw):
+        self.write_calls.append(str(text))
+
+    def warning(self, text, *_a, **_kw):
+        self.warning_calls.append(str(text))
+
+    def code(self, text, **kw):
+        self.code_calls.append((str(text), kw))
+
+    def caption(self, text, *_a, **_kw):
+        self.caption_calls.append(str(text))
+
+    def columns(self, n):
+        return [MagicMock() for _ in range(n if isinstance(n, int) else len(n))]
+
+    def divider(self):
+        pass
+
+    def button(self, label, key=None, **_kw):
+        self.button_calls.append({"label": label, "key": key})
+        return self.button_returns.get(key, False)
+
+    def switch_page(self, target):
+        self.switch_page_calls.append(target)
+
+
+def test_dialog_body_renders_sql_via_st_code_when_role_allowed():
+    from views import admin_audit_queries
+
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(_make_agentic_item())
+
+    sql_texts = [c[0] for c in stub.code_calls if c[1].get("language") == "sql"]
+    assert any("SELECT * FROM lab" in t for t in sql_texts)
+
+
+def test_dialog_body_hides_sql_when_role_cannot_see_query_details():
+    from views import admin_audit_queries
+
+    stub = _RecordingStub(role=RoleTypeEnum.PATIENT.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(_make_agentic_item())
+
+    sql_calls = [c for c in stub.code_calls if c[1].get("language") == "sql"]
+    assert sql_calls == []
+    assert any("restricted" in w for w in stub.write_calls)
+
+
+def test_dialog_body_shows_scrubbed_banner():
+    from views import admin_audit_queries
+
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(_make_agentic_item(logging_mode="scrubbed"))
+
+    assert any("Scrubbed mode" in w for w in stub.warning_calls)
+
+
+def test_dialog_body_shows_disabled_banner_and_skips_sql():
+    from views import admin_audit_queries
+
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(
+            _make_agentic_item(logging_mode="disabled", sql_statements=[])
+        )
+
+    assert any("Logging disabled" in w for w in stub.warning_calls)
+    sql_calls = [c for c in stub.code_calls if c[1].get("language") == "sql"]
+    assert sql_calls == []
+
+
+def test_dialog_body_numbers_multiple_sql_statements():
+    from views import admin_audit_queries
+
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    item = _make_agentic_item(
+        sql_statements=["SELECT 1", "SELECT 2", "SELECT 3"],
+    )
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(item)
+
+    sql_texts = [c[0] for c in stub.code_calls if c[1].get("language") == "sql"]
+    assert sql_texts == ["SELECT 1", "SELECT 2", "SELECT 3"]
+    # And each gets a numbered header.
+    numbered_headers = [m for m in stub.markdown_calls if m.startswith("**SQL ") and " of " in m]
+    assert len(numbered_headers) == 3
+
+
+# ---------------------------------------------------------------------------
+# (16) Question-level dialog renders one unit per query
+# ---------------------------------------------------------------------------
+
+
+def test_question_dialog_body_stacks_units_for_question():
+    from views import admin_audit_queries
+
+    units = [
+        _make_agentic_item(user_message_id=300, tool_call_id=1, call_index=0, sql_statements=["SELECT A"]),
+        _make_agentic_item(user_message_id=300, tool_call_id=2, call_index=1, sql_statements=["SELECT B"]),
+        _make_agentic_item(user_message_id=300, tool_call_id=3, call_index=2, sql_statements=["SELECT C"]),
+    ]
+    groups = admin_audit_queries._group_items_by_question(units)
+    header, _ = groups[0]
+
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_question_detail_dialog_body(header, units)
+
+    # One "### Query N of M" markdown per unit.
+    query_headers = [m for m in stub.markdown_calls if m.startswith("### Query ")]
+    assert len(query_headers) == 3
+    sql_texts = [c[0] for c in stub.code_calls if c[1].get("language") == "sql"]
+    assert sql_texts == ["SELECT A", "SELECT B", "SELECT C"]
+
+
+# ---------------------------------------------------------------------------
+# (17) Full-tab smoke: confirms Phase 1 helper wiring + filter assembly
+# ---------------------------------------------------------------------------
+
+
+def _make_full_tab_stub(*, multiselect_returns=None, button_returns=None, radio_value="Grouped"):
+    captured_multiselect: list[dict] = []
+    captured_page_calls: list[dict] = []
+    multiselect_returns = multiselect_returns or {}
+    button_returns = button_returns or {}
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {"user_role": RoleTypeEnum.ADMIN.value}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.column_config = MagicMock()
+
+        def multiselect(self, label, options=None, key=None, **kw):
+            captured_multiselect.append({"label": label, "options": list(options or []), "key": key, "kwargs": kw})
+            val = multiselect_returns.get(key, [])
+            self.session_state.setdefault(key, val)
+            self.session_state[key] = val
+            return val
+
+        def text_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def radio(self, *_a, options=None, index=0, key=None, **_kw):
+            self.session_state.setdefault(key, radio_value)
+            return radio_value
+
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def data_editor(self, df, **_kw):
+            return df
+
+        def dataframe(self, *_a, **_kw):
+            return MagicMock()
+
+        def expander(self, *_a, **_kw):
+            return MagicMock()
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, key=None, **_kw):
+            return button_returns.get(key, False)
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def rerun(self):
+            pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    return _Stub(), {"multiselect": captured_multiselect, "page_calls": captured_page_calls}
+
+
+def test_tab_renders_filter_row_with_pipeline_chip_and_calls_data_layer():
+    from views import admin_audit_queries
+
+    stub, captures = _make_full_tab_stub(
+        multiselect_returns={"queries_pipeline_filter": ["agentic"]},
+    )
+
+    captured_filters: list[dict] = []
+
+    def _fake_page(filters, page=1, page_size=50):
+        captured_filters.append(filters)
+        return {"items": [], "total": 0}
+
+    with (
+        patch.object(admin_audit_queries, "st", stub),
+        patch.object(
+            admin_audit_queries,
+            "_cached_audit_filter_options",
+            return_value={"usernames": [], "orgs": []},
+        ),
+        patch.object(admin_audit_queries, "get_per_query_audit_page", side_effect=_fake_page),
+    ):
+        admin_audit_queries._render_queries_tab(30)
+
+    # Pipeline chip rendered with the expected options.
+    pipeline_chip = next(
+        (m for m in captures["multiselect"] if m["key"] == "queries_pipeline_filter"),
+        None,
+    )
+    assert pipeline_chip is not None
+    assert pipeline_chip["options"] == ["legacy", "agentic"]
+    # The selected pipeline reached the data layer.
+    assert captured_filters, "data layer not called"
+    assert captured_filters[-1]["pipelines"] == ["agentic"]
+
+
+def test_csv_export_writes_per_query_audit_columns():
+    from views import admin_audit_queries
+
+    stub, _ = _make_full_tab_stub(
+        radio_value="Flat",
+        button_returns={"queries_export_btn": True},
+    )
+
+    captured_export_df: list[pd.DataFrame] = []
+
+    def _fake_download(_label, data=None, **_kw):
+        try:
+            from io import StringIO
+
+            captured_export_df.append(pd.read_csv(StringIO(data.decode("utf-8"))))
+        except Exception:
+            pass
+
+    stub.download_button = _fake_download  # type: ignore[assignment]
+
+    item = _make_agentic_item(
+        sql_statements=["SELECT * FROM t1", "SELECT * FROM t2"],
+        patients_touched=[{"source_id": "pat-1", "display_name": "Alice"}],
+    )
+
+    with (
+        patch.object(admin_audit_queries, "st", stub),
+        patch.object(
+            admin_audit_queries,
+            "_cached_audit_filter_options",
+            return_value={"usernames": [], "orgs": []},
+        ),
+        patch.object(admin_audit_queries, "get_per_query_audit_page", return_value={"items": [item], "total": 1}),
+        patch.object(admin_audit_queries, "get_per_query_audit_export", return_value=[item]),
+    ):
+        admin_audit_queries._render_queries_tab(30)
+
+    assert captured_export_df, "CSV download_button was not called"
+    df = captured_export_df[0]
+    assert set(df.columns) >= {
+        "Asked At",
+        "User",
+        "Pipeline",
+        "Scope",
+        "Tool",
+        "SQL",
+        "Patient(s)",
+        "Logging mode",
+        "Status",
+        "Elapsed (ms)",
+    }
+    # The two SQL statements are joined with the row-level separator.
+    assert " ;; " in str(df.iloc[0]["SQL"])
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — "View user in Manage Users →" deep-link button on the per-query
+# detail dialog. Inherits from the retired Questions tab's equivalent button.
+# ---------------------------------------------------------------------------
+
+
+def test_dialog_body_renders_view_user_in_manage_users_button():
+    from views import admin_audit_queries
+
+    item = _make_agentic_item(user_message_id=200, tool_call_id=42, user_id=7)
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value)
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(item)
+
+    button_keys = [b["key"] for b in stub.button_calls]
+    assert any(k and k.startswith("queries_dialog_goto_users_200_42") for k in button_keys)
+    button_labels = [b["label"] for b in stub.button_calls]
+    assert "View user in Manage Users →" in button_labels
+
+
+def test_dialog_button_press_sets_pref_and_switches_page():
+    from views import admin_audit_queries
+
+    item = _make_agentic_item(user_message_id=200, tool_call_id=42, user_id=7)
+    btn_key = f"queries_dialog_goto_users_{item['user_message_id']}_{item['tool_call_id']}"
+    stub = _RecordingStub(role=RoleTypeEnum.ADMIN.value, button_returns={btn_key: True})
+
+    with patch.object(admin_audit_queries, "st", stub):
+        admin_audit_queries._render_query_detail_dialog_body(item)
+
+    assert stub.session_state.get("manage_users_pref_user_id") == 7
+    assert stub.switch_page_calls == ["views/admin.py"]

--- a/tests/views/test_admin_audit_questions_retirement.py
+++ b/tests/views/test_admin_audit_questions_retirement.py
@@ -1,0 +1,213 @@
+"""Phase 4 — Questions tab retirement + deep-link migration (Epic #190).
+
+Asserts:
+  * The Audit umbrella no longer renders a "Questions" tab.
+  * The legacy ``audit_trail_pref_user_id`` deep-link contract is now
+    honoured by the Queries tab (admins navigating from Manage Users →
+    "View question audit for <username>" still land with their user
+    filter pre-populated).
+  * The forward-compat ``audit_queries_pref_user_id`` key works the same
+    way (new surfaces can adopt the new name without breaking).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from orm.models import RoleTypeEnum
+
+
+# ---------------------------------------------------------------------------
+# (1) Umbrella tab list no longer includes "Questions"
+# ---------------------------------------------------------------------------
+
+
+def test_audit_umbrella_drops_questions_tab():
+    from views import admin_audit
+
+    captured_tab_labels: list[list[str]] = []
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = {}
+            self.secrets = {"agent_logging": {"mode": "full"}}
+
+        def tabs(self, labels):
+            captured_tab_labels.append(list(labels))
+            # Each "tab" is a context manager that swallows whatever the body does.
+            return [MagicMock() for _ in labels]
+
+    stub = _Stub()
+    # Stub out the body renderers so this test only asserts the tab labels.
+    with (
+        patch.object(admin_audit, "st", stub),
+        patch.object(admin_audit, "admin_audit_queries", MagicMock()),
+        patch.object(admin_audit, "admin_audit_by_patient", MagicMock()),
+        patch.object(admin_audit, "_render_audit_tab", MagicMock()),
+        patch.object(admin_audit, "_render_activity_tab", MagicMock()),
+    ):
+        admin_audit.render(30)
+
+    assert captured_tab_labels, "render() must call st.tabs"
+    assert captured_tab_labels[0] == ["Queries", "By Patient", "Admin Actions", "User Activity"]
+    assert "Questions" not in captured_tab_labels[0]
+
+
+# ---------------------------------------------------------------------------
+# (2) + (3) Deep-link prefill — both the legacy and forward-compat keys
+# ---------------------------------------------------------------------------
+
+
+def _make_prefill_stub(*, initial_session_state=None):
+    captured_multiselect: list[dict] = []
+
+    class _Stub:
+        def __init__(self):
+            self.session_state = dict(initial_session_state or {})
+            self.session_state.setdefault("user_role", RoleTypeEnum.ADMIN.value)
+            self.secrets = {"agent_logging": {"mode": "full"}}
+            self.column_config = MagicMock()
+
+        def multiselect(self, label, options=None, key=None, **kw):
+            captured_multiselect.append({"label": label, "options": list(options or []), "key": key, "kwargs": kw})
+            # If a previous code path (deep-link prefill) wrote to session_state
+            # for this key, respect that value. Otherwise return [].
+            val = self.session_state.get(key, [])
+            self.session_state.setdefault(key, val)
+            return val
+
+        def text_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, "")
+            return ""
+
+        def selectbox(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            self.session_state.setdefault(key, val)
+            return val
+
+        def number_input(self, *_a, key=None, **_kw):
+            self.session_state.setdefault(key, 1)
+            return 1
+
+        def radio(self, *_a, options=None, index=0, key=None, **_kw):
+            opts = list(options or [])
+            val = opts[index] if opts else None
+            self.session_state.setdefault(key, val)
+            return val
+
+        def columns(self, spec):
+            n = spec if isinstance(spec, int) else len(spec)
+            return [MagicMock() for _ in range(n)]
+
+        def data_editor(self, df, **_kw):
+            return df
+
+        def dataframe(self, *_a, **_kw):
+            return MagicMock()
+
+        def expander(self, *_a, **_kw):
+            return MagicMock()
+
+        def info(self, *_a, **_kw):
+            pass
+
+        def button(self, *_a, **_kw):
+            return False
+
+        def caption(self, *_a, **_kw):
+            pass
+
+        def markdown(self, *_a, **_kw):
+            pass
+
+        def write(self, *_a, **_kw):
+            pass
+
+        def divider(self):
+            pass
+
+        def warning(self, *_a, **_kw):
+            pass
+
+        def error(self, *_a, **_kw):
+            pass
+
+        def download_button(self, *_a, **_kw):
+            pass
+
+        def code(self, *_a, **_kw):
+            pass
+
+        def rerun(self):
+            pass
+
+        def dialog(self, _title):
+            def _decorator(fn):
+                return fn
+
+            return _decorator
+
+    stub = _Stub()
+    return stub, {"multiselect": captured_multiselect}
+
+
+def test_audit_trail_pref_user_id_prefills_queries_user_filter():
+    """Legacy deep-link key (set by chat_bot.py / admin_users.py) must
+    pre-populate the Queries tab's user filter."""
+    from views import admin_audit_queries
+
+    stub, _ = _make_prefill_stub(initial_session_state={"audit_trail_pref_user_id": 7})
+
+    with (
+        patch.object(admin_audit_queries, "st", stub),
+        patch.object(
+            admin_audit_queries,
+            "_cached_audit_filter_options",
+            return_value={"usernames": ["alice"], "orgs": []},
+        ),
+        patch(
+            "orm.functions.get_all_users",
+            return_value=[{"id": 7, "username": "alice"}, {"id": 8, "username": "bob"}],
+        ),
+        patch.object(
+            admin_audit_queries,
+            "get_per_query_audit_page",
+            return_value={"items": [], "total": 0},
+        ),
+    ):
+        admin_audit_queries._render_queries_tab(30)
+
+    assert stub.session_state.get("queries_user_filter") == ["alice"]
+    # The prefill key is consumed via .pop() so a rerun doesn't re-apply it.
+    assert "audit_trail_pref_user_id" not in stub.session_state
+
+
+def test_audit_queries_pref_user_id_also_accepted():
+    """The forward-compat key (new surfaces can adopt this name) works the
+    same way as the legacy key."""
+    from views import admin_audit_queries
+
+    stub, _ = _make_prefill_stub(initial_session_state={"audit_queries_pref_user_id": 8})
+
+    with (
+        patch.object(admin_audit_queries, "st", stub),
+        patch.object(
+            admin_audit_queries,
+            "_cached_audit_filter_options",
+            return_value={"usernames": ["alice", "bob"], "orgs": []},
+        ),
+        patch(
+            "orm.functions.get_all_users",
+            return_value=[{"id": 7, "username": "alice"}, {"id": 8, "username": "bob"}],
+        ),
+        patch.object(
+            admin_audit_queries,
+            "get_per_query_audit_page",
+            return_value={"items": [], "total": 0},
+        ),
+    ):
+        admin_audit_queries._render_queries_tab(30)
+
+    assert stub.session_state.get("queries_user_filter") == ["bob"]
+    assert "audit_queries_pref_user_id" not in stub.session_state

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -520,6 +520,12 @@ def _render_audit_question_dialog(item: dict) -> None:
     _render_audit_question_dialog_body(item)
 
 
+# DEPRECATED for the Admin → Audit umbrella as of Epic #190 — replaced by
+# views.admin_audit_queries. Still wired into the legacy Admin → Analytics →
+# "Audit Trail" tab (line 1586 below) and the "Latest Questions" preview KPI
+# on the Overview tab; both will be retired in a follow-up that lives outside
+# Epic #190's scope. Do not extend this function — point new audit work at
+# views/admin_audit_queries.py instead.
 def _render_audit_trail_tab(days_int: int):
     """Render the Question Audit Trail tab (#135)."""
     import datetime as _dt

--- a/views/admin_audit.py
+++ b/views/admin_audit.py
@@ -1,21 +1,32 @@
-"""Admin → Audit sub-tab (Epic #144 / #148).
+"""Admin → Audit umbrella (Epic #144 / #148; per-query rewrite Epic #190).
 
-Consolidates three audit-flavored surfaces into one umbrella:
-- Questions — the question audit trail introduced by Epic #133 / Feature #135
-- Admin Actions — the admin action audit log (was Admin Analytics → Admin Audit)
-- User Activity — the user activity log (was Admin Analytics → User Activity,
-  minus the Activity Type pie chart cut by Epic #144 / #147)
+Inner tab list:
+- **Queries** — per-query unit view (one row per legacy assistant SQL or per
+  agentic ToolCall). Owned by ``views/admin_audit_queries.py``. Replaces the
+  pre-#190 "Questions" tab; the unified view supports both Grouped and Flat
+  modes, scope/pipeline filters, scrubbed/disabled mode banners, and CSV
+  export.
+- **By Patient** — patient-pivot view (one or more patients → every query
+  that touched them). Owned by ``views/admin_audit_by_patient.py``.
+- **Admin Actions** — admin action audit log (was Admin Analytics → Admin
+  Audit; consolidated here by Epic #144 / #148).
+- **User Activity** — user activity log (was Admin Analytics → User Activity;
+  Activity Type pie chart cut by Epic #144 / #147).
 
-All cross-Epic deep-link contracts (`audit_trail_pref_user_id` from #133,
-the `View question audit for <username> →` button from Feature #136, and
-the `View all in audit →` link from Feature #142) target this sub-tab via
-st.switch_page("views/admin.py") — the outer Admin tab labelled "Audit" is
-selected client-side by JS shim in the chat-input / Manage Users surfaces.
+All cross-Epic deep-link contracts (``audit_trail_pref_user_id`` from #133,
+the ``View question audit for <username> →`` button from Feature #136, and
+the ``View all in audit →`` link from Feature #142) target this sub-tab via
+``st.switch_page("views/admin.py")`` — the outer Admin tab labelled "Audit"
+is selected client-side by a JS shim in the chat-input / Manage Users
+surfaces. The shim doesn't pick an inner tab, so deep-links land on the
+first inner tab ("Queries"), which now hosts the deep-link prefill that the
+old Questions tab used to own.
 """
 
 import streamlit as st
 
-from views.admin_analytics import _render_activity_tab, _render_audit_tab, _render_audit_trail_tab
+from views import admin_audit_by_patient, admin_audit_queries
+from views.admin_analytics import _render_activity_tab, _render_audit_tab
 
 
 def render(days_int: int) -> None:
@@ -35,7 +46,7 @@ def render(days_int: int) -> None:
     # log_admin_action, the next get_admin_actions_page reorders items, and the
     # data_editor's index-keyed sticky tick now points to the new top row, so the
     # per-tab open_id gate sees a mismatch and tries to fire. Mark the slot claimed
-    # here so all three inner-tab gates skip.
+    # here so all inner-tab gates skip.
     try:
         from streamlit.runtime.scriptrunner_utils.script_run_context import (
             get_script_run_ctx,
@@ -49,10 +60,12 @@ def render(days_int: int) -> None:
         # revert to the audit-vs-audit-only behavior that existed before.
         pass
 
-    inner = st.tabs(["Questions", "Admin Actions", "User Activity"])
+    inner = st.tabs(["Queries", "By Patient", "Admin Actions", "User Activity"])
     with inner[0]:
-        _render_audit_trail_tab(days_int)
+        admin_audit_queries.render(days_int)
     with inner[1]:
-        _render_audit_tab(days_int)
+        admin_audit_by_patient.render(days_int)
     with inner[2]:
+        _render_audit_tab(days_int)
+    with inner[3]:
         _render_activity_tab(days_int)

--- a/views/admin_audit_by_patient.py
+++ b/views/admin_audit_by_patient.py
@@ -1,0 +1,184 @@
+"""Admin → Audit → By Patient sub-tab (Epic #190, Phase 3).
+
+A focused pivot view: the admin picks one or more patients (by name or
+``source_id``) and the tab renders every per-query audit row that touched
+those patients. Only agentic rows can match — the legacy pipeline has no
+structured ``AgentPatientAccess`` record, so legacy questions never appear
+here. This is called out in the picker's help text.
+
+Implementation note: rendering reuses the Phase 2 helpers from
+``views.admin_audit_queries`` (threaded via the ``key_prefix`` argument)
+so we don't fork the data_editor / expander / dialog code. Only the
+patient picker is new in this phase.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from orm.agent_logging_functions import get_patient_audit_autocomplete
+from utils.quick_logger import get_logger
+from views import admin_audit_queries as _q
+from views.admin_analytics import ANALYTICS_CACHE_TTL_SECONDS
+
+logger = get_logger(__name__)
+
+_KEY_PREFIX = "by_patient"
+
+# Cap on the autocomplete option list. Older patients can still be reached
+# via the paste textarea — see _PASTE_HELP for the user-facing note.
+_AUTOCOMPLETE_LIMIT = 500
+
+_TAB_HELP = (
+    "Search by patient name or `source_id` to see every query that touched "
+    "that patient. Only agentic queries appear here — the legacy pipeline "
+    "has no structured patient-touch record."
+)
+_PASTE_HELP = (
+    "Paste one source ID per line for patients outside the autocomplete "
+    "window (older than the date range, or beyond the 500-row cap)."
+)
+
+
+@st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
+def _cached_patient_options(days_int: int) -> list[dict]:
+    """Cached read of the autocomplete options. Cache key = ``days_int``."""
+    return get_patient_audit_autocomplete(days=days_int, limit=_AUTOCOMPLETE_LIMIT)
+
+
+def _format_option(option: dict) -> str:
+    """Render a single autocomplete option label."""
+    sid = option.get("source_id") or ""
+    name = option.get("display_name")
+    if name:
+        return f"{name} ({sid})"
+    return sid
+
+
+def _parse_paste(text: str | None) -> list[str]:
+    """Split a paste-textarea blob into a deduplicated, trimmed list of IDs."""
+    if not text:
+        return []
+    out: list[str] = []
+    seen: set[str] = set()
+    for line in text.splitlines():
+        sid = line.strip()
+        if not sid or sid in seen:
+            continue
+        seen.add(sid)
+        out.append(sid)
+    return out
+
+
+def _render_patient_picker(days_int: int) -> list[str]:
+    """Render the patient picker and return the deduped list of source_ids."""
+    options = _cached_patient_options(days_int)
+
+    pc1, pc2 = st.columns([0.6, 0.4])
+    with pc1:
+        selected_options = st.multiselect(
+            "Patients (recently touched)",
+            options=options,
+            format_func=_format_option,
+            key=f"{_KEY_PREFIX}_picker",
+            help=(
+                "Type a name or source_id to filter the list. "
+                f"Showing up to {_AUTOCOMPLETE_LIMIT} most-recently-touched "
+                "patients in the selected time range."
+            ),
+        )
+    with pc2:
+        paste = st.text_area(
+            "Or paste source IDs",
+            key=f"{_KEY_PREFIX}_paste",
+            help=_PASTE_HELP,
+            height=80,
+        )
+
+    picked: list[str] = []
+    seen: set[str] = set()
+    for opt in selected_options or []:
+        sid = opt.get("source_id") if isinstance(opt, dict) else None
+        if sid and sid not in seen:
+            seen.add(sid)
+            picked.append(sid)
+    for sid in _parse_paste(paste):
+        if sid not in seen:
+            seen.add(sid)
+            picked.append(sid)
+
+    if options:
+        st.caption(
+            f"Showing {len(options)} patient(s) from the last {days_int} day(s). "
+            f"For older patients, paste their source_id."
+        )
+    return picked
+
+
+def _render_by_patient_tab(days_int: int) -> None:
+    st.caption(_TAB_HELP)
+
+    try:
+        logging_mode = st.secrets.get("agent_logging", {}).get("mode", "full")
+    except Exception:
+        logging_mode = "full"
+    selection_enabled = logging_mode != "disabled"
+
+    source_ids = _render_patient_picker(days_int)
+    if not source_ids:
+        st.info("Pick one or more patients above to see every query that touched them across the agentic pipeline.")
+        return
+
+    # Mode toggle (Grouped first because the admin usually wants the
+    # question-level context when investigating a patient).
+    mc1, _spacer = st.columns([1, 7])
+    with mc1:
+        mode = st.radio(
+            "View",
+            options=["Grouped", "Flat"],
+            index=0,
+            horizontal=True,
+            key=f"{_KEY_PREFIX}_view_mode",
+        )
+
+    # Restrict to agentic rows — legacy rows can't match a structured
+    # patient touch anyway (the data layer already excludes them when
+    # source_ids is set), but pinning the pipeline filter here makes the
+    # filter signature stable across page-loads.
+    filters = {
+        "usernames": [],
+        "orgs": [],
+        "days": int(days_int),
+        "search": None,
+        "scopes": None,
+        "pipelines": ["agentic"],
+        "source_ids": source_ids,
+    }
+
+    _q._reset_pagination_on_filter_change(filters, days_int, mode, key_prefix=_KEY_PREFIX)
+    page_size, page = _q._render_pagination_top(key_prefix=_KEY_PREFIX)
+
+    try:
+        result = _q.get_per_query_audit_page(filters, page=page, page_size=int(page_size))
+    except Exception as e:
+        st.error(f"Failed to load patient queries: {e}")
+        logger.warning("get_per_query_audit_page failed in by-patient view: %s", e)
+        return
+
+    items = result.get("items", [])
+    total = int(result.get("total", 0))
+    total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
+
+    if mode == "Flat":
+        _q._render_flat_mode(items, selection_enabled=selection_enabled, key_prefix=_KEY_PREFIX)
+    else:
+        _q._render_grouped_mode(items, key_prefix=_KEY_PREFIX)
+
+    _q._render_pagination_bottom(page, total_pages, total, key_prefix=_KEY_PREFIX)
+
+    if mode == "Flat":
+        _q._render_csv_export(filters, key_prefix=_KEY_PREFIX)
+
+
+def render(days_int: int) -> None:
+    _render_by_patient_tab(days_int)

--- a/views/admin_audit_queries.py
+++ b/views/admin_audit_queries.py
@@ -1,0 +1,756 @@
+"""Admin → Audit → Queries sub-tab (Epic #190, Phase 2).
+
+The existing Questions tab (``views/admin_analytics._render_audit_trail_tab``)
+shows one row per user question — fine for the legacy Vanna pipeline but
+hides the multi-tool, multi-SQL reality of the agentic flow. This tab
+renders one row per *query unit* sourced from
+``orm.logging_functions.get_per_query_audit_page`` (Phase 1):
+
+  * Legacy question → 1 row (the assistant SQL Message).
+  * Agentic question → 1 row per ``ToolCall`` for the run, with the
+    decoded ``sql_executed_json`` list rendered inside the row.
+
+Two view modes back the same per-query row component:
+
+  * **Flat** — single ``st.data_editor``; row-tick opens a per-query
+    detail dialog; CSV export available.
+  * **Grouped** — collapses rows by question into ``st.expander`` blocks,
+    each showing a header (user, scope, total elapsed, query count) and
+    a read-only table of the question's query units.
+
+The Questions tab is left untouched here; Epic #190 Phase 4 retires (or
+aliases) it.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from typing import Any
+
+import pandas as pd
+import streamlit as st
+
+from orm.logging_functions import (
+    ALL_PIPELINES,
+    ALL_SCOPES,
+    SCOPE_LEGACY,
+    get_per_query_audit_export,
+    get_per_query_audit_page,
+)
+from utils.quick_logger import get_logger
+from views.admin_analytics import (
+    _AUDIT_STATUS_EMOJI,
+    _VIEW_COLUMN_HELP,
+    _VIEW_COLUMN_LABEL,
+    _cached_audit_filter_options,
+)
+
+logger = get_logger(__name__)
+
+# Cap each SQL preview to ~80 chars so the table column stays readable.
+_SQL_PREVIEW_CHARS = 80
+
+# Sentinels surfaced to the SQL column in the Flat-mode table. ``_DISABLED``
+# matches the value the data layer already emits for ``logging_mode == 'disabled'``
+# rows; we leave that alone. The scrubbed prefix is decorated here at render
+# time — the data layer passes hashed content through verbatim.
+_DISABLED_SQL_SENTINEL = "(logging disabled)"
+_SCRUBBED_SQL_PREFIX = "(scrubbed) "
+_NO_SQL_TOOL_RESULT = "(no SQL — tool result)"
+_LEGACY_TOOL_LABEL = "(legacy SQL)"
+
+_SCRUBBED_BANNER = (
+    "Scrubbed mode — literals hashed. Verify against a full-fidelity environment before drawing conclusions."
+)
+_DISABLED_BANNER = "Logging disabled for this run — payload columns are not available."
+
+
+# ---------------------------------------------------------------------------
+# Row component (shared by Flat + Grouped + CSV export)
+# ---------------------------------------------------------------------------
+
+
+def _format_sql_preview(item: dict) -> str:
+    """Return the SQL-column display string for a per-query item.
+
+    Rules:
+      * disabled mode → ``"(logging disabled)"``
+      * agentic non-SQL tool call → ``"(no SQL — tool result)"``
+      * scrubbed mode SQL → ``"(scrubbed) {first ~80 chars}"``
+      * agentic SQL with multiple statements → ``"{n} statements: {first ~80}"``
+      * legacy or single agentic SQL → first ~80 chars of the SQL text
+      * no SQL at all → ``""``
+    """
+    mode = item.get("logging_mode")
+    sql_statements = item.get("sql_statements") or []
+    non_sql_summary = item.get("non_sql_summary")
+
+    if mode == "disabled":
+        # The data layer already sets non_sql_summary to the disabled sentinel.
+        return _DISABLED_SQL_SENTINEL
+    if item.get("pipeline") == "agentic" and not sql_statements:
+        # Non-SQL tool call. The data layer routes the tool's result_summary
+        # into ``non_sql_summary`` (e.g. KB hit metadata). Surface a stable
+        # sentinel here regardless of the summary's shape so admins can spot
+        # them at a glance.
+        return _NO_SQL_TOOL_RESULT if non_sql_summary is not None else ""
+    if not sql_statements:
+        return ""
+    first = (sql_statements[0] or "").strip().replace("\n", " ")
+    truncated = first[:_SQL_PREVIEW_CHARS]
+    if len(first) > _SQL_PREVIEW_CHARS:
+        truncated += "…"
+    if mode == "scrubbed":
+        return f"{_SCRUBBED_SQL_PREFIX}{truncated}"
+    if len(sql_statements) > 1:
+        return f"{len(sql_statements)} statements: {truncated}"
+    return truncated
+
+
+def _format_patients_touched(item: dict) -> str:
+    """Comma-separated list of ``source_id`` from ``patients_touched``."""
+    touched = item.get("patients_touched") or []
+    if not touched:
+        return ""
+    return ", ".join(p.get("source_id", "") for p in touched if p.get("source_id"))
+
+
+def _derive_status(item: dict) -> str:
+    """Return one of ``_AUDIT_STATUS_EMOJI`` strings.
+
+    Rules mirror the Questions tab's status logic but adapted for per-query
+    rows:
+      * any ``error`` text → ❌ Error
+      * any SQL or non_sql_summary or success=True → ✅ Success
+      * otherwise → ⚪ Empty
+    """
+    if item.get("error"):
+        return _AUDIT_STATUS_EMOJI["Error"]
+    has_payload = bool(item.get("sql_statements")) or bool(item.get("non_sql_summary"))
+    if item.get("success") is True or has_payload:
+        return _AUDIT_STATUS_EMOJI["Success"]
+    return _AUDIT_STATUS_EMOJI["Empty"]
+
+
+def _per_query_row_to_table_dict(item: dict) -> dict[str, Any]:
+    """Convert a Phase 1 per-query row dict into the table-display dict.
+
+    Used by **both** Flat and Grouped modes so the column shape stays in
+    lockstep. Flat mode keeps the ``View`` checkbox column; Grouped mode
+    strips it before rendering.
+    """
+    return {
+        _VIEW_COLUMN_LABEL: False,
+        "Asked At": item["asked_at"],
+        "User": item["username"],
+        "Organization": item.get("organization") or "(no org)",
+        "Pipeline": item.get("pipeline") or "",
+        "Scope": item.get("scope") or SCOPE_LEGACY,
+        "Tool": item.get("tool_name") or _LEGACY_TOOL_LABEL,
+        "SQL": _format_sql_preview(item),
+        "Patient(s)": _format_patients_touched(item),
+        "Status": _derive_status(item),
+        "Elapsed (ms)": int(item.get("elapsed_ms") or 0),
+    }
+
+
+def _group_items_by_question(items: list[dict]) -> list[tuple[dict, list[dict]]]:
+    """Group per-query items by ``user_message_id`` preserving order.
+
+    Returns a list of ``(group_header, units)`` tuples where ``group_header``
+    summarises the question and ``units`` is the ordered list of per-query
+    items belonging to it.
+    """
+    groups: list[tuple[dict, list[dict]]] = []
+    by_msg: dict[int, int] = {}
+    for it in items:
+        mid = it.get("user_message_id")
+        idx = by_msg.get(mid)
+        if idx is None:
+            header = {
+                "user_message_id": mid,
+                "asked_at": it.get("asked_at"),
+                "username": it.get("username"),
+                "organization": it.get("organization") or "(no org)",
+                "question": it.get("question") or "",
+                "scope": it.get("scope") or SCOPE_LEGACY,
+                "total_elapsed_ms": int(it.get("elapsed_ms") or 0),
+                "query_count": 1,
+                "logging_mode": it.get("logging_mode"),
+            }
+            by_msg[mid] = len(groups)
+            groups.append((header, [it]))
+        else:
+            header, units = groups[idx]
+            header["total_elapsed_ms"] = int(header["total_elapsed_ms"]) + int(it.get("elapsed_ms") or 0)
+            header["query_count"] = int(header["query_count"]) + 1
+            # If any unit has a non-default logging mode, the group inherits
+            # the most "alarming" one (disabled > scrubbed > full).
+            modes_priority = {"disabled": 2, "scrubbed": 1, "full": 0, None: 0}
+            cur_pri = modes_priority.get(header.get("logging_mode"), 0)
+            new_pri = modes_priority.get(it.get("logging_mode"), 0)
+            if new_pri > cur_pri:
+                header["logging_mode"] = it.get("logging_mode")
+            units.append(it)
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Detail dialog bodies (separated for testability)
+# ---------------------------------------------------------------------------
+
+
+def _render_mode_banners(item: dict) -> None:
+    """Render the scrubbed/disabled-mode warning banners for an item."""
+    mode = item.get("logging_mode")
+    if mode == "scrubbed":
+        st.warning(_SCRUBBED_BANNER)
+    elif mode == "disabled":
+        st.warning(_DISABLED_BANNER)
+
+
+def _render_sql_block(item: dict, *, can_see_query_details: bool) -> None:
+    """Render the SQL statements section of the per-query dialog body."""
+    sql_statements = item.get("sql_statements") or []
+    non_sql_summary = item.get("non_sql_summary")
+    mode = item.get("logging_mode")
+
+    if not can_see_query_details:
+        st.markdown("**SQL**")
+        st.write("_(restricted — your role cannot see query details)_")
+        return
+
+    if mode == "disabled":
+        st.markdown("**SQL**")
+        st.write(f"_{_DISABLED_SQL_SENTINEL}_")
+        return
+
+    if sql_statements:
+        if len(sql_statements) == 1:
+            st.markdown("**SQL**")
+            st.code(sql_statements[0], language="sql")
+        else:
+            for i, sql in enumerate(sql_statements, start=1):
+                st.markdown(f"**SQL {i} of {len(sql_statements)}**")
+                st.code(sql, language="sql")
+        return
+
+    if item.get("pipeline") == "agentic":
+        st.markdown("**Tool result**")
+        if non_sql_summary:
+            st.code(non_sql_summary, language="json")
+        else:
+            st.write("_(no result captured)_")
+        return
+
+    # Legacy with no SQL → nothing to show.
+    st.markdown("**SQL**")
+    st.write("_(no SQL captured)_")
+
+
+def _render_patients_block(item: dict) -> None:
+    """Render the patients-touched chips."""
+    touched = item.get("patients_touched") or []
+    if not touched:
+        return
+    st.markdown("**Patient(s) touched**")
+    cols = st.columns(min(4, len(touched)))
+    for i, p in enumerate(touched):
+        label = p.get("display_name") or p.get("source_id") or "(unknown)"
+        sid = p.get("source_id") or ""
+        with cols[i % len(cols)]:
+            st.markdown(f"`{sid}` &nbsp; {label}")
+
+
+def _render_query_detail_dialog_body(item: dict) -> None:
+    """Body of the per-query detail dialog (Flat-mode click target)."""
+    from agent.observability_gate import role_can_see_query_details
+
+    current_role = st.session_state.get("user_role")
+    can_see_query_details = role_can_see_query_details(current_role)
+
+    # Header line
+    org = item.get("organization") or "(no org)"
+    st.markdown(f"**{item['asked_at']}** · {item['username']} · {org}")
+
+    # Pipeline + Scope chips
+    pipeline = item.get("pipeline") or "?"
+    scope = item.get("scope") or SCOPE_LEGACY
+    chips = [f"Pipeline: **{pipeline}**", f"Scope: **{scope}**"]
+    if item.get("tool_name"):
+        chips.append(f"Tool: **{item['tool_name']}**")
+        if item.get("call_index") is not None:
+            chips[-1] += f" (call #{item['call_index']})"
+    st.markdown(" · ".join(chips))
+
+    _render_mode_banners(item)
+
+    st.markdown("**Question**")
+    st.write(item.get("question") or "_(empty)_")
+
+    _render_sql_block(item, can_see_query_details=can_see_query_details)
+
+    _render_patients_block(item)
+
+    err = item.get("error")
+    if err:
+        st.markdown("**Error**")
+        st.code(err, language="text")
+
+    # Metadata caption
+    parts = []
+    if item.get("run_id"):
+        parts.append(f"run_id {item['run_id']}")
+    if item.get("tool_call_id") is not None:
+        parts.append(f"tool_call_id {item['tool_call_id']}")
+    parts.append(f"message_id {item.get('user_message_id')}")
+    parts.append(f"elapsed {int(item.get('elapsed_ms') or 0)}ms")
+    st.caption(" · ".join(parts))
+
+    # Outbound deep-link to Manage Users. Same contract as the retired
+    # Questions tab's dialog (formerly in views/admin_analytics.py:482-507):
+    # set ``manage_users_pref_user_id`` and switch_page so admin.py's
+    # Manage Users surface pre-selects the row. JS shim clicks the outer
+    # "Users" tab after the rerun lands. Key is per-(message, tool_call)
+    # composite so two dialogs in the same rerun (shouldn't happen — cross
+    # tab guard prevents it — but belt and braces) don't collide.
+    st.divider()
+    goto_users_key = f"queries_dialog_goto_users_{item.get('user_message_id')}_{item.get('tool_call_id')}"
+    if st.button(
+        "View user in Manage Users →",
+        key=goto_users_key,
+        type="primary",
+    ):
+        st.session_state["manage_users_pref_user_id"] = item["user_id"]
+        st.components.v1.html(
+            """
+            <script>
+              (function(){
+                try {
+                  var tabs = window.parent.document.querySelectorAll('button[role=tab]');
+                  for (var i = 0; i < tabs.length; i++) {
+                    if (tabs[i].textContent.trim() === 'Users') { tabs[i].click(); break; }
+                  }
+                } catch (e) { console.error('users-tab nav failed', e); }
+              })();
+            </script>
+            """,
+            height=0,
+        )
+        st.switch_page("views/admin.py")
+
+
+@st.dialog("Query Detail")
+def _render_query_detail_dialog(item: dict) -> None:
+    _render_query_detail_dialog_body(item)
+
+
+def _render_question_detail_dialog_body(group_header: dict, units: list[dict]) -> None:
+    """Body of the per-question detail dialog (Grouped-mode click target)."""
+    st.markdown(
+        f"**{group_header.get('asked_at')}** · {group_header.get('username')} · "
+        f"{group_header.get('organization') or '(no org)'}"
+    )
+    st.markdown(
+        f"Scope: **{group_header.get('scope')}** · "
+        f"Query count: **{group_header.get('query_count')}** · "
+        f"Total elapsed: **{int(group_header.get('total_elapsed_ms') or 0)}ms**"
+    )
+    if group_header.get("logging_mode") in {"scrubbed", "disabled"}:
+        _render_mode_banners({"logging_mode": group_header["logging_mode"]})
+
+    st.markdown("**Question**")
+    st.write(group_header.get("question") or "_(empty)_")
+    st.divider()
+
+    for i, unit in enumerate(units):
+        st.markdown(f"### Query {i + 1} of {len(units)}")
+        _render_query_detail_dialog_body(unit)
+        if i + 1 < len(units):
+            st.divider()
+
+
+@st.dialog("Question Detail")
+def _render_question_detail_dialog(group_header: dict, units: list[dict]) -> None:
+    _render_question_detail_dialog_body(group_header, units)
+
+
+# ---------------------------------------------------------------------------
+# Tab body
+# ---------------------------------------------------------------------------
+
+
+def _render_filters_row(days_int: int, options: dict) -> dict:
+    """Render the filter row and return the assembled ``filters`` dict."""
+    f1, f2, f3, f4, f5 = st.columns([0.2, 0.2, 0.2, 0.15, 0.25])
+    with f1:
+        usernames_sel = st.multiselect(
+            "User",
+            options=options["usernames"],
+            key="queries_user_filter",
+        )
+    with f2:
+        orgs_sel = st.multiselect(
+            "Organization",
+            options=options["orgs"],
+            key="queries_org_filter",
+        )
+    with f3:
+        scopes_sel = st.multiselect(
+            "Scope",
+            options=list(ALL_SCOPES),
+            key="queries_scope_filter",
+            help=(
+                "Patient = single-patient questions (PHI access). "
+                "Pop Health = cohort searches. Other = codes / KB / pure SQL. "
+                "Legacy/Unknown = pre-agentic-replatform rows."
+            ),
+        )
+    with f4:
+        pipelines_sel = st.multiselect(
+            "Pipeline",
+            options=list(ALL_PIPELINES),
+            key="queries_pipeline_filter",
+            help="Filter by legacy Vanna pipeline rows vs new agentic pipeline rows.",
+        )
+    with f5:
+        search = st.text_input(
+            "Search question or SQL",
+            placeholder="Substring match (case-insensitive)",
+            key="queries_search",
+        )
+
+    return {
+        "usernames": usernames_sel,
+        "orgs": orgs_sel,
+        "days": int(days_int),
+        "search": search.strip() if search else None,
+        "scopes": sorted(scopes_sel) if scopes_sel else None,
+        "pipelines": sorted(pipelines_sel) if pipelines_sel else None,
+    }
+
+
+def _reset_pagination_on_filter_change(filters: dict, days_int: int, mode: str, key_prefix: str = "queries") -> None:
+    sig_key = f"{key_prefix}_filter_signature"
+    page_key = f"{key_prefix}_page_num"
+    editor_key = f"{key_prefix}_dataframe"
+    dialog_key = f"{key_prefix}_dialog_open_id"
+    sig = json.dumps({**filters, "_days": days_int, "_mode": mode}, sort_keys=True, default=str)
+    if st.session_state.get(sig_key) != sig:
+        st.session_state[sig_key] = sig
+        st.session_state[page_key] = 1
+        # Clear stale editor state so an old tick can't fire the dialog
+        # against a now-different item.
+        editor_state = st.session_state.get(editor_key)
+        if isinstance(editor_state, dict):
+            editor_state["edited_rows"] = {}
+        st.session_state.pop(dialog_key, None)
+
+
+def _render_pagination_top(key_prefix: str = "queries") -> tuple[int, int]:
+    bump_key = f"{key_prefix}_page_bump"
+    page_key = f"{key_prefix}_page_num"
+    size_key = f"{key_prefix}_page_size"
+    if bump_key in st.session_state:
+        st.session_state[page_key] = max(
+            1,
+            int(st.session_state.get(page_key, 1)) + int(st.session_state[bump_key]),
+        )
+        del st.session_state[bump_key]
+    if page_key not in st.session_state:
+        st.session_state[page_key] = 1
+
+    pc1, pc2, _spacer = st.columns([1, 1, 6])
+    with pc1:
+        page_size = st.selectbox(
+            "Page size",
+            options=[25, 50, 100, 200],
+            index=1,
+            key=size_key,
+        )
+    with pc2:
+        st.number_input("Page", min_value=1, step=1, key=page_key)
+    return int(page_size), int(st.session_state[page_key])
+
+
+def _render_pagination_bottom(page: int, total_pages: int, total: int, key_prefix: str = "queries") -> None:
+    prev_key = f"{key_prefix}_prev_btn"
+    next_key = f"{key_prefix}_next_btn"
+    bump_key = f"{key_prefix}_page_bump"
+    cprev, cinfo, cnext = st.columns([1, 3, 1])
+    with cprev:
+        st.button(
+            "Prev",
+            disabled=int(page) <= 1,
+            key=prev_key,
+            on_click=lambda: st.session_state.update({bump_key: -1}),
+        )
+    with cinfo:
+        st.caption(f"Page {int(page)} of {total_pages} • {total} total")
+    with cnext:
+        st.button(
+            "Next",
+            disabled=int(page) >= total_pages,
+            key=next_key,
+            on_click=lambda: st.session_state.update({bump_key: 1}),
+        )
+
+
+def _render_flat_mode(items: list[dict], *, selection_enabled: bool, key_prefix: str = "queries") -> None:
+    """Render Flat mode: single data_editor with row-tick → detail dialog."""
+    if not items:
+        st.info("No queries match the current filters.")
+        return
+
+    table_rows = [_per_query_row_to_table_dict(it) for it in items]
+
+    editor_key = f"{key_prefix}_dataframe"
+    prev_checks_key = f"{key_prefix}_prev_view_checks"
+    dialog_key = f"{key_prefix}_dialog_open_id"
+
+    if not selection_enabled:
+        # agent_logging.mode = "disabled" → still surface rows (the data
+        # layer sentinels payloads) but with no click affordance.
+        readonly_rows = [{k: v for k, v in row.items() if k != _VIEW_COLUMN_LABEL} for row in table_rows]
+        st.dataframe(
+            pd.DataFrame(readonly_rows),
+            width="stretch",
+            hide_index=True,
+            key=editor_key,
+        )
+        return
+
+    edited_df = st.data_editor(
+        pd.DataFrame(table_rows),
+        width="stretch",
+        hide_index=True,
+        num_rows="fixed",
+        key=editor_key,
+        column_config={
+            _VIEW_COLUMN_LABEL: st.column_config.CheckboxColumn(
+                _VIEW_COLUMN_LABEL,
+                help=_VIEW_COLUMN_HELP,
+                default=False,
+                width="small",
+            ),
+            # ``DatetimeColumn`` so the timestamp renders as a localised
+            # "YYYY-MM-DD HH:MM:SS" instead of the raw int-ms-since-epoch
+            # that ``TextColumn`` falls back to when given a datetime.
+            "Asked At": st.column_config.DatetimeColumn("Asked At", format="YYYY-MM-DD HH:mm:ss", disabled=True),
+            "User": st.column_config.TextColumn("User", disabled=True),
+            "Organization": st.column_config.TextColumn("Organization", disabled=True),
+            "Pipeline": st.column_config.TextColumn("Pipeline", disabled=True),
+            "Scope": st.column_config.TextColumn("Scope", disabled=True),
+            "Tool": st.column_config.TextColumn("Tool", disabled=True),
+            "SQL": st.column_config.TextColumn("SQL", disabled=True),
+            "Patient(s)": st.column_config.TextColumn("Patient(s)", disabled=True),
+            "Status": st.column_config.TextColumn("Status", disabled=True),
+            "Elapsed (ms)": st.column_config.NumberColumn("Elapsed (ms)", disabled=True),
+        },
+    )
+
+    try:
+        current_checked = [int(i) for i in edited_df.index[edited_df[_VIEW_COLUMN_LABEL]].tolist()]
+    except Exception:
+        current_checked = []
+
+    # Single-select enforcement (mirrors the Questions tab's pattern,
+    # views/admin_analytics.py:684-702).
+    prev_checked = list(st.session_state.get(prev_checks_key, []))
+    if len(current_checked) > 1:
+        newly_checked = [i for i in current_checked if i not in prev_checked]
+        keep_idx = newly_checked[0] if newly_checked else current_checked[0]
+        editor_state = st.session_state.get(editor_key)
+        if isinstance(editor_state, dict):
+            edited_rows = editor_state.setdefault("edited_rows", {})
+            for idx in current_checked:
+                if idx == keep_idx:
+                    continue
+                row_edits = edited_rows.get(idx)
+                if isinstance(row_edits, dict) and _VIEW_COLUMN_LABEL in row_edits:
+                    del row_edits[_VIEW_COLUMN_LABEL]
+                    if not row_edits:
+                        del edited_rows[idx]
+        st.session_state[prev_checks_key] = [keep_idx]
+        st.rerun()
+    else:
+        st.session_state[prev_checks_key] = current_checked
+
+    checked_count = len(current_checked)
+    if checked_count == 1:
+        row_idx = current_checked[0]
+        if 0 <= row_idx < len(items):
+            selected_item = items[row_idx]
+            row_key = _flat_dialog_open_key(selected_item)
+            open_id = st.session_state.get(dialog_key)
+            if open_id != row_key:
+                if not st.session_state.get("_audit_dialog_claimed_this_rerun"):
+                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                    st.session_state[dialog_key] = row_key
+                    _render_query_detail_dialog(selected_item)
+    elif checked_count == 0:
+        st.session_state.pop(dialog_key, None)
+
+
+def _flat_dialog_open_key(item: dict) -> str:
+    """Composite key identifying which per-query row is currently open in the
+    Flat-mode detail dialog. Distinct per (message, tool_call) so two rows of
+    the same question can each open the dialog independently."""
+    return f"{item.get('user_message_id')}:{item.get('tool_call_id')}"
+
+
+def _render_grouped_mode(items: list[dict], key_prefix: str = "queries") -> None:
+    """Render Grouped mode: one ``st.expander`` per question."""
+    if not items:
+        st.info("No queries match the current filters.")
+        return
+
+    dialog_key = f"{key_prefix}_dialog_open_id"
+    groups = _group_items_by_question(items)
+    for header, units in groups:
+        title = (
+            f"{header['asked_at']} · {header['username']} · "
+            f"{header['scope']} · {header['query_count']} querie(s) · "
+            f"{int(header['total_elapsed_ms'])}ms"
+        )
+        with st.expander(title, expanded=False):
+            if header.get("logging_mode") in {"scrubbed", "disabled"}:
+                _render_mode_banners({"logging_mode": header["logging_mode"]})
+            st.markdown(f"**Question:** {header.get('question') or '_(empty)_'}")
+
+            unit_rows = [
+                {k: v for k, v in _per_query_row_to_table_dict(u).items() if k != _VIEW_COLUMN_LABEL} for u in units
+            ]
+            st.dataframe(pd.DataFrame(unit_rows), width="stretch", hide_index=True)
+
+            btn_key = f"{key_prefix}_group_detail_btn_{header['user_message_id']}"
+            if st.button("View question detail →", key=btn_key):
+                detail_key = f"q:{header['user_message_id']}"
+                if (
+                    not st.session_state.get("_audit_dialog_claimed_this_rerun")
+                    and st.session_state.get(dialog_key) != detail_key
+                ):
+                    st.session_state["_audit_dialog_claimed_this_rerun"] = True
+                    st.session_state[dialog_key] = detail_key
+                    _render_question_detail_dialog(header, units)
+
+
+def _render_csv_export(filters: dict, key_prefix: str = "queries") -> None:
+    """Render the Flat-mode CSV export affordance."""
+    btn_key = f"{key_prefix}_export_btn"
+    download_key = f"{key_prefix}_export_download"
+    if not st.button("📥 Export filtered queries to CSV", key=btn_key):
+        return
+    try:
+        export_rows = get_per_query_audit_export(filters)
+    except Exception as e:
+        st.error(f"Export failed: {e}")
+        logger.error("Per-query audit export failed: %s", e)
+        return
+
+    if not export_rows:
+        st.warning("No queries to export with current filters.")
+        return
+
+    export_df = pd.DataFrame(
+        [
+            {
+                "Asked At": r["asked_at"],
+                "User": r["username"],
+                "Organization": r.get("organization") or "(no org)",
+                "Question": r["question"],
+                "Pipeline": r.get("pipeline") or "",
+                "Scope": r.get("scope") or SCOPE_LEGACY,
+                "Tool": r.get("tool_name") or _LEGACY_TOOL_LABEL,
+                # Full SQL list joined with a separator so the CSV is a single
+                # cell per query unit. Admins who want a per-statement view can
+                # open the Flat-mode dialog.
+                "SQL": " ;; ".join(r.get("sql_statements") or []),
+                "Non-SQL summary": r.get("non_sql_summary") or "",
+                "Patient(s)": _format_patients_touched(r),
+                "Logging mode": r.get("logging_mode") or "",
+                "Status": _derive_status(r),
+                "Elapsed (ms)": int(r.get("elapsed_ms") or 0),
+            }
+            for r in export_rows
+        ]
+    )
+    ts = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    st.download_button(
+        "Download per_query_audit_*.csv",
+        data=export_df.to_csv(index=False).encode("utf-8"),
+        file_name=f"per_query_audit_{ts}.csv",
+        mime="text/csv",
+        key=download_key,
+    )
+
+
+def _render_queries_tab(days_int: int) -> None:
+    try:
+        logging_mode = st.secrets.get("agent_logging", {}).get("mode", "full")
+    except Exception:
+        logging_mode = "full"
+    selection_enabled = logging_mode != "disabled"
+
+    options = _cached_audit_filter_options(days_int)
+
+    # Cross-Epic deep-link prefill (inherited from the retired Questions
+    # tab — see views/admin_analytics.py:545-553 for the original). Honour
+    # both the legacy ``audit_trail_pref_user_id`` key (chat_bot.py,
+    # admin_users.py set this) and the forward-compat
+    # ``audit_queries_pref_user_id`` for surfaces that adopt the new name.
+    pref_user_id = st.session_state.pop("audit_trail_pref_user_id", None)
+    if pref_user_id is None:
+        pref_user_id = st.session_state.pop("audit_queries_pref_user_id", None)
+    if pref_user_id is not None and "queries_user_filter" not in st.session_state:
+        try:
+            from orm.functions import get_all_users
+
+            all_users = get_all_users()
+            match = next((u for u in all_users if u["id"] == int(pref_user_id)), None)
+            if match and match["username"] in options["usernames"]:
+                st.session_state["queries_user_filter"] = [match["username"]]
+        except Exception as e:
+            logger.warning("Queries tab deep-link prefill failed: %s", e)
+
+    filters = _render_filters_row(days_int, options)
+
+    mc1, _spacer = st.columns([1, 7])
+    with mc1:
+        mode = st.radio(
+            "View",
+            options=["Grouped", "Flat"],
+            index=0,
+            horizontal=True,
+            key="queries_view_mode",
+        )
+
+    _reset_pagination_on_filter_change(filters, days_int, mode)
+
+    page_size, page = _render_pagination_top()
+
+    try:
+        result = get_per_query_audit_page(filters, page=page, page_size=int(page_size))
+    except Exception as e:
+        st.error(f"Failed to load queries: {e}")
+        logger.warning("get_per_query_audit_page failed in view: %s", e)
+        return
+
+    items = result.get("items", [])
+    total = int(result.get("total", 0))
+    total_pages = max(1, (total + int(page_size) - 1) // int(page_size))
+
+    if mode == "Flat":
+        _render_flat_mode(items, selection_enabled=selection_enabled)
+    else:
+        _render_grouped_mode(items)
+
+    _render_pagination_bottom(page, total_pages, total)
+
+    if mode == "Flat":
+        _render_csv_export(filters)
+
+
+def render(days_int: int) -> None:
+    _render_queries_tab(days_int)


### PR DESCRIPTION
Closes #190 · Implements #191, #192, #193, #194

## Summary

- **Phase 1 (data)**: New `get_per_query_audit_page` / `get_per_query_audit_export` in `orm/logging_functions.py` — UNION-ALL unfolds each user question into one row per query unit (legacy → 1, agentic → N per ToolCall). New filters: `pipelines`, `source_ids`, `tool_names`. Alembic migration adds a composite index on `thrive_agent_patient_access(source_id, run_id)`.
- **Phase 2 (view)**: New `views/admin_audit_queries.py` — Grouped/Flat toggle, shared row component (`_per_query_row_to_table_dict`), per-row scrubbed/disabled banners, role-gated SQL, per-query + per-question detail dialogs, CSV export (Flat-only). Wired into the Audit umbrella.
- **Phase 3 (pivot)**: New `views/admin_audit_by_patient.py` — patient autocomplete from a new `get_patient_audit_autocomplete` helper + paste-textarea for older patients. Reuses Phase 2 helpers via a `key_prefix` parameter (default `"queries"`) so widget keys don't collide.
- **Phase 4 (retirement)**: Audit umbrella drops the legacy "Questions" tab. Order is now `[Queries, By Patient, Admin Actions, User Activity]`. The `audit_trail_pref_user_id` deep-link contract (chat_bot / admin_users) is migrated to the Queries tab; a new `"View user in Manage Users →"` button in the per-query dialog matches the retired Questions dialog's UX. `_render_audit_trail_tab` stays in `views/admin_analytics.py` for the Analytics → Audit Trail surface (out of epic scope).

## Tests

63 new/updated tests (`pytest tests/views/test_admin_audit_*.py tests/orm/test_per_query_audit.py tests/orm/test_patient_audit_autocomplete.py` → all green). Cross-tab dialog collision tests were retargeted to use Admin Actions as the first dialog source since Questions is gone from the umbrella.

## Manual verification

Verified end-to-end via Chrome DevTools against a local Streamlit instance with prior agentic-run data:

- Umbrella renders the four new tabs (no "Questions").
- Queries tab — filter row (User / Org / Scope / **Pipeline** / Search), Grouped/Flat toggle, pagination, CSV export, dialog auto-open on tick.
- Per-question detail dialog renders with the "View user in Manage Users →" button.
- Flat-mode `Asked At` column was initially showing raw ms-since-epoch; fixed by swapping `TextColumn` → `DatetimeColumn` and re-verified.
- By Patient tab — autocomplete renders `"display_name (source_id)"` via the format_func; paste-textarea is present; empty-state info card shows when no patient is selected.

## ⚠️ Pre-existing upstream bug surfaced by verification

During manual testing I discovered that **every existing `AgentRun` row has `user_message_id = NULL`** (because `agent/deps_builder.py:150` hard-codes it to `None`) and **every `AgentPatientAccess` row has `run_id = NULL`** (the chooser passes whatever's in `st.session_state["agent_current_run_id"]`, which is empty). These wiring gaps existed before this epic and silently prevent the per-row Scope classification from ever returning agentic rows in production — both the retired Questions tab and the new Queries tab show every question as `Legacy/Unknown`. The data-layer code in this PR is correct against the documented contract (and exercised by the new unit tests with proper seeds), but the on-prod outcome will look broken until the upstream wiring is fixed. **Filing as a follow-up issue.**

## Test plan

- [ ] `uv run pytest tests/views/test_admin_audit_queries.py tests/views/test_admin_audit_questions_retirement.py tests/views/test_admin_audit_by_patient.py tests/views/test_admin_audit_dialog_collision.py tests/orm/test_per_query_audit.py tests/orm/test_patient_audit_autocomplete.py` → 63 passed
- [ ] `uv run alembic upgrade head` succeeds on a fresh SQLite DB
- [ ] Visit Admin → Audit and confirm the four inner tabs render (Queries, By Patient, Admin Actions, User Activity)
- [ ] In Queries tab, expand a row in Grouped mode and click "View question detail →"; the dialog opens with a "View user in Manage Users →" button
- [ ] Switch to Flat mode and confirm the Asked At column renders as `YYYY-MM-DD HH:mm:ss` (not raw ms)
- [ ] In By Patient tab, the multiselect lists agentic-touched patients with `"display_name (source_id)"` labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)