### PR TITLE
feat(analytics): restore Top Users + add Top Organizations on Overview

### DIFF
--- a/tests/views/test_admin_overview_top_users_orgs.py
+++ b/tests/views/test_admin_overview_top_users_orgs.py
@@ -1,0 +1,203 @@
+"""Tests for the restored "Top Users by Questions" and new "Top Organizations
+by Questions" sections on Admin → Analytics → Overview.
+
+Both sections were cut by Epic #144 / #147 and the per-user one is being
+restored alongside a new per-org companion at Joe's request after the
+2026-06-15 demo. Each row pairs a horizontal bar chart with a stats grid.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from orm.models import Message, RoleTypeEnum, User, UserRole
+from utils.enums import MessageType, RoleType
+
+
+@pytest.fixture
+def patched_session(monkeypatch, in_memory_orm_session):
+    """Point ``views.admin_analytics.SessionLocal`` at the in-memory DB and
+    clear the ``_read_user_org_question_stats`` cache between tests."""
+    from views import admin_analytics
+
+    monkeypatch.setattr(admin_analytics, "SessionLocal", in_memory_orm_session)
+    admin_analytics._read_user_org_question_stats.clear()
+    yield in_memory_orm_session
+    admin_analytics._read_user_org_question_stats.clear()
+
+
+def _mk_user(username, organization, role_id):
+    return User(
+        username=username,
+        first_name=username.title(),
+        last_name="Tester",
+        password="x",
+        email=f"{username}@{organization.lower().replace(' ', '')}.example",
+        organization=organization,
+        user_role_id=role_id,
+    )
+
+
+def _seed_users(session_factory):
+    """Seed three users across two orgs and return their IDs by username."""
+    with session_factory() as session:
+        admin_role = session.query(UserRole).filter_by(role=RoleTypeEnum.ADMIN).one()
+        rob = _mk_user("rob", "ThriveAI", admin_role.id)
+        cassie = _mk_user("cassie", "ThriveAI", admin_role.id)
+        joe = _mk_user("joe", "Erie County Health", admin_role.id)
+        session.add_all([rob, cassie, joe])
+        session.commit()
+        return {"rob": rob.id, "cassie": cassie.id, "joe": joe.id}
+
+
+def _add_msg(session, user_id, *, role, msg_type, days_ago=0):
+    m = Message(
+        user_id=user_id,
+        role=role,
+        type=msg_type,
+        content="x",
+    )
+    session.add(m)
+    session.commit()
+    # `created_at` has server_default=NOW; backdate after insert for time-window tests.
+    last = session.query(Message).order_by(Message.id.desc()).first()
+    last.created_at = dt.datetime.now() - dt.timedelta(days=days_ago)
+    session.commit()
+
+
+class TestReadUserOrgQuestionStats:
+    """The cached aggregation helper that powers both Overview rows."""
+
+    def test_user_top_orders_by_questions_desc(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        ids = _seed_users(patched_session)
+        with patched_session() as session:
+            for _ in range(5):
+                _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL)
+            for _ in range(2):
+                _add_msg(session, ids["cassie"], role=RoleType.USER, msg_type=MessageType.SQL)
+            _add_msg(session, ids["joe"], role=RoleType.USER, msg_type=MessageType.SQL)
+            session.commit()
+
+        user_top, _, _, _ = _read_user_org_question_stats(30)
+
+        assert list(user_top["User"]) == ["rob", "cassie", "joe"]
+        assert list(user_top["Questions"]) == [5, 2, 1]
+
+    def test_user_top_excludes_zero_question_users(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        ids = _seed_users(patched_session)
+        with patched_session() as session:
+            _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL)
+            session.commit()
+
+        user_top, _, _, _ = _read_user_org_question_stats(30)
+
+        assert list(user_top["User"]) == ["rob"]
+        # cassie and joe asked nothing — they don't belong in the chart.
+        assert "cassie" not in list(user_top["User"])
+        assert "joe" not in list(user_top["User"])
+
+    def test_org_top_aggregates_users_under_same_organization(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        ids = _seed_users(patched_session)
+        with patched_session() as session:
+            # ThriveAI: rob 5, cassie 2 → 7
+            for _ in range(5):
+                _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL)
+            for _ in range(2):
+                _add_msg(session, ids["cassie"], role=RoleType.USER, msg_type=MessageType.SQL)
+            # Erie County Health: joe 4
+            for _ in range(4):
+                _add_msg(session, ids["joe"], role=RoleType.USER, msg_type=MessageType.SQL)
+            session.commit()
+
+        _, _, org_top, _ = _read_user_org_question_stats(30)
+
+        assert list(org_top["Organization"]) == ["ThriveAI", "Erie County Health"]
+        assert list(org_top["Questions"]) == [7, 4]
+
+    def test_time_filter_excludes_questions_older_than_window(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        ids = _seed_users(patched_session)
+        with patched_session() as session:
+            # In-window
+            _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL, days_ago=1)
+            _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL, days_ago=6)
+            # Out-of-window for a 7-day query (45 days ago)
+            _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL, days_ago=45)
+            session.commit()
+
+        user_top_7, _, _, _ = _read_user_org_question_stats(7)
+        user_top_90, _, _, _ = _read_user_org_question_stats(90)
+
+        assert int(user_top_7.loc[user_top_7["User"] == "rob", "Questions"].iloc[0]) == 2
+        assert int(user_top_90.loc[user_top_90["User"] == "rob", "Questions"].iloc[0]) == 3
+
+    def test_stats_grid_breaks_out_dataframes_summaries_charts_errors(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        ids = _seed_users(patched_session)
+        with patched_session() as session:
+            _add_msg(session, ids["rob"], role=RoleType.USER, msg_type=MessageType.SQL)
+            _add_msg(session, ids["rob"], role=RoleType.ASSISTANT, msg_type=MessageType.DATAFRAME)
+            _add_msg(session, ids["rob"], role=RoleType.ASSISTANT, msg_type=MessageType.SUMMARY)
+            _add_msg(session, ids["rob"], role=RoleType.ASSISTANT, msg_type=MessageType.PLOTLY_CHART)
+            _add_msg(session, ids["rob"], role=RoleType.ASSISTANT, msg_type=MessageType.ERROR)
+            session.commit()
+
+        _, user_stats, _, _ = _read_user_org_question_stats(30)
+        rob = user_stats[user_stats["User"] == "rob"].iloc[0]
+
+        assert rob["Questions"] == 1
+        assert rob["DataFrames"] == 1
+        assert rob["Summaries"] == 1
+        assert rob["Charts"] == 1
+        assert rob["Errors"] == 1
+
+    def test_user_stats_includes_users_with_no_activity(self, patched_session):
+        """The full-population grid keeps zero-activity users visible so admins
+        can see who has never asked anything — the chart caps to 10 actives,
+        but the grid is the complete roster.
+        """
+        from views.admin_analytics import _read_user_org_question_stats
+
+        _seed_users(patched_session)
+        _, user_stats, _, _ = _read_user_org_question_stats(30)
+
+        assert set(user_stats["User"]) == {"rob", "cassie", "joe"}
+        assert all(int(q) == 0 for q in user_stats["Questions"])
+
+    def test_org_stats_includes_orgs_with_no_activity(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        _seed_users(patched_session)
+        _, _, _, org_stats = _read_user_org_question_stats(30)
+
+        assert set(org_stats["Organization"]) == {"ThriveAI", "Erie County Health"}
+
+    def test_user_top_caps_at_ten_rows(self, patched_session):
+        from views.admin_analytics import _read_user_org_question_stats
+
+        with patched_session() as session:
+            admin_role = session.query(UserRole).filter_by(role=RoleTypeEnum.ADMIN).one()
+            for i in range(15):
+                u = _mk_user(f"u{i:02d}", "ThriveAI", admin_role.id)
+                session.add(u)
+                session.flush()
+                # Each user asks i+1 questions so order is u14, u13, ..., u00.
+                for _ in range(i + 1):
+                    _add_msg(session, u.id, role=RoleType.USER, msg_type=MessageType.SQL)
+            session.commit()
+
+        user_top, _, _, _ = _read_user_org_question_stats(30)
+
+        assert len(user_top) == 10
+        assert user_top["User"].iloc[0] == "u14"
+        assert user_top["Questions"].iloc[0] == 15

--- a/views/admin.py
+++ b/views/admin.py
@@ -40,9 +40,12 @@ with control_cols[0]:
     )
 with control_cols[1]:
     if st.button("Refresh Data", help="Clear cached data and reload metrics"):
-        from views.admin_analytics import _read_metrics
+        from views.admin_analytics import _read_metrics, _read_user_org_question_stats
+
         _read_metrics.clear()
+        _read_user_org_question_stats.clear()
         from views.errors import _load as _errors_load, _load_aggregates as _errors_load_aggregates
+
         _errors_load.clear()
         _errors_load_aggregates.clear()
         st.rerun()

--- a/views/admin_analytics.py
+++ b/views/admin_analytics.py
@@ -353,6 +353,45 @@ def _render_overview_tab(days_int: int):
 
     st.divider()
 
+    # Per-user and per-organization question totals (restored from pre-#147 Overview,
+    # plus a new Organization row). Chart on the left, grid on the right; both rows
+    # honor the page-level Time Range control.
+    user_top_df, user_stats_df, org_top_df, org_stats_df = _read_user_org_question_stats(days_int)
+
+    st.subheader("Top Users by Questions")
+    u_chart_col, u_grid_col = st.columns(2)
+    with u_chart_col:
+        if not user_top_df.empty:
+            u_bar = px.bar(user_top_df, x="Questions", y="User", orientation="h")
+            u_bar.update_layout(margin=dict(l=0, r=0, t=10, b=0), yaxis=dict(autorange="reversed"))
+            st.plotly_chart(u_bar, width="stretch")
+        else:
+            st.info("No user activity in the selected time range.")
+    with u_grid_col:
+        if not user_stats_df.empty:
+            st.dataframe(user_stats_df, width="stretch", hide_index=True)
+        else:
+            st.info("No users on file.")
+
+    st.divider()
+
+    st.subheader("Top Organizations by Questions")
+    o_chart_col, o_grid_col = st.columns(2)
+    with o_chart_col:
+        if not org_top_df.empty:
+            o_bar = px.bar(org_top_df, x="Questions", y="Organization", orientation="h")
+            o_bar.update_layout(margin=dict(l=0, r=0, t=10, b=0), yaxis=dict(autorange="reversed"))
+            st.plotly_chart(o_bar, width="stretch")
+        else:
+            st.info("No organization activity in the selected time range.")
+    with o_grid_col:
+        if not org_stats_df.empty:
+            st.dataframe(org_stats_df, width="stretch", hide_index=True)
+        else:
+            st.info("No organizations on file.")
+
+    st.divider()
+
     # Latest Questions — compact preview that links to the canonical Audit Trail tab (#136).
     st.subheader("Latest Questions")
     from orm.logging_functions import get_question_audit_page
@@ -401,6 +440,84 @@ def _render_overview_tab(days_int: int):
         """,
         height=60,
     )
+
+
+@st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)
+def _read_user_org_question_stats(days_int: int):
+    """Per-user and per-organization question/activity totals for the Overview tab.
+
+    Both groupings respect the page-level time range. Returns four DataFrames:
+    (user_top, user_stats, org_top, org_stats) — top tables are pre-sorted by
+    Questions desc and capped at 10 rows for the bar charts; stats tables hold
+    the full population with the same five activity counts as the legacy
+    "All Users Stats" / "All Orgs Stats" tables.
+    """
+    chart_types = [
+        MessageType.PLOTLY_CHART.value,
+        MessageType.ST_LINE_CHART.value,
+        MessageType.ST_BAR_CHART.value,
+        MessageType.ST_AREA_CHART.value,
+        MessageType.ST_SCATTER_CHART.value,
+    ]
+    since = dt.datetime.now() - dt.timedelta(days=days_int)
+
+    with SessionLocal() as session:
+        user_rows = (
+            session.query(
+                User.username.label("entity"),
+                func.sum(case((Message.role == RoleType.USER.value, 1), else_=0)).label("questions"),
+                func.sum(case((Message.type == MessageType.DATAFRAME.value, 1), else_=0)).label("dataframes"),
+                func.sum(case((Message.type == MessageType.SUMMARY.value, 1), else_=0)).label("summaries"),
+                func.sum(case((Message.type.in_(chart_types), 1), else_=0)).label("charts"),
+                func.sum(case((Message.type == MessageType.ERROR.value, 1), else_=0)).label("errors"),
+            )
+            .join(Message, Message.user_id == User.id, isouter=True)
+            .filter((Message.created_at >= since) | (Message.id.is_(None)))
+            .group_by(User.username)
+            .all()
+        )
+
+        org_rows = (
+            session.query(
+                User.organization.label("entity"),
+                func.sum(case((Message.role == RoleType.USER.value, 1), else_=0)).label("questions"),
+                func.sum(case((Message.type == MessageType.DATAFRAME.value, 1), else_=0)).label("dataframes"),
+                func.sum(case((Message.type == MessageType.SUMMARY.value, 1), else_=0)).label("summaries"),
+                func.sum(case((Message.type.in_(chart_types), 1), else_=0)).label("charts"),
+                func.sum(case((Message.type == MessageType.ERROR.value, 1), else_=0)).label("errors"),
+            )
+            .join(Message, Message.user_id == User.id, isouter=True)
+            .filter((Message.created_at >= since) | (Message.id.is_(None)))
+            .group_by(User.organization)
+            .all()
+        )
+
+    def _to_stats_df(rows, label):
+        return pd.DataFrame(
+            [
+                {
+                    label: r.entity,
+                    "Questions": int(r.questions or 0),
+                    "DataFrames": int(r.dataframes or 0),
+                    "Summaries": int(r.summaries or 0),
+                    "Charts": int(r.charts or 0),
+                    "Errors": int(r.errors or 0),
+                }
+                for r in rows
+            ]
+        )
+
+    user_stats = _to_stats_df(user_rows, "User").sort_values(
+        ["Questions", "Errors"], ascending=[False, True], ignore_index=True
+    )
+    org_stats = _to_stats_df(org_rows, "Organization").sort_values(
+        ["Questions", "Errors"], ascending=[False, True], ignore_index=True
+    )
+
+    user_top = user_stats[user_stats["Questions"] > 0][["User", "Questions"]].head(10).reset_index(drop=True)
+    org_top = org_stats[org_stats["Questions"] > 0][["Organization", "Questions"]].head(10).reset_index(drop=True)
+
+    return user_top, user_stats, org_top, org_stats
 
 
 @st.cache_data(ttl=ANALYTICS_CACHE_TTL_SECONDS, show_spinner=False)


### PR DESCRIPTION
## Summary
- Restore the "Top Users by Questions" horizontal bar chart cut by Epic #144 / #147, paired with the per-user activity stats grid (questions / dataframes / summaries / charts / errors)
- Add a new "Top Organizations by Questions" row below it, same shape but grouped by `User.organization` (the column added in Epic #179)
- Both rows honor the page-level Time Range control; the new query is cached with the same 5-min TTL as the rest of Overview and the Refresh Data button clears it

## Context
Joe asked for these back during the 2026-06-15 demo — the user-level chart was the "Rob was way out in the lead" view he'd shown customers as part of the audit-trail pitch, and the org-level chart lets him show volume per organization (ThriveAI / Erie County Health / Healthy Link, etc.) without drilling into individual users.

## Test plan
- [x] `uv run pytest tests/views/test_admin_overview_top_users_orgs.py -v` — 8 new tests pass (ordering, time-window filter, org aggregation, full stats breakout, zero-activity rows kept in the grid, 10-row chart cap)
- [x] `uv run pytest tests/views/test_admin_overview_error_kpis.py tests/views/test_admin_audit_questions_retirement.py` — adjacent Overview / audit-retirement tests still pass
- [x] `uv run ruff check views/admin_analytics.py views/admin.py tests/views/test_admin_overview_top_users_orgs.py` — clean
- [ ] Browser smoke: open Admin → Analytics → Overview at 7/30/90-day ranges, confirm both rows render with correct counts and that Refresh Data invalidates the cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)