### PR TITLE
feat(audit): add Question column to flat-mode Queries grid

### DIFF
--- a/tests/views/test_admin_audit_queries_final_answer.py
+++ b/tests/views/test_admin_audit_queries_final_answer.py
@@ -365,6 +365,24 @@ def test_row_dict_answer_column_empty_when_no_answer():
     assert row["Answer"] == ""
 
 
+def test_row_dict_includes_truncated_question_column():
+    from views.admin_audit_queries import _QUESTION_PREVIEW_CHARS, _per_query_row_to_table_dict
+
+    long_question = "q" * (_QUESTION_PREVIEW_CHARS + 50)
+    row = _per_query_row_to_table_dict(_make_item(question=long_question))
+    assert "Question" in row
+    question = row["Question"]
+    assert question.endswith("…")
+    assert len(question) <= _QUESTION_PREVIEW_CHARS
+
+
+def test_row_dict_question_column_empty_when_no_question():
+    from views.admin_audit_queries import _per_query_row_to_table_dict
+
+    row = _per_query_row_to_table_dict(_make_item(question=None))
+    assert row["Question"] == ""
+
+
 # ---------------------------------------------------------------------------
 # View layer: dialog bodies
 # ---------------------------------------------------------------------------

--- a/views/admin_audit_queries.py
+++ b/views/admin_audit_queries.py
@@ -64,6 +64,7 @@ _LEGACY_TOOL_LABEL = "(legacy SQL)"
 # Truncation length for the Flat-mode "Answer" column. The full text is in the
 # dialog and CSV export; the column is for scannability.
 _ANSWER_PREVIEW_CHARS = 120
+_QUESTION_PREVIEW_CHARS = 120
 
 _SCRUBBED_BANNER = (
     "Scrubbed mode — literals hashed. Verify against a full-fidelity environment before drawing conclusions."
@@ -150,6 +151,7 @@ def _per_query_row_to_table_dict(item: dict) -> dict[str, Any]:
         "Asked At": item["asked_at"],
         "User": item["username"],
         "Organization": item.get("organization") or "(no org)",
+        "Question": _truncate(item.get("question") or "", _QUESTION_PREVIEW_CHARS),
         "Pipeline": item.get("pipeline") or "",
         "Scope": item.get("scope") or SCOPE_LEGACY,
         "Tool": item.get("tool_name") or _LEGACY_TOOL_LABEL,
@@ -582,6 +584,11 @@ def _render_flat_mode(items: list[dict], *, selection_enabled: bool, key_prefix:
             "Asked At": st.column_config.DatetimeColumn("Asked At", format="YYYY-MM-DD HH:mm:ss", disabled=True),
             "User": st.column_config.TextColumn("User", disabled=True),
             "Organization": st.column_config.TextColumn("Organization", disabled=True),
+            "Question": st.column_config.TextColumn(
+                "Question",
+                disabled=True,
+                help="User's natural-language question (truncated). Full text in the dialog and CSV export.",
+            ),
             "Pipeline": st.column_config.TextColumn("Pipeline", disabled=True),
             "Scope": st.column_config.TextColumn("Scope", disabled=True),
             "Tool": st.column_config.TextColumn("Tool", disabled=True),


### PR DESCRIPTION
## Summary
- Adds a "Question" column to the per-query audit table's Flat mode so reviewers can see the question text inline without opening the row dialog or expanding Grouped view.
- Placed between Organization and Pipeline to match the CSV export's column order.
- Truncated to 120 chars (matches the existing Answer column treatment); full text remains in the row-tick dialog and the CSV export.

## Test plan
- [x] `uv run pytest tests/views/test_admin_audit_queries_final_answer.py` — 16 pass (2 new)
- [x] `uv run pytest tests/views/ -k audit` — 110 pass
- [ ] Smoke: Admin → Audit → Queries (Flat mode) — confirm new Question column appears between Organization and Pipeline, truncates long questions, full text visible in row-tick dialog and CSV export

🤖 Generated with [Claude Code](https://claude.com/claude-code)