### PR TITLE
feat(#236): honor the in-app LLM model selection in the agentic pipeline

### DIFF
--- a/agent/fallback.py
+++ b/agent/fallback.py
@@ -109,9 +109,11 @@ async def classify_answer_adequacy(
     orchestrator can fail-closed.
 
     The ``model`` kwarg exists for test injection. In production, leave it
-    ``None`` and the function builds the configured model via
-    ``agent.models.build_model()`` — so the user's selected provider /
-    model is honored implicitly.
+    ``None`` and the function builds the model via
+    ``agent.models.build_model()`` using the secrets defaults. Note this
+    classifier always runs on the secrets-configured model — the user's
+    in-app model selection (#236) is threaded into the main agent runner, not
+    into this fallback classifier.
 
     When ``scrubbed=True`` the prompt should be PHI-scrubbed before the
     LLM call. Real wiring deferred — see TODO below.

--- a/agent/models.py
+++ b/agent/models.py
@@ -127,19 +127,25 @@ def _ollama_http_client() -> httpx.AsyncClient:
     )
 
 
-def build_model() -> Any:
+def build_model(provider: str | None = None, model: str | None = None) -> Any:
     """Return a configured Pydantic AI Model for the active provider.
 
-    Provider is determined by ``ai_keys.provider`` in secrets.toml.
-    Supported values: ``ollama``, ``anthropic``, ``bedrock``.
+    Provider defaults to ``ai_keys.provider`` in secrets.toml and the model to
+    the provider's ``ai_keys.*_model`` line. Both can be overridden by the
+    caller — this is how the agent honors the user's in-app model selection
+    (issue #236): only the provider+model *identity* is overridden, while
+    credentials (``ollama_host``, api keys, region) and thinking config stay
+    sourced from secrets. Passing ``None`` for either keeps the secrets value.
+
+    Supported providers: ``ollama``, ``anthropic``, ``bedrock``.
     """
     secrets = _read_secrets()
     ai_keys = secrets.get("ai_keys", {})
-    provider = ai_keys.get("provider")
+    provider = provider or ai_keys.get("provider")
 
     if provider == "ollama":
         host = ai_keys.get("ollama_host", "http://localhost:11434")
-        model_name = ai_keys.get("ollama_model", "qwen3.6:27b")
+        model_name = model or ai_keys.get("ollama_model", "qwen3.6:27b")
         # Use `reasoning_effort` (Ollama OpenAI-compat documented field) to
         # control thinking, not the native /api/chat `think` boolean.
         # Verified empirically against qwen3.6:27b on Ollama 0.23.2:
@@ -183,7 +189,7 @@ def build_model() -> Any:
 
     if provider == "anthropic":
         api_key = ai_keys.get("anthropic_api_key") or ai_keys.get("anthropic_api")
-        model_name = ai_keys.get("anthropic_model", "claude-sonnet-4-6")
+        model_name = model or ai_keys.get("anthropic_model", "claude-sonnet-4-6")
         anthropic_client = AsyncAnthropic(
             api_key=api_key,
             max_retries=_model_max_retries(secrets),
@@ -199,7 +205,7 @@ def build_model() -> Any:
         from pydantic_ai.models.bedrock import BedrockConverseModel
         from pydantic_ai.providers.bedrock import BedrockProvider
 
-        model_id = ai_keys.get("bedrock_model_id", "anthropic.claude-sonnet-4-6-v1:0")
+        model_id = model or ai_keys.get("bedrock_model_id", "anthropic.claude-sonnet-4-6-v1:0")
         region = ai_keys.get("aws_region", "us-east-1")
         return BedrockConverseModel(
             model_id,

--- a/agent/models.py
+++ b/agent/models.py
@@ -32,6 +32,12 @@ from pydantic_ai.providers.anthropic import AnthropicProvider
 
 ModelProvider = Literal["ollama", "anthropic", "bedrock"]
 
+# Providers build_model() can actually construct. The in-app model picker's
+# registry offers others (e.g. openai, used by the legacy Vanna path), so
+# callers threading a user selection must gate on this set — otherwise an
+# unsupported provider id falls through to build_model's ValueError. See #236.
+SUPPORTED_PROVIDERS: frozenset[str] = frozenset({"ollama", "anthropic", "bedrock"})
+
 
 # Default 2 in both the openai and anthropic SDKs. Bumped to 3 to absorb one
 # more transient blip from a busy Ollama / Anthropic endpoint without

--- a/agent/runner.py
+++ b/agent/runner.py
@@ -193,13 +193,23 @@ class AgenticRunner:
     in AgentDeps, not on the runner.
     """
 
-    def __init__(self, model: Optional[Model] = None) -> None:
+    def __init__(
+        self,
+        model: Optional[Model] = None,
+        *,
+        provider_override: str | None = None,
+        model_override: str | None = None,
+    ) -> None:
         # retries=5: small local models (qwen3.6:27b, gemma) often need
         # several attempts to produce a valid date_range / array shape
         # for the discriminated-union clinical query. Two retries was
         # too tight — well-routed runs were aborting on a 3rd malformed
         # call. See the regression run notes in the Phase 2 plan.
-        model_obj = model or build_model()
+        #
+        # `model` is a fully-built Model for test injection and wins outright.
+        # Otherwise build from secrets, letting the caller override just the
+        # provider/model identity to honor the user's in-app selection (#236).
+        model_obj = model or build_model(provider=provider_override, model=model_override)
         self._agent: Agent[AgentDeps, AgentResponse] = Agent(
             model=model_obj,
             deps_type=AgentDeps,

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -195,9 +195,7 @@ def _selected_model() -> tuple[str | None, str | None]:
     if not provider or not model:
         return (None, None)
     if provider not in SUPPORTED_PROVIDERS:
-        logger.debug(
-            "Agent doesn't support selected provider %r; falling back to the secrets model.", provider
-        )
+        logger.debug("Agent doesn't support selected provider %r; falling back to the secrets model.", provider)
         return (None, None)
     try:
         from utils.llm_registry.registry import get_registry

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -172,10 +172,40 @@ def _maybe_invoke_vanna_fallback(
         logger.exception("Vanna fallback invocation failed")
 
 
+def _selected_model() -> tuple[str | None, str | None]:
+    """Resolve the user's in-app LLM selection into a (provider, model) pair to
+    override the secrets defaults (issue #236).
+
+    Returns the persisted ``selected_llm_provider`` / ``selected_llm_model``
+    only when the provider is a real, *configured* registry provider; otherwise
+    ``(None, None)`` so the agent falls back to the secrets model. Model
+    availability is NOT checked here (that would cost a network round-trip on
+    every selection change) — an unavailable model surfaces as a graceful error
+    at run time instead.
+    """
+    provider = st.session_state.get("selected_llm_provider")
+    model = st.session_state.get("selected_llm_model")
+    if not provider or not model:
+        return (None, None)
+    try:
+        from utils.llm_registry.registry import get_registry
+
+        prov = get_registry().get_provider(provider)
+        if prov is None or not prov.is_configured(dict(st.secrets)):
+            return (None, None)
+    except Exception:
+        # Registry/secrets hiccup must never break a run — just fall back.
+        return (None, None)
+    return (provider, model)
+
+
 @st.cache_resource
-def _runner() -> AgenticRunner:
+def _runner(provider: str | None = None, model: str | None = None) -> AgenticRunner:
+    # Keyed on (provider, model): a new selection builds a fresh runner rather
+    # than reusing the cached singleton, so switching models in the UI actually
+    # takes effect. (None, None) is the secrets-driven default.
     configure_observability()
-    return AgenticRunner()
+    return AgenticRunner(provider_override=provider, model_override=model)
 
 
 _LOOP: asyncio.AbstractEventLoop | None = None
@@ -263,7 +293,7 @@ def run_agentic_message_flow(my_question: str) -> None:
         # not touch it from this (calling) thread once produce() owns it.
         sqlite_session = SessionLocal()
         deps = build_agent_deps(sqlite_session)
-        runner = _runner()
+        runner = _runner(*_selected_model())
         prior_history = st.session_state.get("agent_message_history") or None
 
         # Hand events from the loop thread back to this script thread. We

--- a/agent/runtime.py
+++ b/agent/runtime.py
@@ -15,6 +15,7 @@ import streamlit as st
 
 from agent.deps_builder import build_agent_deps
 from agent.fallback import should_fallback
+from agent.models import SUPPORTED_PROVIDERS
 from agent.observability import configure_observability
 from agent.run_logger import mark_run_fallback_invoked, mark_run_final_message_id
 from agent.runner import AgenticRunner
@@ -177,15 +178,26 @@ def _selected_model() -> tuple[str | None, str | None]:
     override the secrets defaults (issue #236).
 
     Returns the persisted ``selected_llm_provider`` / ``selected_llm_model``
-    only when the provider is a real, *configured* registry provider; otherwise
-    ``(None, None)`` so the agent falls back to the secrets model. Model
-    availability is NOT checked here (that would cost a network round-trip on
-    every selection change) — an unavailable model surfaces as a graceful error
-    at run time instead.
+    only when the provider is a real, *configured* registry provider that the
+    agent's ``build_model`` can actually construct; otherwise ``(None, None)``
+    so the agent falls back to the secrets model. Model availability is NOT
+    checked here (that would cost a network round-trip on every selection
+    change) — an unavailable model surfaces as a graceful error at run time
+    instead.
+
+    The provider gate matters: the picker's registry offers providers the agent
+    can't build (e.g. ``openai``, which the legacy Vanna path uses). Threading
+    such a selection into ``build_model`` would raise ``ValueError``, so we fall
+    back to secrets rather than crash the run (#236).
     """
     provider = st.session_state.get("selected_llm_provider")
     model = st.session_state.get("selected_llm_model")
     if not provider or not model:
+        return (None, None)
+    if provider not in SUPPORTED_PROVIDERS:
+        logger.debug(
+            "Agent doesn't support selected provider %r; falling back to the secrets model.", provider
+        )
         return (None, None)
     try:
         from utils.llm_registry.registry import get_registry

--- a/tests/agent/test_models_factory.py
+++ b/tests/agent/test_models_factory.py
@@ -56,6 +56,52 @@ def test_build_model_unknown_provider_raises(monkeypatch):
         build_model()
 
 
+# --- Issue #236: caller can override the secrets provider/model -------------
+
+
+def test_build_model_model_override_wins_over_secrets(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {"ai_keys": {"provider": "ollama", "ollama_model": "secrets-model"}},
+    )
+    model = build_model(provider="ollama", model="picked-model")
+    assert model.model_name == "picked-model"
+
+
+def test_build_model_no_override_uses_secrets_model(monkeypatch):
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {"ai_keys": {"provider": "ollama", "ollama_model": "secrets-model"}},
+    )
+    assert build_model().model_name == "secrets-model"
+
+
+def test_build_model_provider_override_switches_provider(monkeypatch):
+    # Secrets say ollama, but the caller selected an anthropic model.
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {
+            "ai_keys": {
+                "provider": "ollama",
+                "ollama_model": "secrets-model",
+                "anthropic_api_key": "sk-test",
+                "anthropic_model": "secrets-anthropic",
+            }
+        },
+    )
+    model = build_model(provider="anthropic", model="claude-picked")
+    assert model.model_name == "claude-picked"
+
+
+def test_build_model_partial_override_keeps_secrets_provider(monkeypatch):
+    # Only the model is overridden; provider still comes from secrets.
+    monkeypatch.setattr(
+        "agent.models._read_secrets",
+        lambda: {"ai_keys": {"provider": "ollama", "ollama_model": "secrets-model"}},
+    )
+    assert build_model(model="picked-model").model_name == "picked-model"
+
+
 def _ollama_secrets(model_name: str, agent_cfg: dict) -> dict:
     return {
         "ai_keys": {"provider": "ollama", "ollama_model": model_name},

--- a/tests/agent/test_runtime_async_bridge.py
+++ b/tests/agent/test_runtime_async_bridge.py
@@ -143,7 +143,7 @@ def test_run_agentic_flow_closes_sqlite_session_on_exception(monkeypatch):
             raise RuntimeError("simulated agent failure")
             yield  # unreachable, makes this an async generator
 
-    monkeypatch.setattr(runtime_mod, "_runner", lambda: _BoomRunner())
+    monkeypatch.setattr(runtime_mod, "_runner", lambda *a, **kw: _BoomRunner())
     # Avoid touching st.session_state in add_message
     monkeypatch.setattr("utils.chat_bot_helper.add_message", lambda *a, **kw: None, raising=False)
 

--- a/tests/agent/test_runtime_model_selection.py
+++ b/tests/agent/test_runtime_model_selection.py
@@ -75,11 +75,31 @@ def test_selected_model_none_for_unknown_provider(monkeypatch):
 
 
 def test_selected_model_none_for_unconfigured_provider(monkeypatch):
-    _patch_registry(monkeypatch, configured_providers=set())
+    # A supported provider (ollama) that isn't configured must still fall back,
+    # so this genuinely exercises the is_configured branch (not the support gate).
+    monkeypatch.setattr(
+        "utils.llm_registry.registry.get_registry",
+        lambda: SimpleNamespace(get_provider=lambda pid: SimpleNamespace(is_configured=lambda s: False)),
+        raising=True,
+    )
     monkeypatch.setattr(
         runtime_mod,
         "st",
-        _St({"selected_llm_provider": "known-but-unconfigured", "selected_llm_model": "x"}),
+        _St({"selected_llm_provider": "ollama", "selected_llm_model": "x"}),
+        raising=True,
+    )
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_selected_model_none_for_provider_agent_cannot_build(monkeypatch):
+    # The picker offers 'openai' (used by the Vanna path), but the agent's
+    # build_model can't construct it — selecting it must fall back to secrets,
+    # not crash the run with ValueError (#236, review finding).
+    _patch_registry(monkeypatch, configured_providers={"openai"})
+    monkeypatch.setattr(
+        runtime_mod,
+        "st",
+        _St({"selected_llm_provider": "openai", "selected_llm_model": "gpt-4o"}),
         raising=True,
     )
     assert runtime_mod._selected_model() == (None, None)

--- a/tests/agent/test_runtime_model_selection.py
+++ b/tests/agent/test_runtime_model_selection.py
@@ -1,0 +1,112 @@
+"""Issue #236: the agent runner must honor the user's in-app model selection.
+
+`agent.runtime._selected_model()` turns the persisted session selection into a
+(provider, model) override for `build_model`, but only when the provider is a
+real, configured registry provider — otherwise it falls back to the secrets
+default. `_runner(provider, model)` threads that pair into the AgenticRunner and
+is cache-keyed on it so switching models actually rebuilds the runner.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import agent.runtime as runtime_mod
+
+
+class _St:
+    def __init__(self, session_state: dict, secrets: dict | None = None):
+        self.session_state = session_state
+        self.secrets = secrets if secrets is not None else {}
+
+
+def _patch_registry(monkeypatch, *, configured_providers: set[str]):
+    """Fake registry: get_provider returns a provider whose is_configured is
+    True only for the named providers; None for anything unknown."""
+
+    def _get_provider(pid):
+        if pid in configured_providers:
+            return SimpleNamespace(is_configured=lambda secrets: True)
+        if pid == "known-but-unconfigured":
+            return SimpleNamespace(is_configured=lambda secrets: False)
+        return None
+
+    fake_registry = SimpleNamespace(get_provider=_get_provider)
+    monkeypatch.setattr(
+        "utils.llm_registry.registry.get_registry", lambda: fake_registry, raising=True
+    )
+
+
+def test_selected_model_returns_pair_for_configured_provider(monkeypatch):
+    _patch_registry(monkeypatch, configured_providers={"ollama"})
+    monkeypatch.setattr(
+        runtime_mod,
+        "st",
+        _St({"selected_llm_provider": "ollama", "selected_llm_model": "gpt-oss:20b"}),
+        raising=True,
+    )
+    assert runtime_mod._selected_model() == ("ollama", "gpt-oss:20b")
+
+
+def test_selected_model_none_when_unset(monkeypatch):
+    _patch_registry(monkeypatch, configured_providers={"ollama"})
+    monkeypatch.setattr(runtime_mod, "st", _St({}), raising=True)
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_selected_model_none_when_only_provider_set(monkeypatch):
+    _patch_registry(monkeypatch, configured_providers={"ollama"})
+    monkeypatch.setattr(
+        runtime_mod, "st", _St({"selected_llm_provider": "ollama"}), raising=True
+    )
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_selected_model_none_for_unknown_provider(monkeypatch):
+    _patch_registry(monkeypatch, configured_providers={"ollama"})
+    monkeypatch.setattr(
+        runtime_mod,
+        "st",
+        _St({"selected_llm_provider": "mystery", "selected_llm_model": "x"}),
+        raising=True,
+    )
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_selected_model_none_for_unconfigured_provider(monkeypatch):
+    _patch_registry(monkeypatch, configured_providers=set())
+    monkeypatch.setattr(
+        runtime_mod,
+        "st",
+        _St({"selected_llm_provider": "known-but-unconfigured", "selected_llm_model": "x"}),
+        raising=True,
+    )
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_selected_model_falls_back_on_registry_error(monkeypatch):
+    monkeypatch.setattr(
+        "utils.llm_registry.registry.get_registry",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        runtime_mod,
+        "st",
+        _St({"selected_llm_provider": "ollama", "selected_llm_model": "x"}),
+        raising=True,
+    )
+    assert runtime_mod._selected_model() == (None, None)
+
+
+def test_runner_threads_overrides_into_agentic_runner(monkeypatch):
+    spy = MagicMock(return_value="runner-instance")
+    monkeypatch.setattr(runtime_mod, "AgenticRunner", spy, raising=True)
+    monkeypatch.setattr(runtime_mod, "configure_observability", lambda: None, raising=True)
+
+    # Unique args so st.cache_resource doesn't return a value cached by another
+    # test; assert the override kwargs reach AgenticRunner.
+    result = runtime_mod._runner("ollama", "unit-test-model-236")
+    assert result == "runner-instance"
+    spy.assert_called_once_with(provider_override="ollama", model_override="unit-test-model-236")

--- a/tests/agent/test_runtime_session_state.py
+++ b/tests/agent/test_runtime_session_state.py
@@ -69,7 +69,8 @@ def _patch_runtime(monkeypatch, fake_state, runner):
 
     monkeypatch.setattr(runtime_mod, "SessionLocal", lambda: _FakeSession())
     monkeypatch.setattr(runtime_mod, "build_agent_deps", lambda s: MagicMock())
-    monkeypatch.setattr(runtime_mod, "_runner", lambda: runner)
+    # _runner now takes the resolved (provider, model) override (#236).
+    monkeypatch.setattr(runtime_mod, "_runner", lambda *a, **kw: runner)
     monkeypatch.setattr("utils.chat_bot_helper.add_message", lambda *a, **kw: None, raising=False)
 
     class _StSeam:

--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -668,3 +668,83 @@ def test_safety_net_renders_model_slow_message_for_timeout(monkeypatch):
     # Must NOT leak the raw exception text into the user-facing message —
     # the whole point is to replace "Request timed out." with actionable copy.
     assert "Request timed out" not in body
+
+
+# --- Issue #236: unavailable-model error UX ----------------------------------
+
+
+def test_looks_like_model_unavailable_positive():
+    """The real provider phrasings for an unservable model must all match."""
+    import utils.chat_bot_helper as cbh
+
+    cases = [
+        # Ollama 404 body: type=not_found_error
+        "status_code: 404, body: {'message': \"model 'gpt-oss:20b' not found\", 'type': 'not_found_error'}",
+        # Ollama 400 unsupported capability
+        'status_code: 400, body: {\'message\': \'"qwen3-coder-hermes:latest" does not support thinking\'}',
+        # OpenAI-style error code
+        "Error code: 404 - {'error': {'code': 'model_not_found'}}",
+        "No such model: foo",
+    ]
+    for msg in cases:
+        assert cbh.looks_like_model_unavailable(RuntimeError(msg)), f"expected match for: {msg!r}"
+
+
+def test_looks_like_model_unavailable_walks_chain():
+    """The signal may be on a wrapped cause, not the outer exception."""
+    import utils.chat_bot_helper as cbh
+
+    inner = type("ModelHTTPError", (Exception,), {})("body: {'type': 'not_found_error'}")
+    try:
+        try:
+            raise inner
+        except Exception as e:
+            raise RuntimeError("agent run failed") from e
+    except RuntimeError as e:
+        outer = e
+
+    assert cbh.looks_like_model_unavailable(outer)
+
+
+def test_looks_like_model_unavailable_negative():
+    """Timeouts and ordinary data errors must NOT be misclassified — otherwise a
+    SQL 'relation not found' would tell the user to pick a different model."""
+    import utils.chat_bot_helper as cbh
+
+    assert not cbh.looks_like_model_unavailable(RuntimeError("Request timed out."))
+    assert not cbh.looks_like_model_unavailable(RuntimeError('relation "patients" not found'))
+    assert not cbh.looks_like_model_unavailable(ValueError("column not found"))
+    assert not cbh.looks_like_model_unavailable(RuntimeError("kaboom from generate_sql"))
+
+
+class _RaisesModelNotFound:
+    """Mock VannaService that raises an Ollama-shaped 404 model-not-found."""
+
+    def is_sql_valid(self, sql):
+        return True
+
+    def generate_sql(self, question):
+        raise type("ModelHTTPError", (Exception,), {})(
+            "status_code: 404, body: {'message': \"model 'gpt-oss:20b' not found\", 'type': 'not_found_error'}"
+        )
+
+
+def test_safety_net_renders_model_unavailable_message(monkeypatch):
+    """A model-not-found failure must surface the actionable 'pick another model
+    / check secrets.toml' copy, not the generic or timeout message."""
+    import utils.chat_bot_helper as cbh
+
+    fake_st = _fake_st()
+    monkeypatch.setattr(cbh, "st", fake_st)
+    monkeypatch.setattr(cbh.Message, "save", lambda self: self, raising=True)
+    monkeypatch.setattr(cbh, "get_vn", lambda: _RaisesModelNotFound())
+
+    cbh.set_question("Q with bad model", render=False)
+    cbh.normal_message_flow("Q with bad model")  # must not raise
+
+    error_msgs = [m for m in fake_st.session_state["messages"] if getattr(m, "type", None) == "error"]
+    assert error_msgs, "expected a friendly ERROR message"
+    body = error_msgs[-1].content.lower()
+    assert "unavailable" in body and "settings" in body and "secrets.toml" in body, (
+        f"unavailable-model body should point to the picker + secrets; got: {body!r}"
+    )

--- a/tests/utils/test_friendly_errors.py
+++ b/tests/utils/test_friendly_errors.py
@@ -715,6 +715,9 @@ def test_looks_like_model_unavailable_negative():
     assert not cbh.looks_like_model_unavailable(RuntimeError('relation "patients" not found'))
     assert not cbh.looks_like_model_unavailable(ValueError("column not found"))
     assert not cbh.looks_like_model_unavailable(RuntimeError("kaboom from generate_sql"))
+    # The signal is "does not support thinking", not a bare "does not support",
+    # so ordinary DB/driver "does not support" phrasings don't get misrouted.
+    assert not cbh.looks_like_model_unavailable(RuntimeError("function json_agg does not support DISTINCT"))
 
 
 class _RaisesModelNotFound:

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1339,6 +1339,44 @@ def looks_like_model_timeout(e: BaseException) -> bool:
     return "request timed out" in str(e).lower()
 
 
+# Substrings a provider surfaces when the configured/selected model can't be
+# served: Ollama returns `404 {'message': "model 'X' not found", 'type':
+# 'not_found_error'}` and `400 "X" does not support thinking`; OpenAI uses the
+# `model_not_found` code. Matched on the message text (lowercased) because
+# pydantic-ai wraps these as a generic ModelHTTPError whose class name alone
+# doesn't distinguish "unavailable model" from other HTTP failures. Kept
+# specific (not a bare "not found") so ordinary SQL/data errors like "relation
+# not found" don't get misrouted to the model-picker hint. See issue #236.
+_MODEL_UNAVAILABLE_SIGNALS = frozenset(
+    {
+        "not_found_error",
+        "model_not_found",
+        "model not found",
+        "does not support",
+        "no such model",
+    }
+)
+
+
+def looks_like_model_unavailable(e: BaseException) -> bool:
+    """Return True when the failure is the selected/configured LLM model being
+    unavailable (not installed/pulled, unknown, or unsupported for a requested
+    capability) rather than a transient timeout.
+
+    Walks the cause/context chain and matches on message text so it stays
+    independent of pydantic-ai / provider SDK classes on the hot path.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = e
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        text = str(cur).lower()
+        if any(signal in text for signal in _MODEL_UNAVAILABLE_SIGNALS):
+            return True
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
 def normal_message_flow(my_question: str):
     """Top-level entry point — wraps the flow in a safety net so that any
     unexpected exception surfaces as a friendly ERROR card instead of
@@ -1360,7 +1398,14 @@ def normal_message_flow(my_question: str):
         # the first attempt — the generic "Something went wrong" message
         # gave them no signal to wait. Branch the wording so a known-
         # transient cause reads as "wait, then retry" instead of "broken".
-        if looks_like_model_timeout(e):
+        if looks_like_model_unavailable(e):
+            body = (
+                "The selected AI model appears unavailable — it may not be installed on the "
+                "server, or the provider may be misconfigured. Pick a different model under "
+                "Settings → LLM, or check the model set in secrets.toml.\n\n"
+                f"{e}"
+            )
+        elif looks_like_model_timeout(e):
             body = "The AI model is slow or temporarily unreachable. Please wait a moment and try again."
         else:
             body = f"Something went wrong while processing your question.\n\n{e}"

--- a/utils/chat_bot_helper.py
+++ b/utils/chat_bot_helper.py
@@ -1352,7 +1352,7 @@ _MODEL_UNAVAILABLE_SIGNALS = frozenset(
         "not_found_error",
         "model_not_found",
         "model not found",
-        "does not support",
+        "does not support thinking",
         "no such model",
     }
 )


### PR DESCRIPTION
Closes #236

## Problem

The sidebar LLM model picker only affected the legacy Vanna path. The agentic pipeline (default-on) read the model straight from `secrets.toml` (`agent/models.py:build_model()`), so a user's UI selection had no effect, and a misconfigured/unavailable secrets model surfaced as a raw provider error (e.g. Ollama `404 model not found`) with no in-UI way to recover.

## Changes

- **`agent/models.py`** — `build_model(provider=None, model=None)`: the caller can override just the provider+model *identity*; credentials (`ollama_host`, api keys, region) and `ollama_think` config stay sourced from secrets, keyed on the resolved model name. No args = unchanged secrets behavior.
- **`agent/runner.py`** — `AgenticRunner` accepts `provider_override` / `model_override` and threads them into `build_model` (the test `model`-injection path is untouched).
- **`agent/runtime.py`** — new `_selected_model()` resolves the persisted `selected_llm_provider` / `selected_llm_model`, but only when the provider is a **configured** registry provider; otherwise falls back to secrets. The cached `_runner` is **re-keyed on `(provider, model)`** so switching models rebuilds the runner instead of reusing the stale `@st.cache_resource` singleton.
- **`utils/chat_bot_helper.py`** — `looks_like_model_unavailable()` classifies a model-not-found / unsupported-capability failure; the safety net renders actionable copy ("pick a different model under Settings → LLM, or check secrets.toml") instead of the generic or timeout message. Signals are kept specific so ordinary SQL "not found" errors aren't misrouted.
- **`agent/fallback.py`** — corrected the comment that claimed the selection was honored implicitly.

## Tests

- `build_model` override-vs-secrets resolution (identity override, provider switch, partial override).
- `_selected_model()` resolution (configured / unset / unknown / unconfigured provider / registry error) and `_runner` cache-keying.
- Unavailable-model error UX (positive phrasings, cause-chain walk, negatives that must NOT misclassify SQL/data errors, and the end-to-end safety-net message).
- Existing runtime `_runner` test doubles updated for the new signature.

## Testable outcomes (from the issue)

- [x] `build_model(provider=…, model=…)` builds for the override; no-arg call matches secrets behavior.
- [x] No selection → falls back to secrets model (no change for existing deployments).
- [x] Cached runner rebuilds when the selection changes.
- [x] Missing/unavailable model → clear in-UI message, not a raw traceback.
- [x] Unit coverage for the resolution + registry validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)