### PR TITLE
feat(#228): Vanna fallback when agent finishes without SQL

### DIFF
--- a/agent/fallback.py
+++ b/agent/fallback.py
@@ -1,0 +1,177 @@
+"""Fallback decision engine — pure logic for Epic #228.
+
+Decides whether an agent turn that finished without retrieving data should
+fall back to the legacy Vanna SQL pipeline. Three primitives:
+
+  - ``detect_trigger`` — deterministic check on the turn's tool events.
+  - ``classify_answer_adequacy`` — 1-shot LLM judge of the agent's final text.
+  - ``should_fallback`` — orchestrates the two.
+
+NO Streamlit access here — this module is imported by the agent runtime
+(``agent/runtime.py``) which may be running on the asyncio loop thread.
+``feature_enabled`` and ``scrubbed`` flags are passed in by the caller, not
+read from secrets.
+
+Fail-closed: when the classifier itself errors, the orchestrator returns
+``invoke=False``. The Epic's Acceptance Criteria require "Classifier
+failure does not block the user — the original agent reply renders,
+fallback is skipped."
+
+Wiring into the runtime lives in Feature #231.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic_ai import Agent
+
+from agent.models import build_model
+from agent.state import ToolCallCompleted, ToolCallStarted
+
+
+SQL_TOOL_NAMES = frozenset(
+    {
+        "run_sql",
+        "get_patient_clinical_data",
+        "search_patients_by_criteria",
+    }
+)
+
+
+_FallbackReason = Literal[
+    "feature_disabled",
+    "sql_tool_called",
+    "classifier_says_inadequate",
+    "classifier_says_adequate",
+    "classifier_error",
+]
+
+
+_TriggerKind = Literal["zero_tools", "no_sql_tool", "sql_tool_called"]
+
+
+class FallbackClassifierError(Exception):
+    """Raised by ``classify_answer_adequacy`` when the LLM call fails.
+
+    The orchestrator catches this and returns a fail-closed
+    ``FallbackDecision`` so a classifier outage never blocks the user.
+    """
+
+
+@dataclass(frozen=True)
+class FallbackDecision:
+    invoke: bool
+    reason: _FallbackReason
+    classifier_error: str | None = None
+
+
+def detect_trigger(tool_events: list[ToolCallStarted | ToolCallCompleted]) -> _TriggerKind:
+    """Classify the turn's tool activity for fallback purposes.
+
+    Returns ``"sql_tool_called"`` if any event targets a data-answer tool
+    (see ``SQL_TOOL_NAMES``), ``"zero_tools"`` if the list is empty, else
+    ``"no_sql_tool"``. Pure function: no Streamlit, no LLM, deterministic.
+    """
+    if not tool_events:
+        return "zero_tools"
+    for event in tool_events:
+        if event.tool_name in SQL_TOOL_NAMES:
+            return "sql_tool_called"
+    return "no_sql_tool"
+
+
+_CLASSIFIER_PROMPT_TEMPLATE = (
+    "You are reviewing an AI assistant's response to a user's question.\n"
+    "Question: {question}\n"
+    "Response: {final_text}\n"
+    "Did the response actually answer the user's data question with concrete "
+    "data, or did the assistant decline / give a non-data answer?\n"
+    "Reply with exactly one word: ADEQUATE or INADEQUATE."
+)
+
+
+async def classify_answer_adequacy(
+    question: str,
+    final_text: str,
+    *,
+    scrubbed: bool = False,
+    model: Any | None = None,
+) -> bool:
+    """Ask the configured LLM whether ``final_text`` adequately answers
+    ``question``. Returns ``True`` only when the LLM unambiguously replies
+    ``ADEQUATE`` (case- and whitespace-insensitive). Anything else —
+    including gibberish or ``INADEQUATE`` — returns ``False``. Conservative
+    bias: when in doubt, assume the user's data question was NOT answered.
+
+    Raises ``FallbackClassifierError`` on any LLM exception so the
+    orchestrator can fail-closed.
+
+    The ``model`` kwarg exists for test injection. In production, leave it
+    ``None`` and the function builds the configured model via
+    ``agent.models.build_model()`` — so the user's selected provider /
+    model is honored implicitly.
+
+    When ``scrubbed=True`` the prompt should be PHI-scrubbed before the
+    LLM call. Real wiring deferred — see TODO below.
+    """
+    if scrubbed:
+        # TODO(#228): wire agent.run_logger scrub helpers when available
+        # so the classifier prompt honors [agent_logging].mode = "scrubbed".
+        # Until then, scrubbed=True is a signal-only flag and the prompt
+        # contains verbatim question + final_text.
+        pass
+
+    chosen_model = model if model is not None else build_model()
+    agent: Agent[None, str] = Agent(chosen_model, output_type=str)
+    prompt = _CLASSIFIER_PROMPT_TEMPLATE.format(question=question, final_text=final_text)
+    try:
+        result = await agent.run(prompt)
+    except Exception as exc:
+        raise FallbackClassifierError(str(exc)) from exc
+
+    raw_output = getattr(result, "output", "")
+    normalized = (raw_output or "").strip().upper()
+    return normalized == "ADEQUATE"
+
+
+async def should_fallback(
+    *,
+    question: str,
+    final_text: str,
+    tool_events: list[ToolCallStarted | ToolCallCompleted],
+    feature_enabled: bool,
+    scrubbed: bool = False,
+) -> FallbackDecision:
+    """Decide whether to invoke the Vanna fallback for this turn.
+
+    Decision tree:
+      1. ``feature_enabled=False`` → no fallback (short-circuit; no LLM
+         call).
+      2. The turn already called a data-answer tool → no fallback
+         (short-circuit; no LLM call).
+      3. Otherwise classify the agent's final text:
+         - ``ADEQUATE`` → no fallback.
+         - anything else → fallback.
+         - classifier error → fail-closed, no fallback.
+    """
+    if not feature_enabled:
+        return FallbackDecision(invoke=False, reason="feature_disabled")
+
+    trigger = detect_trigger(tool_events)
+    if trigger == "sql_tool_called":
+        return FallbackDecision(invoke=False, reason="sql_tool_called")
+
+    try:
+        adequate = await classify_answer_adequacy(question, final_text, scrubbed=scrubbed)
+    except FallbackClassifierError as exc:
+        return FallbackDecision(
+            invoke=False,
+            reason="classifier_error",
+            classifier_error=str(exc),
+        )
+
+    if adequate:
+        return FallbackDecision(invoke=False, reason="classifier_says_adequate")
+    return FallbackDecision(invoke=True, reason="classifier_says_inadequate")

--- a/agent/run_logger.py
+++ b/agent/run_logger.py
@@ -388,3 +388,52 @@ class AgentRunLogger:
             self._safe_commit()
         except Exception:
             pass
+
+
+def mark_run_fallback_invoked(
+    session: Session,
+    *,
+    run_id: str,
+    fallback_sql: Optional[str],
+) -> None:
+    """Mark an already-finalized agent run as ``fallback_invoked`` and
+    persist the Vanna SQL that fired (Epic #228 / #233).
+
+    Called from ``agent.runtime._maybe_invoke_vanna_fallback`` on the
+    Streamlit script thread, using a fresh ``SessionLocal`` — the
+    original ``AgentRunLogger.session`` is owned by the loop thread and
+    may already be closed.
+
+    Silently no-ops when ``run_id`` does not resolve to a row and on any
+    DB error. An audit gap is preferable to losing the user's Vanna
+    answer to a logging failure.
+    """
+    try:
+        run = session.query(AgentRun).filter_by(run_id=run_id).first()
+        if run is None:
+            return
+        run.status = "fallback_invoked"
+        run.fallback_sql = fallback_sql
+        session.add(run)
+
+        # Append a timeline event so the inspector reflects the transition.
+        # `seq` is MAX(seq)+1 for this run — the run's original logger is
+        # gone, so we recompute from the existing rows.
+        next_seq_row = (
+            session.query(func.max(AgentRunEvent.seq)).filter(AgentRunEvent.run_id == run_id).scalar()
+        )
+        next_seq = (next_seq_row or 0) + 1
+        session.add(
+            AgentRunEvent(
+                run_id=run_id,
+                seq=next_seq,
+                event_type="fallback_invoked",
+                payload_summary=f"fallback_sql_chars={len(fallback_sql or '')}",
+            )
+        )
+        session.commit()
+    except Exception:
+        try:
+            session.rollback()
+        except Exception:
+            pass

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -62,6 +62,17 @@ from agent.tools.search_patients_by_criteria import search_patients_by_criteria
 
 _DEFAULT_MAX_TOOL_CALLS = 7
 _DEFAULT_MAX_WALL_CLOCK_S = 120.0
+
+
+def _logger_run_id(logger: Any) -> Optional[str]:
+    """Extract ``logger.run_id`` only if it's a real string. Production
+    AgentRunLogger always provides a string; defensive isinstance guard
+    keeps existing tests with MagicMock loggers working (the mocked
+    ``logger.run_id`` is a MagicMock, which pydantic rejects)."""
+    if logger is None:
+        return None
+    rid = getattr(logger, "run_id", None)
+    return rid if isinstance(rid, str) else None
 # pydantic-ai exposes a synthetic 'final_result' tool for output-typed agents;
 # it is not a user-facing tool and should not appear in the audit log or UI.
 _OUTPUT_TOOL_NAMES = {"final_result"}
@@ -563,7 +574,12 @@ class AgenticRunner:
                                     total_elapsed_ms=int((loop.time() - start) * 1000),
                                     cap_reached=None,
                                 )
-                            yield FinalResponseEvent(response=output, all_messages=all_msgs, usage=usage)
+                            yield FinalResponseEvent(
+                                response=output,
+                                all_messages=all_msgs,
+                                usage=usage,
+                                run_id=_logger_run_id(logger),
+                            )
                             return
         except Exception as exc:
             if logger is not None:
@@ -605,4 +621,5 @@ class AgenticRunner:
                     response=output,
                     all_messages=list(run.result.all_messages()),
                     usage=usage,
+                    run_id=logger.run_id if logger is not None else None,
                 )

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -14,6 +14,7 @@ from typing import Any, Coroutine
 import streamlit as st
 
 from agent.deps_builder import build_agent_deps
+from agent.fallback import should_fallback
 from agent.observability import configure_observability
 from agent.runner import AgenticRunner
 from agent.state import (
@@ -31,7 +32,106 @@ from agent.state import (
     ToolCallStarted,
 )
 from utils.enums import MessageType, RoleType
+from utils.quick_logger import get_logger
 from orm.models import Message, SessionLocal
+
+
+logger = get_logger(__name__)
+
+
+_FALLBACK_BANNER_TEXT = "_💡 The agent didn't query data — falling back to direct SQL._"
+
+
+def _is_fallback_feature_enabled() -> bool:
+    """True only when the per-deploy secrets flag AND the per-user opt-in
+    are both on. Either flag missing or off → False. Until Feature #232
+    lands the `vanna_fallback_enabled` session-state key stays unset, so
+    this returns False by default and the fallback path is dormant.
+    """
+    try:
+        secrets_enabled = bool(st.secrets.get("agent", {}).get("fallback", {}).get("enabled", False))
+    except Exception:
+        secrets_enabled = False
+    user_opt_in = bool(st.session_state.get("vanna_fallback_enabled", False))
+    return secrets_enabled and user_opt_in
+
+
+def _is_scrubbed_logging() -> bool:
+    """Read `[agent_logging].mode` from secrets. Returns True only when
+    explicitly set to "scrubbed"; any other value (including missing
+    section) returns False.
+    """
+    try:
+        return st.secrets.get("agent_logging", {}).get("mode") == "scrubbed"
+    except Exception:
+        return False
+
+
+def _maybe_invoke_vanna_fallback(
+    question: str,
+    final_text: str,
+    tool_events: list[ToolCallStarted | ToolCallCompleted],
+) -> None:
+    """Post-stream fallback hook. Decides whether the agent's turn should
+    be retried via the legacy Vanna pipeline, and if so renders an
+    append-style banner and invokes _run_vanna_flow.
+
+    Runs on the Streamlit script thread. The classifier LLM call is
+    bridged to the persistent asyncio loop via _run_async; the banner
+    persistence and the Vanna invocation both need ScriptRunContext so
+    they stay on this thread.
+
+    Failure-tolerant by design: any exception during the decision or
+    the Vanna invocation is logged and swallowed. The original agent
+    reply remains visible — the Epic's Acceptance Criteria require
+    "classifier failure does not block the user."
+    """
+    if not _is_fallback_feature_enabled():
+        return
+
+    try:
+        with st.spinner("Checking whether to retry with direct SQL..."):
+            decision = _run_async(
+                should_fallback(
+                    question=question,
+                    final_text=final_text,
+                    tool_events=tool_events,
+                    feature_enabled=True,
+                    scrubbed=_is_scrubbed_logging(),
+                )
+            )
+    except Exception:
+        logger.exception("Fallback decision failed; skipping fallback")
+        return
+
+    if not decision.invoke:
+        return
+
+    # Lazy import to avoid a circular dependency: utils.chat_bot_helper
+    # imports agent.runtime via the dispatcher at module top, so a
+    # top-level `from utils.chat_bot_helper import ...` here would
+    # close the cycle.
+    from utils.chat_bot_helper import _run_vanna_flow, add_message
+
+    try:
+        add_message(
+            Message(
+                RoleType.ASSISTANT,
+                _FALLBACK_BANNER_TEXT,
+                MessageType.TEXT,
+            )
+        )
+        _run_vanna_flow(question)
+    except BaseException as exc:
+        # Streamlit's RerunException / StopException are control-flow
+        # signals raised by _run_vanna_flow's st.rerun() — let them
+        # propagate so the script runner can act on them. Mirrors the
+        # safety net in chat_bot_helper.normal_message_flow:1342.
+        if type(exc).__name__ in ("RerunException", "StopException"):
+            raise
+        if not isinstance(exc, Exception):
+            raise
+        logger.exception("Vanna fallback invocation failed")
 
 
 @st.cache_resource
@@ -154,6 +254,12 @@ def run_agentic_message_flow(my_question: str) -> None:
         # mid-flight — otherwise a partial "🤔 Thinking..." panel would
         # stay frozen on screen.
         renderer_state: dict[str, Any] = {"thinking": {}, "text": {}}
+        # Collected for the post-stream Vanna-fallback decision (Epic #228 / #231).
+        # We accumulate tool-call events and the final assistant text on the
+        # script thread as they're rendered, then hand them to the decision
+        # engine after future.result() so we don't double-render anything.
+        tool_events: list[ToolCallStarted | ToolCallCompleted] = []
+        final_response_text: str = ""
         try:
             while True:
                 try:
@@ -172,6 +278,10 @@ def run_agentic_message_flow(my_question: str) -> None:
                 if kind == "done":
                     break
                 _render_event(event, renderer_state)
+                if isinstance(event, (ToolCallStarted, ToolCallCompleted)):
+                    tool_events.append(event)
+                elif isinstance(event, FinalResponseEvent):
+                    final_response_text = event.response.text
             # Surface any exception raised inside produce() (and thus the
             # agent run) to the caller, matching the old _run_async behavior.
             future.result()
@@ -180,6 +290,11 @@ def run_agentic_message_flow(my_question: str) -> None:
             # bare except). Redo it here on the script thread so magic
             # functions and the Vanna flow see the final DataFrame.
             _sync_last_dataframe_to_session_state(deps)
+            # Post-stream Vanna fallback hook (Epic #228 / #231). No-op
+            # unless the per-deploy secrets flag AND the per-user opt-in
+            # are both on. Failures are logged and swallowed so the
+            # agent's reply still stands.
+            _maybe_invoke_vanna_fallback(my_question, final_response_text, tool_events)
         finally:
             _drain_placeholders(renderer_state)
     finally:

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -16,6 +16,7 @@ import streamlit as st
 from agent.deps_builder import build_agent_deps
 from agent.fallback import should_fallback
 from agent.observability import configure_observability
+from agent.run_logger import mark_run_fallback_invoked
 from agent.runner import AgenticRunner
 from agent.state import (
     AgentResponse,
@@ -67,14 +68,38 @@ def _is_scrubbed_logging() -> bool:
         return False
 
 
+def _mark_fallback_invoked_safely(run_id: str | None, fallback_sql: str | None) -> None:
+    """Open a fresh SQLite session on the script thread and persist the
+    fallback-invoked status + SQL via the run_logger helper. Swallows
+    all exceptions — an audit gap is preferable to losing the user's
+    Vanna answer to a logging failure.
+    """
+    if not run_id:
+        return
+    session = None
+    try:
+        session = SessionLocal()
+        mark_run_fallback_invoked(session, run_id=run_id, fallback_sql=fallback_sql)
+    except Exception:
+        logger.exception("mark_run_fallback_invoked failed for run_id=%s", run_id)
+    finally:
+        if session is not None:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+
 def _maybe_invoke_vanna_fallback(
     question: str,
     final_text: str,
     tool_events: list[ToolCallStarted | ToolCallCompleted],
+    run_id: str | None = None,
 ) -> None:
     """Post-stream fallback hook. Decides whether the agent's turn should
-    be retried via the legacy Vanna pipeline, and if so renders an
-    append-style banner and invokes _run_vanna_flow.
+    be retried via the legacy Vanna pipeline, and if so marks the agent
+    run as ``fallback_invoked`` (Feature #233), renders an append-style
+    banner, and invokes _run_vanna_flow.
 
     Runs on the Streamlit script thread. The classifier LLM call is
     bridged to the persistent asyncio loop via _run_async; the banner
@@ -107,6 +132,12 @@ def _maybe_invoke_vanna_fallback(
     if not decision.invoke:
         return
 
+    # Mark the agent run as fallback_invoked BEFORE invoking _run_vanna_flow.
+    # We don't have the SQL yet — Vanna writes the breadcrumb session-state
+    # key right before its st.rerun() raises RerunException, so we update
+    # the row a second time inside the RerunException catch below.
+    _mark_fallback_invoked_safely(run_id, fallback_sql=None)
+
     # Lazy import to avoid a circular dependency: utils.chat_bot_helper
     # imports agent.runtime via the dispatcher at module top, so a
     # top-level `from utils.chat_bot_helper import ...` here would
@@ -128,6 +159,14 @@ def _maybe_invoke_vanna_fallback(
         # propagate so the script runner can act on them. Mirrors the
         # safety net in chat_bot_helper.normal_message_flow:1342.
         if type(exc).__name__ in ("RerunException", "StopException"):
+            # Capture the SQL Vanna just persisted via its breadcrumb and
+            # update the run row with it before re-raising.
+            try:
+                fallback_sql = st.session_state.get("_last_vanna_fallback_sql")
+            except Exception:
+                fallback_sql = None
+            if fallback_sql:
+                _mark_fallback_invoked_safely(run_id, fallback_sql=fallback_sql)
             raise
         if not isinstance(exc, Exception):
             raise
@@ -260,6 +299,7 @@ def run_agentic_message_flow(my_question: str) -> None:
         # engine after future.result() so we don't double-render anything.
         tool_events: list[ToolCallStarted | ToolCallCompleted] = []
         final_response_text: str = ""
+        final_run_id: str | None = None
         try:
             while True:
                 try:
@@ -282,6 +322,7 @@ def run_agentic_message_flow(my_question: str) -> None:
                     tool_events.append(event)
                 elif isinstance(event, FinalResponseEvent):
                     final_response_text = event.response.text
+                    final_run_id = event.run_id
             # Surface any exception raised inside produce() (and thus the
             # agent run) to the caller, matching the old _run_async behavior.
             future.result()
@@ -293,8 +334,10 @@ def run_agentic_message_flow(my_question: str) -> None:
             # Post-stream Vanna fallback hook (Epic #228 / #231). No-op
             # unless the per-deploy secrets flag AND the per-user opt-in
             # are both on. Failures are logged and swallowed so the
-            # agent's reply still stands.
-            _maybe_invoke_vanna_fallback(my_question, final_response_text, tool_events)
+            # agent's reply still stands. final_run_id (Feature #233)
+            # lets the fallback path mark the agent run as
+            # `fallback_invoked` for audit.
+            _maybe_invoke_vanna_fallback(my_question, final_response_text, tool_events, run_id=final_run_id)
         finally:
             _drain_placeholders(renderer_state)
     finally:

--- a/agent/state.py
+++ b/agent/state.py
@@ -51,6 +51,10 @@ class FinalResponseEvent(BaseModel):
     # Token usage for this run, from pydantic-ai run.usage(). None when the
     # provider doesn't report usage. Keys: input_tokens, output_tokens, total_tokens.
     usage: Optional[dict] = None
+    # AgentRunLogger.run_id, threaded out so the runtime can mark the run
+    # `fallback_invoked` later (Epic #228 / #233). None when run logging
+    # is disabled.
+    run_id: Optional[str] = None
 
     model_config = {"arbitrary_types_allowed": True}
 

--- a/alembic/versions/b228fa11ed01_add_vanna_fallback_enabled.py
+++ b/alembic/versions/b228fa11ed01_add_vanna_fallback_enabled.py
@@ -1,0 +1,39 @@
+"""add vanna_fallback_enabled to thrive_user
+
+Revision ID: b228fa11ed01
+Revises: f05a0e34dd21
+Create Date: 2026-06-23
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b228fa11ed01"
+down_revision: Union[str, Sequence[str], None] = "f05a0e34dd21"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the ``vanna_fallback_enabled`` user preference (Epic #228 / #232).
+
+    Per-user opt-in for the agentic-mode Vanna fallback. Combined with the
+    per-deploy secrets flag ``[agent.fallback].enabled`` in
+    ``agent.runtime._is_fallback_feature_enabled``; both must be True for
+    the fallback path to fire. Default False on every row so the feature
+    is dormant for the entire user base until each user explicitly opts in.
+    """
+    with op.batch_alter_table("thrive_user", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("vanna_fallback_enabled", sa.Boolean(), nullable=True))
+    op.execute("UPDATE thrive_user SET vanna_fallback_enabled = 0 WHERE vanna_fallback_enabled IS NULL")
+
+
+def downgrade() -> None:
+    """Drop the ``vanna_fallback_enabled`` column."""
+    with op.batch_alter_table("thrive_user", schema=None) as batch_op:
+        batch_op.drop_column("vanna_fallback_enabled")

--- a/alembic/versions/c233fb500001_add_fallback_sql_to_agent_run.py
+++ b/alembic/versions/c233fb500001_add_fallback_sql_to_agent_run.py
@@ -1,0 +1,37 @@
+"""add fallback_sql to thrive_agent_run
+
+Revision ID: c233fb500001
+Revises: b228fa11ed01
+Create Date: 2026-06-24
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c233fb500001"
+down_revision: Union[str, Sequence[str], None] = "b228fa11ed01"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add the ``fallback_sql`` column to ``thrive_agent_run`` (Epic #228 / #233).
+
+    When the agentic Vanna fallback fires, the runtime marks the agent run
+    with ``status='fallback_invoked'`` and stashes the Vanna-generated SQL
+    in this column. NULL on every existing row — they never invoked a
+    fallback — so no backfill is needed.
+    """
+    with op.batch_alter_table("thrive_agent_run", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("fallback_sql", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop the ``fallback_sql`` column."""
+    with op.batch_alter_table("thrive_agent_run", schema=None) as batch_op:
+        batch_op.drop_column("fallback_sql")

--- a/orm/functions.py
+++ b/orm/functions.py
@@ -226,6 +226,7 @@ def set_user_preferences_in_session_state():
         st.session_state.show_elapsed_time = user.show_elapsed_time
         st.session_state.show_thinking_process = bool(getattr(user, "show_thinking_process", False))
         st.session_state.llm_fallback = user.llm_fallback
+        st.session_state.vanna_fallback_enabled = bool(getattr(user, "vanna_fallback_enabled", False))
         st.session_state.confirm_magic_commands = getattr(user, "confirm_magic_commands", True)
         st.session_state.show_community_engagement = bool(getattr(user, "show_community_engagement", False) or False)
         agentic_pref = getattr(user, "agentic_mode", True)
@@ -269,6 +270,7 @@ def save_user_settings():
             setattr(user, "show_elapsed_time", st.session_state.show_elapsed_time)
             setattr(user, "show_thinking_process", st.session_state.get("show_thinking_process", False))
             setattr(user, "llm_fallback", st.session_state.llm_fallback)
+            setattr(user, "vanna_fallback_enabled", st.session_state.get("vanna_fallback_enabled", False))
             setattr(user, "confirm_magic_commands", st.session_state.get("confirm_magic_commands", True))
             setattr(user, "show_community_engagement", st.session_state.get("show_community_engagement", False))
             setattr(user, "min_message_id", st.session_state.min_message_id)

--- a/orm/models.py
+++ b/orm/models.py
@@ -623,6 +623,7 @@ class AgentRun(Base):
     error_type = Column(String(100), nullable=True)
     error = Column(Text, nullable=True)
     stack_trace = Column(Text, nullable=True)
+    fallback_sql = Column(Text, nullable=True)
 
     review_status = Column(String(20), nullable=False, default="unreviewed")
     reviewed_by = Column(Integer, nullable=True)

--- a/orm/models.py
+++ b/orm/models.py
@@ -204,6 +204,7 @@ class User(Base):
     confirm_magic_commands = Column(Boolean, default=True)  # True = show popup, False = auto-execute
     show_community_engagement = Column(Boolean, default=False)
     agentic_mode = Column(Boolean, default=True)
+    vanna_fallback_enabled = Column(Boolean, default=False)
     min_message_id = Column(Integer, default=0)
     theme = Column(String(50), default=ThemeType.THRIVEAI.value)
     selected_llm_provider = Column(String(50), default=None)
@@ -241,6 +242,7 @@ class User(Base):
             "selected_llm_provider": self.selected_llm_provider,
             "selected_llm_model": self.selected_llm_model,
             "agentic_mode": self.agentic_mode,
+            "vanna_fallback_enabled": self.vanna_fallback_enabled,
         }
 
 

--- a/tests/agent/test_fallback.py
+++ b/tests/agent/test_fallback.py
@@ -1,0 +1,194 @@
+"""Unit tests for the Vanna-fallback decision engine (Feature #230 of Epic #228).
+
+Three primitives under test:
+  - ``detect_trigger`` — deterministic event classification.
+  - ``classify_answer_adequacy`` — 1-shot LLM judge (mocked).
+  - ``should_fallback`` — orchestrator that combines them.
+
+LLM calls in the classifier tests are mocked via pydantic-ai's TestModel
+(``custom_output_text``) for the happy/sad paths, and via a module-level
+patch of ``agent.fallback.Agent`` for the error path. No real provider
+calls are made.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+from agent.fallback import (
+    FallbackClassifierError,
+    FallbackDecision,
+    SQL_TOOL_NAMES,
+    classify_answer_adequacy,
+    detect_trigger,
+    should_fallback,
+)
+from agent.state import ToolCallStarted
+
+
+def _event(tool_name: str) -> ToolCallStarted:
+    return ToolCallStarted(tool_name=tool_name, arguments={})
+
+
+# ----- detect_trigger -----------------------------------------------------
+
+
+def test_sql_tool_names_constant_contents():
+    assert SQL_TOOL_NAMES == frozenset({"run_sql", "get_patient_clinical_data", "search_patients_by_criteria"})
+
+
+def test_detect_trigger_zero_tools():
+    assert detect_trigger([]) == "zero_tools"
+
+
+def test_detect_trigger_no_sql_tool_called():
+    events = [_event("search_knowledge_base"), _event("find_patient")]
+    assert detect_trigger(events) == "no_sql_tool"
+
+
+def test_detect_trigger_sql_tool_called():
+    events = [_event("search_knowledge_base"), _event("run_sql")]
+    assert detect_trigger(events) == "sql_tool_called"
+
+
+def test_detect_trigger_get_patient_clinical_data_counts():
+    assert detect_trigger([_event("get_patient_clinical_data")]) == "sql_tool_called"
+
+
+def test_detect_trigger_search_patients_by_criteria_counts():
+    assert detect_trigger([_event("search_patients_by_criteria")]) == "sql_tool_called"
+
+
+# ----- classify_answer_adequacy ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_classify_answer_adequacy_yes():
+    model = TestModel(custom_output_text="ADEQUATE")
+    assert await classify_answer_adequacy("q", "answer", model=model) is True
+
+
+@pytest.mark.asyncio
+async def test_classify_answer_adequacy_no():
+    model = TestModel(custom_output_text="INADEQUATE")
+    assert await classify_answer_adequacy("q", "answer", model=model) is False
+
+
+@pytest.mark.asyncio
+async def test_classify_answer_adequacy_ambiguous_treated_as_inadequate():
+    model = TestModel(custom_output_text="maybe sort of yes")
+    assert await classify_answer_adequacy("q", "answer", model=model) is False
+
+
+@pytest.mark.asyncio
+async def test_classify_answer_adequacy_lenient_whitespace_and_case():
+    model = TestModel(custom_output_text="  adequate\n")
+    assert await classify_answer_adequacy("q", "answer", model=model) is True
+
+
+@pytest.mark.asyncio
+async def test_classify_answer_adequacy_raises_on_llm_error(monkeypatch):
+    class _FailingAgent:
+        def __init__(self, *_a, **_k):
+            pass
+
+        async def run(self, *_a, **_k):
+            raise RuntimeError("LLM down")
+
+    monkeypatch.setattr("agent.fallback.Agent", _FailingAgent)
+    with pytest.raises(FallbackClassifierError, match="LLM down"):
+        await classify_answer_adequacy("q", "answer", model="injected-sentinel")
+
+
+# ----- should_fallback ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_should_fallback_feature_disabled_short_circuits(monkeypatch):
+    called = {"classifier": False}
+
+    async def _spy(*_a, **_k):
+        called["classifier"] = True
+        return True
+
+    monkeypatch.setattr("agent.fallback.classify_answer_adequacy", _spy)
+
+    decision = await should_fallback(
+        question="q",
+        final_text="answer",
+        tool_events=[],
+        feature_enabled=False,
+    )
+    assert decision == FallbackDecision(invoke=False, reason="feature_disabled")
+    assert called["classifier"] is False
+
+
+@pytest.mark.asyncio
+async def test_should_fallback_sql_tool_called_short_circuits(monkeypatch):
+    called = {"classifier": False}
+
+    async def _spy(*_a, **_k):
+        called["classifier"] = True
+        return True
+
+    monkeypatch.setattr("agent.fallback.classify_answer_adequacy", _spy)
+
+    decision = await should_fallback(
+        question="q",
+        final_text="answer",
+        tool_events=[_event("run_sql")],
+        feature_enabled=True,
+    )
+    assert decision == FallbackDecision(invoke=False, reason="sql_tool_called")
+    assert called["classifier"] is False
+
+
+@pytest.mark.asyncio
+async def test_should_fallback_classifier_says_inadequate_returns_invoke_true(monkeypatch):
+    async def _classify(*_a, **_k):
+        return False
+
+    monkeypatch.setattr("agent.fallback.classify_answer_adequacy", _classify)
+
+    decision = await should_fallback(
+        question="how many patients?",
+        final_text="I'm not sure what you mean.",
+        tool_events=[_event("search_knowledge_base")],
+        feature_enabled=True,
+    )
+    assert decision == FallbackDecision(invoke=True, reason="classifier_says_inadequate")
+
+
+@pytest.mark.asyncio
+async def test_should_fallback_classifier_says_adequate_returns_invoke_false(monkeypatch):
+    async def _classify(*_a, **_k):
+        return True
+
+    monkeypatch.setattr("agent.fallback.classify_answer_adequacy", _classify)
+
+    decision = await should_fallback(
+        question="what does hie_consent mean?",
+        final_text="HIE consent is a flag indicating ...",
+        tool_events=[],
+        feature_enabled=True,
+    )
+    assert decision == FallbackDecision(invoke=False, reason="classifier_says_adequate")
+
+
+@pytest.mark.asyncio
+async def test_should_fallback_classifier_error_fails_closed(monkeypatch):
+    async def _raising(*_a, **_k):
+        raise FallbackClassifierError("provider down")
+
+    monkeypatch.setattr("agent.fallback.classify_answer_adequacy", _raising)
+
+    decision = await should_fallback(
+        question="q",
+        final_text="answer",
+        tool_events=[],
+        feature_enabled=True,
+    )
+    assert decision.invoke is False
+    assert decision.reason == "classifier_error"
+    assert decision.classifier_error == "provider down"

--- a/tests/agent/test_run_logger_fallback.py
+++ b/tests/agent/test_run_logger_fallback.py
@@ -1,0 +1,113 @@
+"""Tests for the post-finalize ``mark_run_fallback_invoked`` helper
+(Feature #233 of Epic #228).
+
+The helper is module-level (not a method on ``AgentRunLogger``) because
+the fallback fires AFTER the original logger's session is closed by the
+agent runtime — we need a fresh session opened on the Streamlit script
+thread.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agent.run_logger import mark_run_fallback_invoked
+from orm.models import AgentRun, AgentRunEvent, Base
+
+
+def _session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _seed_run(session, *, run_id: str = "r1", status: str = "success") -> AgentRun:
+    run = AgentRun(
+        run_id=run_id,
+        session_id="s1",
+        user_id=1,
+        user_role=1,
+        question="q",
+        status=status,
+        success=(status == "success"),
+        logging_mode="full",
+    )
+    session.add(run)
+    # Seed a couple of pre-existing events so the helper's seq calculation
+    # has something to work against.
+    for seq in (1, 2, 3):
+        session.add(
+            AgentRunEvent(
+                run_id=run_id,
+                seq=seq,
+                event_type=f"placeholder_{seq}",
+            )
+        )
+    session.commit()
+    return run
+
+
+def test_mark_run_fallback_invoked_updates_status_and_sql():
+    s = _session()
+    _seed_run(s)
+
+    mark_run_fallback_invoked(s, run_id="r1", fallback_sql="SELECT 1")
+
+    run = s.query(AgentRun).filter_by(run_id="r1").one()
+    assert run.status == "fallback_invoked"
+    assert run.fallback_sql == "SELECT 1"
+    assert run.success is True  # original success flag preserved
+
+
+def test_mark_run_fallback_invoked_handles_missing_sql():
+    s = _session()
+    _seed_run(s)
+
+    mark_run_fallback_invoked(s, run_id="r1", fallback_sql=None)
+
+    run = s.query(AgentRun).filter_by(run_id="r1").one()
+    assert run.status == "fallback_invoked"
+    assert run.fallback_sql is None
+
+
+def test_mark_run_fallback_invoked_silently_handles_missing_run():
+    s = _session()
+    # No row seeded — the helper must NOT raise.
+    mark_run_fallback_invoked(s, run_id="does-not-exist", fallback_sql="SELECT 1")
+    # And no row appeared.
+    assert s.query(AgentRun).count() == 0
+
+
+def test_mark_run_fallback_invoked_emits_event_row():
+    s = _session()
+    _seed_run(s)  # writes 3 placeholder events at seq 1,2,3.
+
+    mark_run_fallback_invoked(s, run_id="r1", fallback_sql="SELECT 42")
+
+    ev = s.query(AgentRunEvent).filter_by(event_type="fallback_invoked").one()
+    assert ev.seq == 4  # one past the highest pre-existing seq
+    assert ev.payload_summary == "fallback_sql_chars=9"
+
+
+def test_mark_run_fallback_invoked_event_seq_for_run_without_prior_events():
+    s = _session()
+    # Seed an AgentRun without seeding any events.
+    run = AgentRun(
+        run_id="r-lonely",
+        session_id="s",
+        user_id=1,
+        user_role=1,
+        question="q",
+        status="success",
+        success=True,
+        logging_mode="full",
+    )
+    s.add(run)
+    s.commit()
+
+    mark_run_fallback_invoked(s, run_id="r-lonely", fallback_sql="X")
+
+    ev = s.query(AgentRunEvent).filter_by(run_id="r-lonely").one()
+    assert ev.seq == 1
+    assert ev.event_type == "fallback_invoked"

--- a/tests/agent/test_runtime_fallback.py
+++ b/tests/agent/test_runtime_fallback.py
@@ -1,0 +1,331 @@
+"""Unit tests for the runtime Vanna-fallback wiring (Feature #231 of Epic #228).
+
+The integration point lives in ``agent/runtime.py``:
+  - feature-flag helpers (``_is_fallback_feature_enabled``,
+    ``_is_scrubbed_logging``)
+  - the post-stream hook (``_maybe_invoke_vanna_fallback``)
+
+The consumer-loop event-collection logic inside
+``run_agentic_message_flow`` is a 4-line type check — exercised via the
+``isinstance`` sanity test below rather than by driving the whole loop.
+"""
+
+from __future__ import annotations
+
+import types
+from contextlib import nullcontext
+
+import pytest
+
+from agent.fallback import FallbackDecision
+from agent.state import (
+    FinalResponseEvent,
+    ToolCallCompleted,
+    ToolCallStarted,
+)
+
+
+def _fake_st(secrets: dict | None = None, session_state: dict | None = None):
+    """Build a minimal Streamlit double for the runtime helpers.
+
+    ``secrets.get`` mirrors the chained ``st.secrets.get("agent", {})
+    .get("fallback", {})...`` pattern in the production code.
+    ``session_state`` is exposed both as a dict (``.get``) and attribute
+    namespace.
+    """
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    if session_state:
+        st.session_state.update(session_state)
+
+    st.secrets = secrets if secrets is not None else {}
+    st.spinner = lambda *_a, **_k: nullcontext()
+    return st
+
+
+# ---------- _is_fallback_feature_enabled ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "secrets,opt_in,expected",
+    [
+        ({"agent": {"fallback": {"enabled": True}}}, True, True),
+        ({"agent": {"fallback": {"enabled": True}}}, False, False),
+        ({"agent": {"fallback": {"enabled": False}}}, True, False),
+        ({"agent": {"fallback": {"enabled": False}}}, False, False),
+        ({}, True, False),
+        ({"agent": {}}, True, False),
+        ({"agent": {"fallback": {}}}, True, False),
+    ],
+)
+def test_is_fallback_feature_enabled_requires_both_flags(monkeypatch, secrets, opt_in, expected):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(secrets=secrets, session_state={"vanna_fallback_enabled": opt_in})
+    monkeypatch.setattr(runtime, "st", fake_st)
+    assert runtime._is_fallback_feature_enabled() is expected
+
+
+def test_is_fallback_feature_enabled_handles_missing_session_key(monkeypatch):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(secrets={"agent": {"fallback": {"enabled": True}}})
+    monkeypatch.setattr(runtime, "st", fake_st)
+    # session-state key missing entirely — must default to False.
+    assert runtime._is_fallback_feature_enabled() is False
+
+
+# ---------- _is_scrubbed_logging ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "secrets,expected",
+    [
+        ({"agent_logging": {"mode": "scrubbed"}}, True),
+        ({"agent_logging": {"mode": "full"}}, False),
+        ({"agent_logging": {"mode": "disabled"}}, False),
+        ({"agent_logging": {}}, False),
+        ({}, False),
+    ],
+)
+def test_is_scrubbed_logging(monkeypatch, secrets, expected):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st(secrets=secrets)
+    monkeypatch.setattr(runtime, "st", fake_st)
+    assert runtime._is_scrubbed_logging() is expected
+
+
+# ---------- _maybe_invoke_vanna_fallback ---------------------------------
+
+
+def _patch_chat_bot_helper(monkeypatch, on_call=None):
+    """Patch the lazy-imported chat_bot_helper symbols.
+
+    Returns a ``calls`` list that records each invocation. The first
+    string per entry is "add_message" or "vanna"; the second is the
+    payload.
+    """
+    calls: list[tuple[str, object]] = []
+
+    def _fake_add_message(msg, render=True):
+        calls.append(("add_message", msg))
+
+    def _fake_run_vanna_flow(question):
+        calls.append(("vanna", question))
+        if on_call is not None:
+            on_call()
+
+    import utils.chat_bot_helper as cbh
+
+    monkeypatch.setattr(cbh, "add_message", _fake_add_message)
+    monkeypatch.setattr(cbh, "_run_vanna_flow", _fake_run_vanna_flow)
+    return calls
+
+
+def test_maybe_invoke_vanna_fallback_short_circuits_when_feature_disabled(monkeypatch):
+    import agent.runtime as runtime
+
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: False)
+
+    run_async_calls = []
+
+    def _spy_run_async(coro):
+        run_async_calls.append(coro)
+        coro.close()
+        return None
+
+    monkeypatch.setattr(runtime, "_run_async", _spy_run_async)
+    calls = _patch_chat_bot_helper(monkeypatch)
+
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [])
+
+    assert run_async_calls == []
+    assert calls == []
+
+
+def test_maybe_invoke_vanna_fallback_skips_when_decision_says_no(monkeypatch):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _mock_run_async(coro):
+        coro.close()
+        return FallbackDecision(invoke=False, reason="classifier_says_adequate")
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+    calls = _patch_chat_bot_helper(monkeypatch)
+
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [])
+
+    assert calls == []
+
+
+def test_maybe_invoke_vanna_fallback_invokes_vanna_when_decision_says_yes(monkeypatch):
+    import agent.runtime as runtime
+    from utils.enums import MessageType, RoleType
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _mock_run_async(coro):
+        coro.close()
+        return FallbackDecision(invoke=True, reason="classifier_says_inadequate")
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+    calls = _patch_chat_bot_helper(monkeypatch)
+
+    runtime._maybe_invoke_vanna_fallback("how many patients?", "I'm not sure.", [])
+
+    # Banner first, then Vanna call.
+    assert len(calls) == 2
+    kind0, msg = calls[0]
+    assert kind0 == "add_message"
+    assert msg.role == RoleType.ASSISTANT.value
+    assert msg.type == MessageType.TEXT.value
+    assert "falling back to direct SQL" in msg.content
+
+    kind1, question = calls[1]
+    assert kind1 == "vanna"
+    assert question == "how many patients?"
+
+
+def test_maybe_invoke_vanna_fallback_swallows_classifier_exception(monkeypatch):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _raising_run_async(coro):
+        coro.close()
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(runtime, "_run_async", _raising_run_async)
+    calls = _patch_chat_bot_helper(monkeypatch)
+
+    # Must NOT raise. Must NOT invoke Vanna.
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [])
+
+    assert calls == []
+
+
+def test_maybe_invoke_vanna_fallback_passes_scrubbed_flag(monkeypatch):
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: True)
+
+    captured: dict = {}
+
+    async def _spy_should_fallback(**kwargs):
+        captured.update(kwargs)
+        return FallbackDecision(invoke=False, reason="classifier_says_adequate")
+
+    monkeypatch.setattr(runtime, "should_fallback", _spy_should_fallback)
+
+    def _mock_run_async(coro):
+        # Drive the spy coroutine to completion in the test loop so we
+        # capture its kwargs, then return what the spy yielded.
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+    _patch_chat_bot_helper(monkeypatch)
+
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [])
+
+    assert captured.get("scrubbed") is True
+    assert captured.get("question") == "q?"
+    assert captured.get("final_text") == "answer"
+    assert captured.get("feature_enabled") is True
+
+
+def test_maybe_invoke_vanna_fallback_passes_tool_events(monkeypatch):
+    """The tool-event list captured during the consumer loop must reach
+    should_fallback verbatim — it's how the decision engine knows which
+    tools (if any) the agent actually called.
+    """
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    captured: dict = {}
+
+    async def _spy_should_fallback(**kwargs):
+        captured.update(kwargs)
+        return FallbackDecision(invoke=False, reason="classifier_says_adequate")
+
+    monkeypatch.setattr(runtime, "should_fallback", _spy_should_fallback)
+
+    def _mock_run_async(coro):
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+    _patch_chat_bot_helper(monkeypatch)
+
+    events = [
+        ToolCallStarted(tool_name="search_knowledge_base", arguments={}),
+        ToolCallStarted(tool_name="find_patient", arguments={"first_name": "Jane"}),
+    ]
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", events)
+
+    assert captured.get("tool_events") == events
+
+
+# ---------- consumer-loop event classification ----------------------------
+
+
+def test_isinstance_check_distinguishes_tool_events_from_others():
+    """The runtime's consumer loop uses ``isinstance(event,
+    (ToolCallStarted, ToolCallCompleted))`` to accumulate tool events
+    and ``isinstance(event, FinalResponseEvent)`` to capture the final
+    text. Pin the type-check semantics so neither class is accidentally
+    dropped from the tuple later.
+    """
+    started = ToolCallStarted(tool_name="run_sql", arguments={"sql": "SELECT 1"})
+    completed = ToolCallCompleted(
+        tool_name="run_sql",
+        result_summary="ok",
+        success=True,
+        elapsed_ms=42,
+    )
+
+    assert isinstance(started, (ToolCallStarted, ToolCallCompleted))
+    assert isinstance(completed, (ToolCallStarted, ToolCallCompleted))
+    # FinalResponseEvent must NOT match the tool-event tuple — otherwise
+    # the consumer loop would over-collect.
+    from agent.state import AgentResponse
+
+    final = FinalResponseEvent(
+        response=AgentResponse(text="done"),
+        all_messages=[],
+        usage=None,
+    )
+    assert not isinstance(final, (ToolCallStarted, ToolCallCompleted))
+    assert isinstance(final, FinalResponseEvent)

--- a/tests/agent/test_runtime_fallback.py
+++ b/tests/agent/test_runtime_fallback.py
@@ -298,6 +298,129 @@ def test_maybe_invoke_vanna_fallback_passes_tool_events(monkeypatch):
     assert captured.get("tool_events") == events
 
 
+# ---------- mark_run_fallback_invoked wiring (Feature #233) ---------------
+
+
+def test_maybe_invoke_vanna_fallback_marks_run_before_invoking_vanna(monkeypatch):
+    """Audit ordering: the agent run must be marked `fallback_invoked`
+    BEFORE _run_vanna_flow is called. If we marked it after, a Vanna
+    failure would leave the audit row stuck at `status='success'` while
+    the user saw the fallback attempt.
+    """
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _mock_run_async(coro):
+        coro.close()
+        return FallbackDecision(invoke=True, reason="classifier_says_inadequate")
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+
+    # Spy that records the order of operations across mark-then-vanna.
+    call_log: list[tuple] = []
+
+    def _spy_mark(run_id, fallback_sql):
+        call_log.append(("mark", run_id, fallback_sql))
+
+    monkeypatch.setattr(runtime, "_mark_fallback_invoked_safely", _spy_mark)
+
+    import utils.chat_bot_helper as cbh
+
+    monkeypatch.setattr(cbh, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(cbh, "_run_vanna_flow", lambda q: call_log.append(("vanna", q)))
+
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [], run_id="r-abc")
+
+    # First call is the pre-invocation mark with no SQL yet.
+    assert call_log[0] == ("mark", "r-abc", None)
+    # Second is the Vanna invocation.
+    assert call_log[1] == ("vanna", "q?")
+
+
+def test_maybe_invoke_vanna_fallback_persists_sql_on_rerun(monkeypatch):
+    """When _run_vanna_flow raises RerunException, the runtime must read
+    the breadcrumb session-state key and mark the run a SECOND time
+    with the captured SQL before re-raising.
+    """
+    import agent.runtime as runtime
+
+    class RerunException(BaseException):
+        pass
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _mock_run_async(coro):
+        coro.close()
+        return FallbackDecision(invoke=True, reason="classifier_says_inadequate")
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+
+    mark_calls: list[tuple] = []
+    monkeypatch.setattr(
+        runtime,
+        "_mark_fallback_invoked_safely",
+        lambda run_id, fallback_sql: mark_calls.append((run_id, fallback_sql)),
+    )
+
+    def _fake_vanna(question):
+        fake_st.session_state["_last_vanna_fallback_sql"] = "SELECT 42"
+        raise RerunException()
+
+    import utils.chat_bot_helper as cbh
+
+    monkeypatch.setattr(cbh, "add_message", lambda *_a, **_k: None)
+    monkeypatch.setattr(cbh, "_run_vanna_flow", _fake_vanna)
+
+    # The RerunException must propagate so Streamlit handles the rerun.
+    try:
+        runtime._maybe_invoke_vanna_fallback("q?", "answer", [], run_id="r-xyz")
+    except BaseException as exc:
+        assert type(exc).__name__ == "RerunException"
+    else:
+        raise AssertionError("RerunException was not propagated")
+
+    # Two mark calls: one before Vanna with NULL SQL, one after with the
+    # captured SQL.
+    assert mark_calls == [("r-xyz", None), ("r-xyz", "SELECT 42")]
+
+
+def test_maybe_invoke_vanna_fallback_skips_mark_when_run_id_is_none(monkeypatch):
+    """run_id may be None when agent run logging is disabled. The mark
+    helper must be a no-op in that case — no DB session opened.
+    """
+    import agent.runtime as runtime
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(runtime, "st", fake_st)
+    monkeypatch.setattr(runtime, "_is_fallback_feature_enabled", lambda: True)
+    monkeypatch.setattr(runtime, "_is_scrubbed_logging", lambda: False)
+
+    def _mock_run_async(coro):
+        coro.close()
+        return FallbackDecision(invoke=False, reason="classifier_says_adequate")
+
+    monkeypatch.setattr(runtime, "_run_async", _mock_run_async)
+
+    mark_calls = []
+    monkeypatch.setattr(
+        runtime,
+        "mark_run_fallback_invoked",
+        lambda *_a, **_k: mark_calls.append("called"),
+    )
+
+    runtime._maybe_invoke_vanna_fallback("q?", "answer", [], run_id=None)
+
+    # Decision said no-fallback AND run_id was None, so mark was never reached.
+    assert mark_calls == []
+
+
 # ---------- consumer-loop event classification ----------------------------
 
 

--- a/tests/orm/test_vanna_fallback_pref.py
+++ b/tests/orm/test_vanna_fallback_pref.py
@@ -1,0 +1,150 @@
+"""Per-user Vanna-fallback opt-in (Feature #232 of Epic #228).
+
+Covers:
+  - ORM column exists with default False.
+  - Round-trip persistence.
+  - set_user_preferences_in_session_state mirrors the column to
+    st.session_state.vanna_fallback_enabled on login.
+  - save_user_settings writes the session-state value back to the DB.
+"""
+
+from __future__ import annotations
+
+import types
+from contextlib import nullcontext
+
+from orm.functions import (
+    create_user,
+    save_user_settings,
+    set_user_preferences_in_session_state,
+)
+from orm.models import User, UserRole
+
+
+def _seed_user(session_factory, *, username: str = "fallback_test_user") -> int:
+    with session_factory() as session:
+        role_id = session.query(UserRole).filter(UserRole.role_name == "Doctor").one().id
+    assert (
+        create_user(
+            username,
+            "pw",
+            "Fall",
+            "Back",
+            role_id,
+            email=f"{username}@example.com",
+            organization="Acme",
+        )
+        is True
+    )
+    with session_factory() as session:
+        return session.query(User).filter(User.username == username).one().id
+
+
+def _fake_st():
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    st.session_state["cookies"] = {}
+    st.chat_message = lambda *_a, **_k: nullcontext()
+    st.empty = lambda: None
+    st.rerun = lambda: None
+    st.toast = lambda *_a, **_k: None
+    st.markdown = lambda *_a, **_k: None
+    st.error = lambda *_a, **_k: None
+    return st
+
+
+def test_vanna_fallback_enabled_column_exists_and_defaults_false(in_memory_orm_session):
+    user_id = _seed_user(in_memory_orm_session)
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        # Column exists and default kicks in (False) for a freshly-created row.
+        assert hasattr(user, "vanna_fallback_enabled")
+        assert user.vanna_fallback_enabled is False
+
+
+def test_vanna_fallback_enabled_round_trip(in_memory_orm_session):
+    user_id = _seed_user(in_memory_orm_session)
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        user.vanna_fallback_enabled = True
+        session.commit()
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        assert user.vanna_fallback_enabled is True
+
+
+def test_set_user_preferences_loads_vanna_fallback_into_session_state(monkeypatch, in_memory_orm_session):
+    import json as _json
+
+    user_id = _seed_user(in_memory_orm_session)
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        user.vanna_fallback_enabled = True
+        session.commit()
+
+    fake_st = _fake_st()
+    fake_st.session_state["cookies"] = {"user_id": _json.dumps(user_id)}
+    import orm.functions as fns
+
+    monkeypatch.setattr(fns, "st", fake_st)
+
+    set_user_preferences_in_session_state()
+
+    assert fake_st.session_state.vanna_fallback_enabled is True
+
+
+def test_save_user_settings_writes_vanna_fallback_back_to_db(monkeypatch, in_memory_orm_session):
+    import json as _json
+
+    user_id = _seed_user(in_memory_orm_session)
+
+    fake_st = _fake_st()
+    fake_st.session_state["cookies"] = {"user_id": _json.dumps(user_id)}
+    # Populate every key save_user_settings reads so it doesn't AttributeError.
+    fake_st.session_state.update(
+        {
+            "show_sql": True,
+            "show_table": True,
+            "show_plotly_code": True,
+            "show_chart": True,
+            "show_question_history": True,
+            "show_summary": True,
+            "voice_input": False,
+            "speak_summary": False,
+            "show_suggested": False,
+            "show_followup": False,
+            "show_elapsed_time": True,
+            "show_thinking_process": False,
+            "llm_fallback": False,
+            "vanna_fallback_enabled": True,
+            "confirm_magic_commands": True,
+            "show_community_engagement": False,
+            "min_message_id": 0,
+            "selected_llm_provider": None,
+            "selected_llm_model": None,
+        }
+    )
+
+    import orm.functions as fns
+
+    monkeypatch.setattr(fns, "st", fake_st)
+
+    save_user_settings()
+
+    with in_memory_orm_session() as session:
+        user = session.query(User).filter(User.id == user_id).one()
+        assert user.vanna_fallback_enabled is True

--- a/tests/utils/test_chat_bot_helper_dispatch.py
+++ b/tests/utils/test_chat_bot_helper_dispatch.py
@@ -75,6 +75,27 @@ def test_dispatcher_routes_to_agent_when_agentic_mode_on(monkeypatch):
     assert vanna_calls == []
 
 
+def test_run_vanna_flow_writes_breadcrumb_for_audit():
+    """Feature #233 audit breadcrumb: _run_vanna_flow must stash the
+    final SQL into st.session_state['_last_vanna_fallback_sql'] right
+    before each st.rerun() call. The agent runtime reads this key
+    inside its RerunException handler to populate AgentRun.fallback_sql.
+
+    Cheap pin: assert the literal key appears in the function's source
+    so the breadcrumb can't be accidentally removed without breaking
+    this test.
+    """
+    import inspect
+
+    import utils.chat_bot_helper as cbh
+
+    source = inspect.getsource(cbh._run_vanna_flow)
+    assert source.count('"_last_vanna_fallback_sql"') >= 2, (
+        "Vanna flow must write the audit breadcrumb on BOTH rerun paths "
+        "(success and error). See Feature #233 / Epic #228."
+    )
+
+
 def test_dispatcher_routes_to_vanna_when_agentic_mode_off(monkeypatch):
     import utils.chat_bot_helper as cbh
 

--- a/tests/utils/test_chat_bot_helper_dispatch.py
+++ b/tests/utils/test_chat_bot_helper_dispatch.py
@@ -1,0 +1,96 @@
+"""Pins the Vanna-flow dispatcher contract (Feature #229, Epic #228).
+
+`_run_message_flow` is the seam between the agentic and legacy Vanna paths.
+The Vanna body was extracted into `_run_vanna_flow` so it can be invoked
+independently — both directly from the dispatcher and (in Feature #231) as
+the agent's fallback path. These tests defend against accidental re-inlining
+of the Vanna body back into the dispatcher.
+"""
+
+import inspect
+import types
+from contextlib import nullcontext
+
+
+def _fake_st():
+    st = types.SimpleNamespace()
+
+    class _State(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError:
+                raise AttributeError(k)
+
+        def __setattr__(self, k, v):
+            self[k] = v
+
+    st.session_state = _State()
+    st.chat_message = lambda *_a, **_k: nullcontext()
+    st.empty = lambda: None
+    st.rerun = lambda: None
+    st.toast = lambda *_a, **_k: None
+    st.markdown = lambda *_a, **_k: None
+    return st
+
+
+def test_run_vanna_flow_is_a_callable_with_question_param():
+    from utils.chat_bot_helper import _run_vanna_flow
+
+    assert callable(_run_vanna_flow)
+    sig = inspect.signature(_run_vanna_flow)
+    assert list(sig.parameters) == ["my_question"]
+
+
+def test_run_message_flow_is_a_callable_with_question_param():
+    from utils.chat_bot_helper import _run_message_flow
+
+    assert callable(_run_message_flow)
+    sig = inspect.signature(_run_message_flow)
+    assert list(sig.parameters) == ["my_question"]
+
+
+def test_dispatcher_routes_to_agent_when_agentic_mode_on(monkeypatch):
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    fake_st.session_state["agentic_mode"] = True
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    agent_calls = []
+
+    def _fake_agent_flow(q):
+        agent_calls.append(q)
+
+    import agent.runtime as runtime_mod
+
+    monkeypatch.setattr(runtime_mod, "run_agentic_message_flow", _fake_agent_flow)
+
+    vanna_calls = []
+    monkeypatch.setattr(cbh, "_run_vanna_flow", lambda q: vanna_calls.append(q))
+
+    cbh._run_message_flow("how many patients?")
+
+    assert agent_calls == ["how many patients?"]
+    assert vanna_calls == []
+
+
+def test_dispatcher_routes_to_vanna_when_agentic_mode_off(monkeypatch):
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    fake_st.session_state["agentic_mode"] = False
+    monkeypatch.setattr(cbh, "st", fake_st)
+
+    vanna_calls = []
+    monkeypatch.setattr(cbh, "_run_vanna_flow", lambda q: vanna_calls.append(q))
+
+    import agent.runtime as runtime_mod
+
+    agent_calls = []
+    monkeypatch.setattr(runtime_mod, "run_agentic_message_flow", lambda q: agent_calls.append(q))
+
+    cbh._run_message_flow("how many patients?")
+
+    assert vanna_calls == ["how many patients?"]
+    assert agent_calls == []

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1350,10 +1350,7 @@ def normal_message_flow(my_question: str):
         # gave them no signal to wait. Branch the wording so a known-
         # transient cause reads as "wait, then retry" instead of "broken".
         if looks_like_model_timeout(e):
-            body = (
-                "The AI model is slow or temporarily unreachable. "
-                "Please wait a moment and try again."
-            )
+            body = "The AI model is slow or temporarily unreachable. Please wait a moment and try again."
         else:
             body = f"Something went wrong while processing your question.\n\n{e}"
         try:
@@ -1831,6 +1828,12 @@ def _run_vanna_flow(my_question: str):
         # Clear the question from session state after successful processing
         st.session_state.my_question = None
 
+        # Breadcrumb for the agent's Vanna fallback (Epic #228 / Feature
+        # #233). Lets agent.runtime._maybe_invoke_vanna_fallback capture
+        # the SQL we ran after st.rerun() raises RerunException. No-op
+        # for legacy users (the key is just never read).
+        st.session_state["_last_vanna_fallback_sql"] = final_sql
+
         # Trigger a rerun to properly refresh the UI
         st.rerun()
     elif final_sql:
@@ -1917,6 +1920,11 @@ def _run_vanna_flow(my_question: str):
 
         # Clear the question from session state after error processing
         st.session_state.my_question = None
+
+        # Breadcrumb for the agent's Vanna fallback (Epic #228 / Feature
+        # #233). On the error path, prefer the last SQL we actually
+        # tried so the audit reflects what was attempted.
+        st.session_state["_last_vanna_fallback_sql"] = last_failed_sql or final_sql
 
         # Trigger a rerun to properly refresh the UI
         st.rerun()

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1391,6 +1391,24 @@ def _run_message_flow(my_question: str):
         from agent.runtime import run_agentic_message_flow
 
         return run_agentic_message_flow(my_question)
+    return _run_vanna_flow(my_question)
+
+
+def _run_vanna_flow(my_question: str):
+    """Legacy single-shot Vanna SQL pipeline.
+
+    Generates SQL from the question via Vanna+RAG, runs it against
+    [postgres], renders DataFrame / chart / summary, and persists the
+    turn as orm.Message rows.
+
+    THREAD: must run on the Streamlit script thread — touches
+    st.session_state and renders widgets. Do NOT invoke from the
+    agent's asyncio loop thread.
+
+    Per Epic #228, this function will also be invoked as the agent's
+    fallback path when the agent finishes a turn without retrieving
+    data (wired in Feature #231).
+    """
     # ----- existing Vanna flow follows unchanged -----
     # Ethical guardrails temporarily disabled for training/testing
     # guardrail_sentence, guardrail_score = get_ethical_guideline(my_question)

--- a/views/chat_bot.py
+++ b/views/chat_bot.py
@@ -406,6 +406,38 @@ def _render_agentic_section():
         except Exception:
             pass
 
+    # Vanna-fallback opt-in (Epic #228 / Feature #232). Renders only when
+    # agentic_mode is on — the fallback hook fires from the agentic
+    # runtime, so the toggle is meaningless in legacy mode.
+    if agentic_mode:
+        vanna_fallback_initial = bool(
+            getattr(st.session_state.get("user"), "vanna_fallback_enabled", False)
+            if st.session_state.get("user")
+            else st.session_state.get("vanna_fallback_enabled", False)
+        )
+        vanna_fallback_enabled = st.checkbox(
+            "Auto-fallback to Vanna when agent doesn't query data",
+            value=vanna_fallback_initial,
+            help=(
+                "When the agent finishes a turn without retrieving data and "
+                "a one-shot classifier judges the answer inadequate, retry "
+                "the same question through the legacy Vanna SQL pipeline. "
+                "Requires [agent.fallback].enabled = true in secrets."
+            ),
+            key="vanna_fallback_enabled_dialog_checkbox",
+        )
+        st.session_state.vanna_fallback_enabled = vanna_fallback_enabled
+        if vanna_fallback_enabled != vanna_fallback_initial:
+            try:
+                import json as _json
+
+                _uid_str = st.session_state.cookies.get("user_id")
+                if _uid_str:
+                    _uid = _json.loads(_uid_str)
+                    update_user_preferences(user_id=_uid, vanna_fallback_enabled=vanna_fallback_enabled)
+            except Exception:
+                pass
+
 
 def _settings_dialog_body():
     """Pure body of the Settings dialog. Split from the ``@st.dialog``-


### PR DESCRIPTION
Tracks Epic #228 — automatic Vanna fallback when the agent finishes a turn without retrieving data.

This PR is shipped in 5 incremental commits, one per child Feature:

- [x] #229 — Extract Vanna flow into a callable function (`_run_vanna_flow`)
- [x] #230 — Fallback decision engine (classifier + trigger detection)
- [x] #231 — Runtime dispatch + append-style fallback rendering
- [x] #232 — Per-user opt-in (secrets flag + `User` column + sidebar)
- [x] #233 — Audit fallback in `agent_run` (status + `fallback_sql` column)

All 5 children landed. Per-child `reviewing-code-and-fix` ran clean on each commit. Marking ready for human review.

Closes #229
Closes #230
Closes #231
Closes #232
Closes #233

## Known limitation — multi-turn references to a fallback result

Per the design choice locked in during Epic refinement ("Vanna fallback result does NOT enter `agent_message_history`"), the agent has **no transcript record of a Vanna fallback result on subsequent turns**. The user sees the fallback's SQL + table in the chat UI, but the agent's pydantic-ai message history only contains the agent's own (failed) attempt.

**Practical effect:** if turn N fires a fallback and the user's turn N+1 naturally references the fallback result (e.g. "select the patient Blaine377 Kiehn525" after a previous fallback surfaced that patient via Vanna SQL), the agent's `find_patient` may be called with confused/empty arguments because its history shows no prior chooser/patient mention. The visible UI seems to carry context but the agent's transcript does not.

**Workarounds for users:**
- Click **🧹 Reset agent** between a fallback turn and a follow-up that references it. Or just **Clear** the chat.
- Re-state the identifier explicitly in the follow-up (e.g. "find patient Blaine377 Kiehn525" instead of "select the patient Blaine377 Kiehn525").

**Path forward (deferred):** the "synthesize a tool-result in agent_message_history" option was explicitly considered and not chosen for this Epic (`docs/...` design Q&A). A follow-up could inject a synthetic tool call + result into the history when a fallback fires, so subsequent agent turns see what the user saw. That changes the audit story (the transcript would contain a tool call that didn't actually go through pydantic-ai), so it needs its own design decision and ticket — file as a new Feature against Epic #228 if you want it.