### PR TITLE
feat(cd): auto-deploy dev to streamlitadmin-dev via self-hosted runner

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,7 +14,11 @@ jobs:
         run: |
           cd /home/streamlituser/thrive_ui
           git fetch origin dev
-          git checkout -B dev origin/dev
+          # -f: discard tracked drift (e.g. uv.lock rewritten by `uv sync`) so the
+          # deploy never depends on a clean tree. Untracked/gitignored files
+          # (secrets.toml, .venv, chromadb/, *.milvus.db) are NOT touched; `git clean`
+          # is never run.
+          git checkout -f -B dev origin/dev
           git reset --hard origin/dev
       - name: Deploy
         run: /home/streamlituser/thrive_ui/scripts/deploy/dev_deploy.sh

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,20 @@
+name: Deploy dev
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: [self-hosted, thrive-dev]
+    steps:
+      - name: Update deploy tree
+        run: |
+          cd /home/streamlituser/thrive_ui
+          git fetch origin dev
+          git checkout -B dev origin/dev
+          git reset --hard origin/dev
+      - name: Deploy
+        run: /home/streamlituser/thrive_ui/scripts/deploy/dev_deploy.sh

--- a/deploy/streamlit.service
+++ b/deploy/streamlit.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Thrive AI Streamlit (dev)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=streamlituser
+Group=streamlituser
+WorkingDirectory=/home/streamlituser/thrive_ui
+ExecStart=/home/streamlituser/.local/bin/uv run --no-sync streamlit run app.py --server.port 8501 --server.address 0.0.0.0 --server.headless true
+Restart=always
+RestartSec=5
+MemoryMax=1400M
+MemorySwapMax=0
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/sudoers.d/streamlit-deploy
+++ b/deploy/sudoers.d/streamlit-deploy
@@ -1,0 +1,1 @@
+streamlituser ALL=(root) NOPASSWD: /usr/bin/systemctl restart streamlit, /usr/bin/systemctl start streamlit, /usr/bin/systemctl stop streamlit, /usr/bin/systemctl status streamlit, /usr/bin/systemctl is-active streamlit

--- a/scripts/deploy/dev_deploy.sh
+++ b/scripts/deploy/dev_deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Deploy the current dev checkout: sync deps, migrate, restart Streamlit.
+# Safe to run by hand as streamlituser (operates on the already-updated tree).
+set -euo pipefail
+
+REPO_DIR="/home/streamlituser/thrive_ui"
+UV="/home/streamlituser/.local/bin/uv"
+SYSTEMCTL="/usr/bin/systemctl"
+
+export PATH="/home/streamlituser/.local/bin:$PATH"  # systemd's env lacks ~/.local/bin
+cd "$REPO_DIR"
+
+echo "==> uv sync"
+"$UV" sync
+
+echo "==> alembic upgrade head"
+"$UV" run alembic upgrade head
+
+echo "==> restart streamlit"
+sudo "$SYSTEMCTL" restart streamlit
+
+echo "==> verify active"
+"$SYSTEMCTL" is-active streamlit   # is-active needs no root; non-zero exit fails the deploy
+echo "==> deploy OK"


### PR DESCRIPTION
## What

Continuous deployment for the `dev` branch to the `streamlitadmin-dev` box (`aiweb01-dev`). On every push to `dev`, a self-hosted GitHub Actions runner on the (firewalled) box pulls the change, syncs deps, runs Alembic migrations, and restarts Streamlit — no inbound firewall exposure.

## How it works

```
push to dev → GitHub → [outbound long-poll] → self-hosted runner (as streamlituser)
  → .github/workflows/deploy-dev.yml
      · git fetch + force-checkout origin/dev   (no actions/checkout; deploys the real tree)
      · scripts/deploy/dev_deploy.sh: uv sync → alembic upgrade head → systemctl restart streamlit
```

## Files

- `.github/workflows/deploy-dev.yml` — triggers on push to `dev` + `workflow_dispatch`; `runs-on: [self-hosted, thrive-dev]`; `concurrency: deploy-dev`.
- `scripts/deploy/dev_deploy.sh` — `uv sync` → `alembic upgrade head` → `sudo systemctl restart streamlit` → health check. Fail-fast: a bad sync/migration aborts before restart, leaving the old process serving.
- `deploy/streamlit.service` — systemd unit running Streamlit as `streamlituser` on `0.0.0.0:8501` (version-controlled copy of what's installed on the box).
- `deploy/sudoers.d/streamlit-deploy` — narrow grant: `streamlituser` may run `systemctl … streamlit` only.

## Server-side provisioning (done, not in this PR)

sudoers drop-in, `streamlit.service` (enabled + running), and the self-hosted runner (label `thrive-dev`, runs as `streamlituser`) are installed on the box.

## Notes

- **No `actions/checkout`** — that would deploy into the runner's `_work` dir, not `/home/streamlituser/thrive_ui`. The workflow updates the existing checkout in place.
- **Force-checkout** (`git checkout -f -B dev origin/dev`) so the deploy never depends on a clean tree: `uv sync` rewrites `uv.lock` (the committed lock is inconsistent with the pyaudio-commented `pyproject.toml`), which would otherwise block the next `git checkout`. Untracked/gitignored files (`secrets.toml`, `.venv/`, `chromadb/`, `*.milvus.db`) are never touched; `git clean` is never run.
- Verified end-to-end: a push deployed green against a dirty tree, server HEAD matched `origin/dev`, and Streamlit restarted (health `ok`).

## Follow-up (not in this PR)

The committed `uv.lock` lists `pyaudio` while `pyproject.toml` has it commented out (`uv lock --check` flags it). Harmless here — `uv sync` re-resolves and drops it — but re-locking to make them consistent would remove the per-deploy lock churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
