### PR TITLE
feat(#222): configurable toggle to hide chatbot thinking process

### DIFF
--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -252,6 +252,20 @@ def _render_event(event: StreamEvent, state: dict[str, Any] | None = None) -> No
     if isinstance(event, ThinkingDeltaEvent):
         slot = _open_slot(state, "thinking", event.turn_index)
         slot["buf"] += event.delta
+        # Epic #222 / Feature #226: when the user has the toggle off, render
+        # a single static placeholder for the turn instead of the live
+        # chunk-by-chunk stream. The slot is still opened so the matching
+        # ThinkingCompletedEvent can outer.empty() the bubble, and the
+        # buffer still accumulates so any downstream consumer sees parity
+        # with the on-path. ``static_rendered`` makes the off-path
+        # idempotent across repeated deltas in the same turn.
+        if not st.session_state.get("show_thinking_process", False):
+            if not slot.get("static_rendered"):
+                with slot["outer"].container():
+                    with st.chat_message(RoleType.ASSISTANT.value):
+                        st.caption("🤔 Thinking…")
+                slot["static_rendered"] = True
+            return
         _write_slot(slot, header="🤔 **Thinking...**")
         return
 

--- a/alembic/versions/f05a0e34dd21_add_show_thinking_process_to_thrive_user.py
+++ b/alembic/versions/f05a0e34dd21_add_show_thinking_process_to_thrive_user.py
@@ -1,0 +1,38 @@
+"""add show_thinking_process to thrive_user
+
+Revision ID: f05a0e34dd21
+Revises: c8d5e3a90212
+Create Date: 2026-06-23 10:13:43.773482
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f05a0e34dd21"
+down_revision: Union[str, Sequence[str], None] = "c8d5e3a90212"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the ``show_thinking_process`` user preference (Epic #222).
+
+    Adds a nullable Boolean column via ``batch_alter_table`` (SQLite has no
+    direct ``ALTER COLUMN``) and backfills every existing row to ``False``
+    so the toggle defaults to hidden for the entire user base, matching the
+    Epic's acceptance criteria.
+    """
+    with op.batch_alter_table("thrive_user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("show_thinking_process", sa.Boolean(), nullable=True))
+    op.execute("UPDATE thrive_user SET show_thinking_process = 0 WHERE show_thinking_process IS NULL")
+
+
+def downgrade() -> None:
+    """Drop the ``show_thinking_process`` column."""
+    with op.batch_alter_table("thrive_user", schema=None) as batch_op:
+        batch_op.drop_column("show_thinking_process")

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -224,6 +224,7 @@ def set_user_preferences_in_session_state():
         st.session_state.show_suggested = user.show_suggested
         st.session_state.show_followup = user.show_followup
         st.session_state.show_elapsed_time = user.show_elapsed_time
+        st.session_state.show_thinking_process = bool(getattr(user, "show_thinking_process", False))
         st.session_state.llm_fallback = user.llm_fallback
         st.session_state.confirm_magic_commands = getattr(user, "confirm_magic_commands", True)
         st.session_state.show_community_engagement = bool(getattr(user, "show_community_engagement", False) or False)
@@ -266,6 +267,7 @@ def save_user_settings():
             setattr(user, "show_suggested", st.session_state.show_suggested)
             setattr(user, "show_followup", st.session_state.show_followup)
             setattr(user, "show_elapsed_time", st.session_state.show_elapsed_time)
+            setattr(user, "show_thinking_process", st.session_state.get("show_thinking_process", False))
             setattr(user, "llm_fallback", st.session_state.llm_fallback)
             setattr(user, "confirm_magic_commands", st.session_state.get("confirm_magic_commands", True))
             setattr(user, "show_community_engagement", st.session_state.get("show_community_engagement", False))

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -808,6 +808,7 @@ def update_user_preferences(user_id: int, **preferences) -> bool:
                 "show_suggested",
                 "show_followup",
                 "show_elapsed_time",
+                "show_thinking_process",
                 "llm_fallback",
                 "show_community_engagement",
                 "min_message_id",

--- a/orm/models.py
+++ b/orm/models.py
@@ -199,6 +199,7 @@ class User(Base):
     show_suggested = Column(Boolean, default=False)
     show_followup = Column(Boolean, default=False)
     show_elapsed_time = Column(Boolean, default=True)
+    show_thinking_process = Column(Boolean, default=False)
     llm_fallback = Column(Boolean, default=False)
     confirm_magic_commands = Column(Boolean, default=True)  # True = show popup, False = auto-execute
     show_community_engagement = Column(Boolean, default=False)
@@ -231,6 +232,7 @@ class User(Base):
             "show_suggested": self.show_suggested,
             "show_followup": self.show_followup,
             "show_elapsed_time": self.show_elapsed_time,
+            "show_thinking_process": self.show_thinking_process,
             "llm_fallback": self.llm_fallback,
             "confirm_magic_commands": self.confirm_magic_commands,
             "show_community_engagement": self.show_community_engagement,

--- a/tests/agent/test_render_event_thinking.py
+++ b/tests/agent/test_render_event_thinking.py
@@ -1,0 +1,143 @@
+"""Unit tests for the gated transient thinking-bubble (Epic #222 / Feature #226).
+
+Covers the agentic render path's `ThinkingDeltaEvent` consumer in
+``agent.runtime._render_event``. The persistent ``MessageType.THINKING``
+message added on ``ThinkingCompletedEvent`` renders via
+``utils.chat_bot_helper._render_thinking`` and is gated there (Feature
+#225); this file does not re-cover the persistent-render branch.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.state import ThinkingCompletedEvent, ThinkingDeltaEvent
+
+
+def _fake_st(show_thinking: bool | None) -> MagicMock:
+    """Build a MagicMock standing in for ``streamlit`` inside agent.runtime.
+
+    ``show_thinking`` controls what ``st.session_state.get("show_thinking_process",
+    False)`` returns; pass ``None`` to simulate a session where the key is
+    missing entirely (default-off per Epic #222 acceptance criteria).
+    ``st.empty()``, ``st.container()``, and ``st.chat_message()`` are
+    configured as context managers so the ``with`` blocks in the production
+    code don't crash when entered.
+    """
+    fake_st = MagicMock()
+    overrides: dict = {} if show_thinking is None else {"show_thinking_process": show_thinking}
+    fake_st.session_state.get = MagicMock(side_effect=lambda key, default=None: overrides.get(key, default))
+
+    outer = MagicMock()
+    container = MagicMock()
+    container.__enter__ = MagicMock(return_value=None)
+    container.__exit__ = MagicMock(return_value=None)
+    outer.container = MagicMock(return_value=container)
+    fake_st.empty = MagicMock(return_value=outer)
+
+    chat_message = MagicMock()
+    chat_message.__enter__ = MagicMock(return_value=None)
+    chat_message.__exit__ = MagicMock(return_value=None)
+    fake_st.chat_message = MagicMock(return_value=chat_message)
+    return fake_st
+
+
+def test_thinking_delta_off_renders_static_caption_once(monkeypatch):
+    """Toggle off → one static caption, no streaming header in markdown."""
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(show_thinking=False)
+    monkeypatch.setattr(runtime, "st", fake_st)
+
+    state: dict = {"thinking": {}, "text": {}}
+    runtime._render_event(ThinkingDeltaEvent(delta="thinking content", turn_index=1), state)
+
+    fake_st.caption.assert_called_once_with("🤔 Thinking…")
+    # The "🤔 **Thinking...**" streaming header is rendered via st.markdown
+    # in _write_slot — when off, that path must NOT be taken.
+    streaming_markdown_calls = [
+        c for c in fake_st.markdown.call_args_list if "Thinking..." in (c.args[0] if c.args else "")
+    ]
+    assert streaming_markdown_calls == [], (
+        f"Expected no streaming-header markdown calls when toggle is off; saw {streaming_markdown_calls}"
+    )
+    slot = state["thinking"][1]
+    assert slot["static_rendered"] is True
+    assert slot["buf"] == "thinking content", "Buffer must still accumulate for parity with on-path."
+
+
+def test_thinking_delta_off_is_idempotent_on_repeats(monkeypatch):
+    """Toggle off + multiple deltas for same turn_index → caption rendered ONCE."""
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(show_thinking=False)
+    monkeypatch.setattr(runtime, "st", fake_st)
+
+    state: dict = {"thinking": {}, "text": {}}
+    for i, chunk in enumerate(["chunk-1", "chunk-2", "chunk-3"]):
+        runtime._render_event(ThinkingDeltaEvent(delta=chunk, turn_index=1), state)
+
+    fake_st.caption.assert_called_once_with("🤔 Thinking…")
+    slot = state["thinking"][1]
+    assert slot["static_rendered"] is True
+    assert slot["buf"] == "chunk-1chunk-2chunk-3"
+
+
+def test_thinking_delta_on_renders_streaming_header(monkeypatch):
+    """Toggle on → existing _write_slot behavior (streaming header markdown)."""
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(show_thinking=True)
+    monkeypatch.setattr(runtime, "st", fake_st)
+
+    state: dict = {"thinking": {}, "text": {}}
+    runtime._render_event(ThinkingDeltaEvent(delta="streamed chunk", turn_index=1), state)
+
+    streaming_calls = [c for c in fake_st.markdown.call_args_list if "Thinking..." in (c.args[0] if c.args else "")]
+    assert len(streaming_calls) == 1, f"Expected one streaming markdown when toggle is on, saw {streaming_calls}"
+    assert "streamed chunk" in streaming_calls[0].args[0], "Streamed delta must appear in the markdown body."
+    # The static off-path caption must NOT have been called.
+    fake_st.caption.assert_not_called()
+
+
+def test_thinking_delta_off_defaults_when_pref_missing(monkeypatch):
+    """No `show_thinking_process` key in session state → behaves as off (default per Epic)."""
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(show_thinking=None)
+    monkeypatch.setattr(runtime, "st", fake_st)
+
+    state: dict = {"thinking": {}, "text": {}}
+    runtime._render_event(ThinkingDeltaEvent(delta="content", turn_index=1), state)
+
+    fake_st.caption.assert_called_once_with("🤔 Thinking…")
+
+
+def test_thinking_completed_empties_slot_and_persists_regardless_of_toggle(monkeypatch):
+    """ThinkingCompletedEvent unchanged: always empties the slot AND adds
+    a persistent MessageType.THINKING message. Toggle state does not gate
+    persistence — only rendering of the persisted message (handled by #225)."""
+    import agent.runtime as runtime
+
+    for show in (False, True):
+        fake_st = _fake_st(show_thinking=show)
+        monkeypatch.setattr(runtime, "st", fake_st)
+
+        state: dict = {"thinking": {}, "text": {}}
+        # Seed a prior delta so the slot exists.
+        runtime._render_event(ThinkingDeltaEvent(delta="content", turn_index=1), state)
+        outer = state["thinking"][1]["outer"]
+
+        with patch("utils.chat_bot_helper.add_message") as add_message_mock:
+            runtime._render_event(
+                ThinkingCompletedEvent(text="content", elapsed_ms=500, turn_index=1),
+                state,
+            )
+
+        outer.empty.assert_called_once()
+        assert 1 not in state["thinking"], "Completed turn must be removed from the state dict."
+        add_message_mock.assert_called_once()
+        persisted_msg = add_message_mock.call_args.args[0]
+        from utils.enums import MessageType
+
+        assert persisted_msg.type == MessageType.THINKING.value, (
+            f"Persistent message must be MessageType.THINKING regardless of toggle, got {persisted_msg.type}"
+        )

--- a/tests/orm/test_user_show_thinking_process.py
+++ b/tests/orm/test_user_show_thinking_process.py
@@ -1,0 +1,99 @@
+"""show_thinking_process should default OFF for everybody — new users and existing.
+
+- New users created via the ORM / ``create_user`` get ``show_thinking_process = False``.
+- The schema migration backfills any pre-existing rows to ``False``.
+- ``User.to_dict()`` exposes the new key so downstream serializers see it.
+"""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+from orm.functions import create_user
+from orm.models import User, UserRole
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_create_user_defaults_show_thinking_process_off(in_memory_orm_session):
+    with in_memory_orm_session() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+
+    assert (
+        create_user(
+            "thinkdoc",
+            "pw",
+            "Think",
+            "Doc",
+            role_id,
+            email="thinkdoc@example.com",
+            organization="Acme",
+        )
+        is True
+    )
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "thinkdoc").one()
+        assert user.show_thinking_process is False
+
+
+def test_user_to_dict_includes_show_thinking_process(in_memory_orm_session):
+    with in_memory_orm_session() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Nurse").one().id
+
+    create_user(
+        "dictnurse",
+        "pw",
+        "Dict",
+        "Nurse",
+        role_id,
+        email="dictnurse@example.com",
+        organization="Acme",
+    )
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "dictnurse").one()
+        payload = user.to_dict()
+        assert "show_thinking_process" in payload
+        assert payload["show_thinking_process"] is False
+
+
+def test_migration_backfills_show_thinking_process_to_false(tmp_path):
+    """Upgrade to the prior revision, insert a user without the new column,
+    then upgrade to head — the new migration must add the column and backfill
+    every row to ``0`` (False)."""
+    url = f"sqlite:///{tmp_path / 'thrive.sqlite3'}"
+    cfg = Config(str(REPO_ROOT / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", url)
+
+    # Schema state just before the show_thinking_process migration.
+    command.upgrade(cfg, "c8d5e3a90212")
+
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        # Seed a minimal UserRole row so the Epic #179 FK constraint resolves
+        # (matches the pattern in tests/orm/test_agentic_mode_default.py).
+        conn.execute(
+            text(
+                "INSERT INTO thrive_user_role (id, role_name, description, role) "
+                "VALUES (4, 'Patient', 'Patient access', 'PATIENT')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO thrive_user "
+                "(username, first_name, last_name, password, email, organization, user_role_id) "
+                "VALUES ('legacy_thinking', 'Leg', 'Acy', 'x', 'legacy@example.com', 'Acme', 4)"
+            )
+        )
+
+    # Apply the new migration.
+    command.upgrade(cfg, "head")
+
+    with engine.connect() as conn:
+        val = conn.execute(
+            text("SELECT show_thinking_process FROM thrive_user WHERE username='legacy_thinking'")
+        ).scalar()
+    assert val == 0, "existing user should be backfilled to show_thinking_process = False"

--- a/tests/orm/test_user_show_thinking_process.py
+++ b/tests/orm/test_user_show_thinking_process.py
@@ -11,7 +11,7 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, text
 
-from orm.functions import create_user
+from orm.functions import create_user, update_user_preferences
 from orm.models import User, UserRole
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -58,6 +58,36 @@ def test_user_to_dict_includes_show_thinking_process(in_memory_orm_session):
         payload = user.to_dict()
         assert "show_thinking_process" in payload
         assert payload["show_thinking_process"] is False
+
+
+def test_update_user_preferences_persists_show_thinking_process(in_memory_orm_session):
+    """The admin-capable ``update_user_preferences`` path must accept
+    ``show_thinking_process`` — exercises the allowlist + round-trip
+    persistence, since the self-service ``save_user_settings`` path is
+    Streamlit-coupled and harder to unit-test directly."""
+    with in_memory_orm_session() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+
+    create_user(
+        "rtuser",
+        "pw",
+        "Round",
+        "Trip",
+        role_id,
+        email="rtuser@example.com",
+        organization="Acme",
+    )
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.username == "rtuser").one()
+        assert user.show_thinking_process is False
+        user_id = user.id
+
+    assert update_user_preferences(user_id, show_thinking_process=True) is True
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        assert user.show_thinking_process is True
 
 
 def test_migration_backfills_show_thinking_process_to_false(tmp_path):

--- a/tests/utils/test_render_thinking.py
+++ b/tests/utils/test_render_thinking.py
@@ -1,0 +1,93 @@
+"""Unit tests for the gated `_render_thinking` renderer (Epic #222 / Feature #225).
+
+Covers the Vanna single-shot render path. When ``show_thinking_process`` is
+off the renderer collapses to a compact placeholder; when on it renders the
+full expander with the message content. The live-streaming block at
+``chat_bot_helper.py:~1450`` is exercised via manual smoke per the spec
+(Ollama runtime required) — only the deterministic renderer path is
+unit-tested here.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from orm.models import Message
+from utils.enums import MessageType, RoleType
+
+
+def _make_thinking_message(content: str = "internal monologue", elapsed: float | None = 0.42) -> Message:
+    msg = Message(
+        role=RoleType.ASSISTANT,
+        content=content,
+        type=MessageType.THINKING,
+        query="",
+        question="",
+        elapsed_time=Decimal(str(elapsed)) if elapsed is not None else None,
+    )
+    return msg
+
+
+def _fake_st(session_state_overrides: dict | None = None) -> MagicMock:
+    """A MagicMock standing in for the ``streamlit`` module inside chat_bot_helper.
+
+    ``st.session_state.get`` returns values from ``session_state_overrides``;
+    keys absent from the dict fall through to the default the caller passed.
+    ``st.expander`` is configured as a context manager so the `with` block in
+    ``_render_thinking`` doesn't crash when entered.
+    """
+    overrides = session_state_overrides or {}
+    fake_st = MagicMock()
+    fake_st.session_state.get = MagicMock(side_effect=lambda key, default=None: overrides.get(key, default))
+    fake_st.expander.return_value.__enter__ = MagicMock(return_value=None)
+    fake_st.expander.return_value.__exit__ = MagicMock(return_value=None)
+    return fake_st
+
+
+def test_render_thinking_off_renders_caption_only(monkeypatch):
+    """When the user has the toggle off, the renderer must show a single
+    compact caption and skip the expander entirely."""
+    import utils.chat_bot_helper as helper
+
+    fake_st = _fake_st({"show_thinking_process": False})
+    monkeypatch.setattr(helper, "st", fake_st)
+
+    helper._render_thinking(_make_thinking_message(), 0)
+
+    assert fake_st.caption.call_count == 1, "Expected a single caption call for the placeholder."
+    caption_text = fake_st.caption.call_args.args[0]
+    assert "Thinking" in caption_text, f"Caption text should mention 'Thinking', got: {caption_text!r}"
+    fake_st.expander.assert_not_called()
+    fake_st.markdown.assert_not_called()
+
+
+def test_render_thinking_on_renders_expander(monkeypatch):
+    """When the toggle is on, render the full expander with the message
+    content — preserves pre-toggle behavior exactly."""
+    import utils.chat_bot_helper as helper
+
+    fake_st = _fake_st({"show_thinking_process": True, "show_elapsed_time": True})
+    monkeypatch.setattr(helper, "st", fake_st)
+
+    msg = _make_thinking_message(content="my full chain-of-thought")
+    helper._render_thinking(msg, 0)
+
+    fake_st.expander.assert_called_once_with("🤔 AI Thinking Process", expanded=False)
+    fake_st.markdown.assert_called_once_with("my full chain-of-thought")
+    # `show_elapsed_time` is on AND `elapsed_time` is not None → caption with the timing.
+    timing_captions = [c for c in fake_st.caption.call_args_list if "Thinking time" in c.args[0]]
+    assert len(timing_captions) == 1, "Expected exactly one 'Thinking time' caption when both flags are on."
+
+
+def test_render_thinking_defaults_to_off_when_pref_missing(monkeypatch):
+    """If `show_thinking_process` isn't set in session state (e.g. a brand-new
+    session before settings load), the default must be off per Epic #222
+    acceptance criteria."""
+    import utils.chat_bot_helper as helper
+
+    fake_st = _fake_st({})  # no key for show_thinking_process
+    monkeypatch.setattr(helper, "st", fake_st)
+
+    helper._render_thinking(_make_thinking_message(), 0)
+
+    assert fake_st.caption.call_count == 1
+    fake_st.expander.assert_not_called()

--- a/tests/views/test_settings_dialog.py
+++ b/tests/views/test_settings_dialog.py
@@ -1,0 +1,89 @@
+"""Unit tests for the Settings dialog's display form (Epic #222 / Feature #224).
+
+Verifies the ``show_thinking_process`` checkbox is wired into
+``_render_display_form`` and that submitting the form copies the value into
+``st.session_state`` before persisting via ``save_user_settings``. The actual
+persistence layer is covered by ``tests/orm/test_user_show_thinking_process.py``.
+"""
+
+from unittest.mock import MagicMock
+
+
+def _build_fake_st(submit: bool, checkbox_overrides: dict | None = None) -> MagicMock:
+    """Return a ``MagicMock`` shaped to stand in for the ``streamlit`` module
+    inside ``_render_display_form``.
+
+    ``checkbox_overrides`` maps checkbox labels to the value that
+    ``st.checkbox`` should return for that label — this is what the form
+    bindings (``form_show_*``) capture inside the function. Any label not in
+    the dict falls back to the ``value=`` kwarg the caller passed in.
+    """
+    fake_st = MagicMock()
+    fake_st.session_state.get = MagicMock(side_effect=lambda key, default=None: default)
+
+    overrides = checkbox_overrides or {}
+
+    def checkbox_side_effect(label, *args, value=None, help=None, **_kwargs):
+        return overrides.get(label, value)
+
+    fake_st.checkbox.side_effect = checkbox_side_effect
+
+    # ``st.form`` is used as a context manager — make the MagicMock return a
+    # context manager that yields ``None``.
+    fake_st.form.return_value.__enter__ = MagicMock(return_value=None)
+    fake_st.form.return_value.__exit__ = MagicMock(return_value=None)
+
+    fake_st.form_submit_button.return_value = submit
+    return fake_st
+
+
+def test_render_display_form_includes_show_thinking_process_checkbox(monkeypatch):
+    """The Display section must surface the new checkbox so users can toggle
+    the thinking-process display from the Settings dialog."""
+    import views.chat_bot as page
+
+    fake_st = _build_fake_st(submit=False)
+    monkeypatch.setattr(page, "st", fake_st)
+
+    page._render_display_form()
+
+    labels = [call.args[0] for call in fake_st.checkbox.call_args_list]
+    assert "Show AI thinking process" in labels, (
+        f"Settings dialog is missing the show_thinking_process checkbox; observed checkboxes={labels}"
+    )
+
+    # The default value must come from session_state with a False fallback —
+    # matches the Epic acceptance criteria that the toggle defaults to hidden.
+    keys_queried = [c.args[0] for c in fake_st.session_state.get.call_args_list if c.args]
+    assert "show_thinking_process" in keys_queried, (
+        "Checkbox default must be read from st.session_state.get('show_thinking_process', False) "
+        "so toggled-and-saved state survives a rerun."
+    )
+    show_thinking_get_calls = [
+        c for c in fake_st.session_state.get.call_args_list if c.args and c.args[0] == "show_thinking_process"
+    ]
+    assert any((c.args[1] is False) for c in show_thinking_get_calls if len(c.args) >= 2), (
+        "Default value passed to st.session_state.get must be False per Epic #222 acceptance criteria."
+    )
+
+
+def test_render_display_form_submit_persists_show_thinking_process(monkeypatch):
+    """Clicking Save must copy the form value to ``st.session_state`` AND
+    call ``save_user_settings`` so the DB column is written."""
+    import views.chat_bot as page
+
+    fake_st = _build_fake_st(
+        submit=True,
+        checkbox_overrides={"Show AI thinking process": True},
+    )
+    monkeypatch.setattr(page, "st", fake_st)
+
+    save_mock = MagicMock()
+    monkeypatch.setattr(page, "save_user_settings", save_mock)
+
+    page._render_display_form()
+
+    assert fake_st.session_state.show_thinking_process is True, (
+        "Submit branch must copy form_show_thinking_process into st.session_state.show_thinking_process."
+    )
+    save_mock.assert_called_once()

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1493,8 +1493,12 @@ def _run_message_flow(my_question: str):
                         # Brief delay for visual continuity (1.5 seconds)
                         time.sleep(1.5)
 
-                    # Clear the placeholder - we'll add the thinking as a proper message
-                    thinking_placeholder.empty()
+                # Clear the placeholder unconditionally - we'll add the thinking
+                # as a proper message below. When show_thinking is off we
+                # populate the placeholder before the stream, so we must clear
+                # it even when streamed_sql was never written to session_state
+                # (e.g. backend errored after the stream loop). Epic #222.
+                thinking_placeholder.empty()
 
             # Phase 2: Persistent display - add thinking to chat history as collapsible expander
             # If we collected thinking text, add it as a proper message

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1198,7 +1198,16 @@ def _render_followup(message: Message, index: int):
 
 
 def _render_thinking(message: Message, index: int):
-    """Render thinking messages in an expandable container."""
+    """Render thinking messages.
+
+    Gated by Epic #222 / Feature #225: when ``show_thinking_process`` is
+    off (the default), render a compact placeholder instead of the full
+    expander. THINKING messages are always persisted regardless of the
+    toggle — only the rendering changes.
+    """
+    if not st.session_state.get("show_thinking_process", False):
+        st.caption("🤔 Thinking…")
+        return
     with st.expander("🤔 AI Thinking Process", expanded=False):
         st.markdown(message.content)
         if st.session_state.get("show_elapsed_time", True) and message.elapsed_time is not None:
@@ -1447,6 +1456,12 @@ def _run_message_flow(my_question: str):
 
     # If we have a thinking model, display the thinking stream
     thinking_text = ""  # Initialize outside the try block for use later
+    # Epic #222 / Feature #225: respect the per-user toggle. When off, show a
+    # static "Thinking…" placeholder for the duration of the stream instead of
+    # rendering streamed chunks live; skip the 1.5s "Done thinking" pause since
+    # the user can't see the content anyway. The THINKING message is still
+    # persisted below so historical re-renders honor the current toggle state.
+    show_thinking = st.session_state.get("show_thinking_process", False)
     if has_thinking_model and hasattr(vn_instance, "stream_generate_sql"):
         try:
             thinking_chunks = []
@@ -1454,13 +1469,16 @@ def _run_message_flow(my_question: str):
             # Create a placeholder for real-time thinking display
             with st.chat_message(RoleType.ASSISTANT.value):
                 thinking_placeholder = st.empty()
+                if not show_thinking:
+                    thinking_placeholder.markdown("🤔 **Thinking…**")
 
                 # Stream the SQL generation and show thinking in real-time
                 stream_gen = vn_instance.stream_generate_sql(my_question)
                 for chunk in stream_gen:
                     thinking_chunks.append(chunk)
                     # Update the thinking display in real-time
-                    thinking_placeholder.markdown("🤔 **Thinking...**\n\n" + "".join(thinking_chunks))
+                    if show_thinking:
+                        thinking_placeholder.markdown("🤔 **Thinking...**\n\n" + "".join(thinking_chunks))
 
                 # After streaming completes, get the cached result
                 if hasattr(st.session_state, "streamed_sql"):
@@ -1469,7 +1487,7 @@ def _run_message_flow(my_question: str):
                     thinking_text = st.session_state.get("streamed_thinking", "")
 
                     # Phase 1: Graceful transition - show completion indicator
-                    if thinking_text and thinking_text.strip():
+                    if show_thinking and thinking_text and thinking_text.strip():
                         # Show "Done thinking" state for a brief moment
                         thinking_placeholder.markdown("✅ **Done thinking**\n\n" + "".join(thinking_chunks))
                         # Brief delay for visual continuity (1.5 seconds)

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -316,6 +316,11 @@ def _render_display_form():
             value=st.session_state.get("show_elapsed_time", True),
             help="Display how long each query took to execute.",
         )
+        form_show_thinking_process = st.checkbox(
+            "Show AI thinking process",
+            value=st.session_state.get("show_thinking_process", False),
+            help="When enabled, show the model's full thinking process for each query. When disabled, only a 'Thinking…' placeholder is shown while the model is running.",
+        )
         form_show_question_history = st.checkbox(
             "Show Question History",
             value=st.session_state.get("show_question_history", True),
@@ -362,6 +367,7 @@ def _render_display_form():
             st.session_state.show_table = form_show_table
             st.session_state.show_chart = form_show_chart
             st.session_state.show_elapsed_time = form_show_elapsed_time
+            st.session_state.show_thinking_process = form_show_thinking_process
             st.session_state.show_question_history = form_show_question_history
             st.session_state.voice_input = form_voice_input
             st.session_state.speak_summary = form_speak_summary


### PR DESCRIPTION
## Summary

Epic #222: adds a per-user "Show AI thinking process" toggle in the chat Settings dialog, gating both the Vanna and agentic render paths. When OFF (default), a compact "Thinking…" placeholder replaces the full thinking expander/bubble.

This PR ships the epic in four sequential phases, each implemented and reviewed on the same branch:

- [x] **#223** — Phase 1: Schema & persistence (`show_thinking_process` column on `thrive_user`, Alembic migration, ORM load/save wiring)
- [x] **#224** — Phase 2: Settings modal checkbox
- [x] **#225** — Phase 3: Vanna render path gating
- [x] **#226** — Phase 4: Agentic render path gating

## Test plan

- [x] `uv run pytest tests/orm/test_user_show_thinking_process.py` (3/3 pass)
- [x] `uv run pytest tests/test_alembic.py` (baseline drift check passes)
- [x] `uv run alembic upgrade head` + `downgrade -1` + `upgrade head` reversible
- [x] `uv run ruff check` and `ruff format --check` clean
- [ ] Phase 2-4 acceptance tests (TBD per phase)
- [ ] Manual end-to-end: toggle off → live thinking shows "Thinking…" placeholder; toggle on → existing expander/bubble unchanged

Tracks #222
Closes #223
Closes #224
Closes #225
Closes #226
