### PR TITLE
feat(admin-evals): activate curated drafts from the Evaluations panel

### DIFF
--- a/orm/evaluation_functions.py
+++ b/orm/evaluation_functions.py
@@ -232,9 +232,7 @@ def record_final_verdict(
     with SessionLocal() as session:
         try:
             _require_admin(session, admin_user_id)
-            result = (
-                session.query(EvaluationCaseResult).filter(EvaluationCaseResult.id == result_id).one_or_none()
-            )
+            result = session.query(EvaluationCaseResult).filter(EvaluationCaseResult.id == result_id).one_or_none()
             if result is None:
                 raise EvaluationServiceError(f"Evaluation result {result_id} not found.")
             old_verdict = result.final_verdict
@@ -277,9 +275,7 @@ def _persist_case_execution(session: Session, run: EvaluationRun, result: Evalua
     increment)."""
     result.status = execution.status  # "completed" | "failed"
     result.completed_at = datetime.now(timezone.utc)
-    result.result_json = json.dumps(
-        {"patient": execution.patient, "turns": list(execution.turns)}, default=str
-    )
+    result.result_json = json.dumps({"patient": execution.patient, "turns": list(execution.turns)}, default=str)
     result.error_type = execution.error_type
     result.error_message = execution.error_message
     if execution.status == "completed":
@@ -383,9 +379,7 @@ async def run_evaluation_cases(run_id: str, resources, *, heartbeat=None) -> Eva
                 session.commit()
                 return view
 
-            case_row = (
-                session.query(EvaluationCase).filter(EvaluationCase.id == result.evaluation_case_id).one()
-            )
+            case_row = session.query(EvaluationCase).filter(EvaluationCase.id == result.evaluation_case_id).one()
             payload = json.loads(case_row.payload_json)
             result.status = "running"
             result.started_at = datetime.now(timezone.utc)
@@ -715,6 +709,35 @@ def list_curated_cases(admin_user_id: int, include_drafts: bool = False) -> list
                 pass
             out.append({"id": case.id, "case_id": case.case_id, "status": case.status, "title": title})
         return out
+
+
+def activate_curated_case(case_id: int, admin_user_id: int) -> None:
+    """Promote a draft curated case to ``active`` so it joins the runnable suite.
+
+    Idempotent for already-active cases; raises if the case is missing, not
+    curated, or in a non-activatable status (e.g. ``expired``)."""
+    with SessionLocal() as session:
+        try:
+            _require_admin(session, admin_user_id)
+            case = (
+                session.query(EvaluationCase)
+                .filter(
+                    EvaluationCase.id == case_id,
+                    EvaluationCase.source_type == "curated",
+                )
+                .one_or_none()
+            )
+            if case is None:
+                raise EvaluationServiceError("Curated case not found.")
+            if case.status == "active":
+                return
+            if case.status != "draft":
+                raise EvaluationServiceError(f"Only draft curated cases can be activated (status: {case.status}).")
+            case.status = "active"
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
 
 
 def launch_evaluation(case_ids: list[int], admin_user_id: int, resources=None) -> EvaluationRunView:

--- a/tests/evals/test_review_workflow.py
+++ b/tests/evals/test_review_workflow.py
@@ -152,3 +152,99 @@ def test_final_verdict_flows_into_report(eval_db, monkeypatch):
     report = get_evaluation_run_report(run_id, admin_id)
     assert report["cases"][0]["final_verdict"] == "incorrect"
     assert report["cases"][0]["review_note"] == "date wrong"
+
+
+def _curated_draft(session, admin_id, case_id="cd1"):
+    payload = NormalizedCase(
+        case_id=case_id,
+        version=1,
+        source_type="curated",
+        title="draft title",
+        patient_source_id="",
+        patient_label="",
+        turns=(NormalizedTurn(role="main", prompt="Reusable Q?"),),
+    ).to_payload()
+    case = EvaluationCase(
+        case_id=case_id,
+        version=1,
+        source_type="curated",
+        status="draft",
+        payload_json=json.dumps(payload),
+        created_by=admin_id,
+    )
+    session.add(case)
+    session.flush()
+    return case
+
+
+def test_activate_curated_case_flips_draft_to_active(eval_db):
+    from orm.evaluation_functions import activate_curated_case, list_curated_cases
+
+    with eval_db() as s:
+        admin = _user(s, role=RoleTypeEnum.ADMIN, username="admin")
+        draft = _curated_draft(s, admin.id)
+        s.commit()
+        admin_id, case_pk = admin.id, draft.id
+
+    # Draft absent from the active suite, present once drafts are included.
+    assert list_curated_cases(admin_id) == []
+    assert [c["status"] for c in list_curated_cases(admin_id, include_drafts=True)] == ["draft"]
+
+    activate_curated_case(case_pk, admin_id)
+
+    active = list_curated_cases(admin_id)
+    assert [c["id"] for c in active] == [case_pk]
+    assert active[0]["status"] == "active"
+
+
+def test_activate_curated_case_is_idempotent(eval_db):
+    from orm.evaluation_functions import activate_curated_case
+
+    with eval_db() as s:
+        admin = _user(s, role=RoleTypeEnum.ADMIN, username="admin")
+        draft = _curated_draft(s, admin.id)
+        s.commit()
+        admin_id, case_pk = admin.id, draft.id
+
+    activate_curated_case(case_pk, admin_id)
+    activate_curated_case(case_pk, admin_id)  # no error the second time
+
+
+def test_activate_curated_case_rejects_missing(eval_db):
+    from orm.evaluation_functions import EvaluationServiceError, activate_curated_case
+
+    with eval_db() as s:
+        admin = _user(s, role=RoleTypeEnum.ADMIN, username="admin")
+        s.commit()
+        admin_id = admin.id
+
+    with pytest.raises(EvaluationServiceError):
+        activate_curated_case(9999, admin_id)
+
+
+def test_activate_curated_case_rejects_expired(eval_db):
+    from orm.evaluation_functions import EvaluationServiceError, activate_curated_case
+
+    with eval_db() as s:
+        admin = _user(s, role=RoleTypeEnum.ADMIN, username="admin")
+        draft = _curated_draft(s, admin.id)
+        draft.status = "expired"
+        s.commit()
+        admin_id, case_pk = admin.id, draft.id
+
+    with pytest.raises(EvaluationServiceError):
+        activate_curated_case(case_pk, admin_id)
+
+
+def test_activate_curated_case_rejects_non_admin(eval_db):
+    from orm.evaluation_functions import activate_curated_case
+
+    with eval_db() as s:
+        admin = _user(s, role=RoleTypeEnum.ADMIN, username="admin")
+        doctor = _user(s, role=RoleTypeEnum.DOCTOR, username="doc")
+        draft = _curated_draft(s, admin.id)
+        s.commit()
+        doc_id, case_pk = doctor.id, draft.id
+
+    with pytest.raises(PermissionError):
+        activate_curated_case(case_pk, doc_id)

--- a/views/admin_evaluations.py
+++ b/views/admin_evaluations.py
@@ -19,6 +19,7 @@ import streamlit as st
 from evals.cases import CuratedCaseDraft, SnapshotUnavailable, promote_feedback_case, snapshot_feedback_case
 from orm.evaluation_functions import (
     EvaluationServiceError,
+    activate_curated_case,
     get_evaluation_run_report,
     launch_evaluation,
     list_admin_notifications,
@@ -196,10 +197,36 @@ def _render_feedback_source(admin_id: int, days_int: int) -> None:
             _launch(case_ids, admin_id)
 
 
+def _render_curated_drafts(admin_id: int, drafts: list[dict]) -> None:
+    """Show promoted-but-inactive curated drafts, each with an activation button.
+
+    Activating flips the draft to ``active`` so it joins the runnable suite."""
+    if not drafts:
+        return
+    with st.expander(f"Draft curated cases ({len(drafts)}) — review, then activate", expanded=False):
+        st.caption("Promoted feedback cases are saved as drafts. Activate one to add it to the runnable suite.")
+        for draft in drafts:
+            cols = st.columns([0.8, 0.2])
+            cols[0].write(draft["title"] or draft["case_id"])
+            if cols[1].button("Activate", key=f"activate_draft_{draft['id']}"):
+                try:
+                    activate_curated_case(draft["id"], admin_id)
+                except EvaluationServiceError as exc:
+                    st.error(str(exc))
+                else:
+                    st.toast("Curated case activated.")
+                    st.rerun()
+
+
 def _render_curated_source(admin_id: int) -> None:
-    cases = list_curated_cases(admin_id)
+    all_cases = list_curated_cases(admin_id, include_drafts=True)
+    drafts = [c for c in all_cases if c["status"] == "draft"]
+    cases = [c for c in all_cases if c["status"] == "active"]
+
+    _render_curated_drafts(admin_id, drafts)
+
     if not cases:
-        st.info("No active curated evaluation cases. Promote a reviewed feedback case to build the suite.")
+        st.info("No active curated evaluation cases. Promote a reviewed feedback case, then activate the draft.")
         return
 
     df = pd.DataFrame(cases)


### PR DESCRIPTION
## Problem

Promoting a thumbs-down feedback case creates a curated case with `status="draft"` (`evals/cases.py:promote_feedback_case`). But the **Curated suite** launcher calls `list_curated_cases(admin_id)` with the default `include_drafts=False`, so it only lists `active` cases. A promoted draft could never reach the runnable suite without a manual DB `UPDATE`.

## Change

- **Service:** new `activate_curated_case(case_id, admin_user_id)` in `orm/evaluation_functions.py` — admin-gated, flips `draft → active`. Idempotent for already-active cases; raises `EvaluationServiceError` for missing/non-draft (e.g. `expired`) cases.
- **UI:** `views/admin_evaluations.py` Curated-suite source now fetches with `include_drafts=True` and renders a **"Draft curated cases (N)"** expander. Each draft has an **Activate** button that promotes it into the active suite and reruns. The empty-state copy now points admins at activation.

## Tests

Added 5 tests in `tests/evals/test_review_workflow.py` (activate flips draft→active, idempotency, rejects missing/expired, rejects non-admin). Full `tests/evals/` suite: 89 passed. Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)