### PR TITLE
Stabilize audit tests and document HeL architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Working Agreement
+
+These instructions apply to the entire repository.
+
+## GitHub delivery workflow
+
+Unless the user explicitly asks for a different workflow, substantive changes
+must be delivered through GitHub:
+
+1. Identify the existing issue before coding, or create a narrowly scoped issue
+   when the work is not tracked.
+2. Check the GitHub Project and issue labels before assuming ownership. An issue
+   assigned to Thrive may still be a HEALTHeLINK responsibility. Treat
+   `thrive`, `healthelink`, `joint`, and `external-dependency` labels as the
+   ownership source of truth, and call out contradictions.
+3. Work on a dedicated branch. Codex-created branches use the `codex/` prefix.
+4. Keep unrelated working-tree changes out of the branch, commit, and pull
+   request. Stage explicit paths in a mixed worktree; do not use `git add -A`.
+5. Run focused tests for the changed behavior and a proportionate broader
+   suite. Record the exact commands and results in the pull request.
+6. Open a pull request that explains the problem, root cause, implementation,
+   impact, and validation. Use `Closes #N` only when the merged change fully
+   satisfies that issue; otherwise use `Refs #N` and state what remains.
+7. Merge only after required checks pass and review requirements are satisfied.
+8. After merge, reconcile GitHub: comment with evidence, close completed issues,
+   and update Project status (`Todo`, `In Progress`, `Blocked`, `In Review`, or
+   `Done`). Never close an external dependency merely because Thrive's portion
+   is complete.
+
+## Safety and scope
+
+- Preserve user changes already present in the worktree.
+- Do not commit credentials, PHI, patient rosters, evaluation results, local
+  databases, screenshots, or generated reports containing sensitive data.
+- Consent, patient identity resolution, Public Health role mapping, and
+  compliance acceptance criteria require the documented business decision;
+  do not invent one to unblock implementation.
+- Prefer evidence over status claims: cite tests, merged code, deployed checks,
+  or an explicit external sign-off.

--- a/docs/healtheintelligence-architecture.md
+++ b/docs/healtheintelligence-architecture.md
@@ -1,0 +1,153 @@
+# HEALTHeINTELLIGENCE Architecture
+
+Current implementation view as of 2026-07-16. This document describes the
+deployed application boundary and the responsibilities shared by Thrive AI and
+HEALTHeLINK (HeL). It deliberately leaves unresolved consent, patient identity
+resolution, Public Health role mapping, and final compliance acceptance
+criteria as open decisions.
+
+## System context
+
+```mermaid
+flowchart LR
+    subgraph HEL["HEALTHeLINK-managed boundary"]
+        User["ECDOH / HeL user"]
+        Okta["Okta OIDC and groups"]
+        HeO["HeO analytics warehouse\nclinical views"]
+        Ops["HeL operations and analytics\nvalidation and sign-off"]
+    end
+
+    subgraph Thrive["Thrive-managed application"]
+        UI["Streamlit UI\nchat, admin, audit, evaluations"]
+        Auth["Authentication and role mapping"]
+        Agent["Agentic runtime\npatient and population tools"]
+        Legacy["Legacy Vanna SQL path"]
+        RAG["Schema and training retrieval\nChromaDB or Milvus"]
+        Audit["Application database\nmessages, users, audit, evaluations"]
+        Worker["Evaluation worker"]
+    end
+
+    User -->|"sign in"| Okta
+    Okta -->|"OIDC claims"| Auth
+    Auth --> UI
+    UI --> Agent
+    UI --> Legacy
+    Agent -->|"read-only clinical queries"| HeO
+    Legacy -->|"generated SQL"| HeO
+    Agent --> RAG
+    Legacy --> RAG
+    Agent --> Audit
+    Legacy --> Audit
+    UI --> Audit
+    Worker --> Agent
+    Worker --> Audit
+    Ops -->|"acceptance criteria and validation"| UI
+```
+
+## Authenticated request flow
+
+```mermaid
+sequenceDiagram
+    participant U as User browser
+    participant O as HeL Okta
+    participant S as Streamlit application
+    participant A as Agentic runtime
+    participant W as HeO warehouse
+    participant D as Application audit DB
+
+    U->>S: Open application
+    S->>O: OIDC authorization request
+    O-->>S: ID token with identity and groups
+    S->>D: JIT-create or synchronize user and role
+    U->>S: Ask a clinical or population question
+    S->>D: Record question and run metadata
+    S->>A: Question, role, selected patient, prior turns
+    A->>W: Parameterized read-only query through a tool
+    W-->>A: Result rows or explicit no-records result
+    A->>D: Record tool calls, SQL metadata, patient access, status
+    A-->>S: Final answer and evidence summary
+    S-->>U: Render answer
+```
+
+## Component responsibilities
+
+| Component | Responsibility | Primary implementation |
+| --- | --- | --- |
+| Streamlit entry and views | Session lifecycle, chat, administration, audit, and evaluation UI | `app.py`, `views/` |
+| Okta integration | OIDC flow, group-to-role mapping, JIT user synchronization, logout | `utils/okta_auth.py`, `utils/auth.py` |
+| Agentic runtime | Multi-turn orchestration, patient selection, tool execution, final-answer synthesis | `agent/runtime.py`, `agent/runner.py`, `agent/tools/` |
+| Clinical data access | Dialect-aware, parameterized reads against HeO views | `agent/db/analytics_adapter.py`, `agent/db/queries/` |
+| Legacy SQL generation | Vanna-based text-to-SQL path retained during transition | `utils/vanna_calls.py`, `utils/chat_bot_helper.py` |
+| Retrieval and training context | Role-aware schema, examples, and documentation retrieval | `utils/chromadb_vector.py`, `utils/milvus_vector.py` |
+| Application persistence | Users, messages, settings, agent runs, tool calls, patient access, evaluations | `orm/models.py`, `orm/agent_logging_functions.py`, `orm/logging_functions.py` |
+| Audit UI | 7-, 30-, or 90-day views for queries, patients, admin actions, and user activity | `views/admin.py`, `views/admin_audit.py`, `views/admin_audit_queries.py`, `views/admin_audit_by_patient.py` |
+| Evaluation workspace | Curated/feedback cases, durable runs, review history, async execution | `evals/`, `views/admin_evaluations.py` |
+| Schema management | Versioned application-database migrations | `alembic/` |
+
+## Data and security boundaries
+
+- HeO clinical data remains in the HeL analytics warehouse. The application
+  reads it through configured analytics connections; it does not treat the
+  application SQLite database as a clinical source of truth.
+- The application database contains identity, configuration, conversation,
+  audit, and evaluation metadata. Logging mode controls how much result detail
+  is retained. Evaluation retention can purge PHI payloads while preserving
+  run and review audit metadata.
+- Real patient rosters and evaluation outputs contain PHI or PHI pointers and
+  remain uncommitted. `evals/roster.yaml`, local databases, and generated result
+  artifacts are operational inputs, not repository assets.
+- Role mapping is derived from Okta groups and synchronized at login. The
+  current code supports Admin, Doctor, Nurse, and Patient. A distinct Public
+  Health role/group requires an approved mapping before implementation.
+- Consent and patient identity resolution are enforced only after their source
+  rules are approved. Aggregate/de-identified exemptions and small-cell
+  protections must follow the final consent decision, not an inferred rule.
+
+## Audit and compliance baseline
+
+The application records user activity, submitted questions, agent runs, tool
+calls, executed-SQL metadata, response status/timing, and patient access. Admins
+can inspect and export a rolling 90-day window from the application. Older
+records remain queryable in backend audit tables subject to deployment
+retention and HeL analytics access.
+
+The remaining acceptance step for the SHIN-NY baseline is operational: HeL must
+confirm the minimum required dataset and verify that its analytics users can
+query the deployed backend records. Thrive's automated tests verify storage,
+filtering, pagination, scope classification, and UI presentation; they do not
+prove external account access.
+
+## Validation and operations
+
+- The authenticated evaluation workspace persists runs and per-case results,
+  supports human verdicts with change history, and resumes asynchronous work
+  after stale-worker recovery.
+- The CLI harness accepts a gitignored patient roster and a YAML question set.
+  HeL/Joe must provide the production 20-patient roster, the authoritative
+  Q0-Q14 formats, and known-answer expectations before go-live scoring is
+  complete.
+- Deployment configuration and credentials live outside source control. The
+  repository includes Alembic migrations and service definitions, while HeL
+  owns the identity-provider, network, warehouse, and downstream operational
+  access needed by the deployed service.
+
+## Ownership and open decisions
+
+| Area | Thrive responsibility | HeL / joint responsibility | Current state |
+| --- | --- | --- | --- |
+| Okta | OIDC client behavior and claim handling | App assignment, groups, claims, and production IdP configuration | Integrated; final IdP items external |
+| Patient identity | Apply the approved resolver consistently in tools and queries | Supply and approve post-Fusion matching rules | Open |
+| Consent | Implement the approved enforcement and exemption rules | Name business owner; approve population, SQL, blanks, and exceptions | Open |
+| Public Health RBAC | Add approved role mapping and authorization behavior | Define role/group and permitted capabilities | Open |
+| SHIN-NY audit | Persist and expose baseline audit data | Define minimum dataset and verify analytics access | Code baseline present; operational sign-off open |
+| Validation | Maintain harness and remediate product defects | Supply roster/expected answers and perform UAT/revalidation | In progress |
+
+## Code-level evidence
+
+- Okta mapping and synchronization: `utils/okta_auth.py`
+- Agent conversation continuity: `agent/runtime.py`, `agent/runner.py`
+- Patient and population tools: `agent/tools/`
+- Audit models and readers: `orm/models.py`, `orm/agent_logging_functions.py`,
+  `orm/logging_functions.py`
+- 90-day admin selector: `views/admin.py`
+- Evaluation behavior and PHI handling: `evals/README.md`

--- a/tests/orm/test_patient_audit_autocomplete.py
+++ b/tests/orm/test_patient_audit_autocomplete.py
@@ -17,6 +17,11 @@ from sqlalchemy.orm import sessionmaker
 from orm.models import AgentPatientAccess, Base, RoleTypeEnum, User, UserRole
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 @pytest.fixture
 def session_factory(monkeypatch):
     from orm import agent_logging_functions as alf
@@ -93,7 +98,7 @@ def test_three_distinct_source_ids_ordered_by_last_touched_desc(session_factory)
 
     s = session_factory()
     _seed_user(s)
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     _add_access(s, source_id="pat-1", display_name="Alice", created_at=base - timedelta(minutes=10))
     _add_access(s, source_id="pat-2", display_name="Bob", created_at=base - timedelta(minutes=5))
     _add_access(s, source_id="pat-3", display_name="Carol", created_at=base)
@@ -108,7 +113,7 @@ def test_repeated_touches_aggregate_into_one_row(session_factory):
 
     s = session_factory()
     _seed_user(s)
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(4):
         _add_access(s, source_id="pat-1", display_name="Alice", created_at=base - timedelta(minutes=i))
 
@@ -124,7 +129,7 @@ def test_same_source_id_two_display_names_returns_two_rows(session_factory):
 
     s = session_factory()
     _seed_user(s)
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     _add_access(s, source_id="pat-1", display_name="Alice A", created_at=base - timedelta(minutes=5))
     _add_access(s, source_id="pat-1", display_name="Alice Anders", created_at=base)
 
@@ -153,7 +158,7 @@ def test_query_filter_matches_source_id_substring(session_factory):
 
     s = session_factory()
     _seed_user(s)
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     _add_access(s, source_id="pat-12-abc", display_name="X", created_at=base)
     _add_access(s, source_id="pat-99-xyz", display_name="Y", created_at=base - timedelta(minutes=1))
 
@@ -166,7 +171,7 @@ def test_query_filter_matches_display_name_substring(session_factory):
 
     s = session_factory()
     _seed_user(s)
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     _add_access(s, source_id="pat-A", display_name="Alice Anders", created_at=base)
     _add_access(s, source_id="pat-B", display_name="Bob Brown", created_at=base - timedelta(minutes=1))
 

--- a/tests/orm/test_per_query_audit.py
+++ b/tests/orm/test_per_query_audit.py
@@ -34,6 +34,11 @@ from orm.models import (
 from utils.enums import MessageType, RoleType
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures & seed helpers (mirrors tests/orm/test_question_audit_scope.py)
 # ---------------------------------------------------------------------------
@@ -255,7 +260,7 @@ def test_legacy_question_yields_one_row_with_assistant_sql(session_factory):
         s,
         user_id=10,
         content="legacy q",
-        when=datetime(2026, 6, 1, 12, 0, 0),
+        when=AUDIT_NOW,
         assistant_sql="SELECT 1",
         assistant_sql_elapsed=Decimal("1.250000"),
     )
@@ -282,7 +287,7 @@ def test_legacy_question_with_no_assistant_sql_still_emits_row(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    _add_question(s, user_id=10, content="bare q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_question(s, user_id=10, content="bare q", when=AUDIT_NOW)
 
     page = get_per_query_audit_page(_filters(), page=1, page_size=50)
     assert page["total"] == 1
@@ -300,7 +305,7 @@ def test_agentic_question_with_three_tool_calls_emits_three_rows(session_factory
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="agentic q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="agentic q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-1", user_id=10, user_message_id=mid)
     _add_tool_call(
         s,
@@ -354,7 +359,7 @@ def test_agentic_sql_executed_json_preserves_order(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="multi-sql", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="multi-sql", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-2", user_id=10, user_message_id=mid)
     _add_tool_call(
         s,
@@ -381,7 +386,7 @@ def test_patients_touched_attached_per_tool_call(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="touch q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="touch q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-3", user_id=10, user_message_id=mid)
     _add_tool_call(
         s,
@@ -413,7 +418,7 @@ def test_patients_touched_empty_for_legacy_rows(session_factory):
         s,
         user_id=10,
         content="legacy",
-        when=datetime(2026, 6, 1, 12, 0, 0),
+        when=AUDIT_NOW,
         assistant_sql="SELECT 1",
     )
 
@@ -434,10 +439,10 @@ def _seed_mixed_pipelines(s):
         s,
         user_id=10,
         content="legacy q",
-        when=datetime(2026, 6, 1, 12, 0, 0),
+        when=AUDIT_NOW,
         assistant_sql="SELECT legacy",
     )
-    agentic_mid = _add_question(s, user_id=10, content="agentic q", when=datetime(2026, 6, 1, 12, 5, 0))
+    agentic_mid = _add_question(s, user_id=10, content="agentic q", when=AUDIT_NOW + timedelta(minutes=5))
     _add_agent_run(s, run_id="run-pip", user_id=10, user_message_id=agentic_mid)
     _add_tool_call(
         s,
@@ -479,14 +484,14 @@ def test_source_ids_filter_excludes_legacy_and_other_runs(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
     # Two agentic questions; only run-A touched pat-001.
-    mid_a = _add_question(s, user_id=10, content="qA", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid_a = _add_question(s, user_id=10, content="qA", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-A", user_id=10, user_message_id=mid_a)
     _add_tool_call(
         s, run_id="run-A", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tcA", sql_executed=["SELECT 1"]
     )
     _add_patient_access(s, run_id="run-A", user_id=10, source_id="pat-001")
 
-    mid_b = _add_question(s, user_id=10, content="qB", when=datetime(2026, 6, 1, 12, 5, 0))
+    mid_b = _add_question(s, user_id=10, content="qB", when=AUDIT_NOW + timedelta(minutes=5))
     _add_agent_run(s, run_id="run-B", user_id=10, user_message_id=mid_b)
     _add_tool_call(
         s, run_id="run-B", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tcB", sql_executed=["SELECT 2"]
@@ -498,7 +503,7 @@ def test_source_ids_filter_excludes_legacy_and_other_runs(session_factory):
         s,
         user_id=10,
         content="legacy q",
-        when=datetime(2026, 6, 1, 12, 10, 0),
+        when=AUDIT_NOW + timedelta(minutes=10),
         assistant_sql="SELECT legacy",
     )
 
@@ -513,7 +518,7 @@ def test_tool_names_filter_restricts_to_named_tools(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="mixed tools", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="mixed tools", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-t", user_id=10, user_message_id=mid)
     _add_tool_call(
         s, run_id="run-t", user_id=10, tool_name="run_sql", call_index=0, tool_call_uid="tc0", sql_executed=["SELECT 1"]
@@ -541,7 +546,7 @@ def test_scope_filter_patient_carries_over_to_per_row_view(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
     # Patient-scope run (selected_patient_source_id set) with 2 tool calls.
-    mid_p = _add_question(s, user_id=10, content="patient q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid_p = _add_question(s, user_id=10, content="patient q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-pat", user_id=10, user_message_id=mid_p, selected_patient_source_id="pat-001")
     _add_tool_call(
         s,
@@ -562,7 +567,7 @@ def test_scope_filter_patient_carries_over_to_per_row_view(session_factory):
         sql_executed=["SELECT 2"],
     )
     # Pop-Health run.
-    mid_o = _add_question(s, user_id=10, content="cohort q", when=datetime(2026, 6, 1, 12, 5, 0))
+    mid_o = _add_question(s, user_id=10, content="cohort q", when=AUDIT_NOW + timedelta(minutes=5))
     _add_agent_run(s, run_id="run-pop", user_id=10, user_message_id=mid_o)
     _add_tool_call(
         s,
@@ -592,7 +597,7 @@ def test_pagination_offset_limit_and_total(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
     # 11 user questions; mix of legacy + agentic
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     n = 0
     for i in range(7):
         _add_question(
@@ -633,7 +638,7 @@ def test_disabled_logging_mode_emits_sentinel(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="disabled q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="disabled q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-d", user_id=10, user_message_id=mid, logging_mode="disabled")
     # Even in disabled mode there can be carrier ToolCalls (the run_logger
     # writes the row before short-circuiting payload columns). Seed one with
@@ -662,7 +667,7 @@ def test_scrubbed_mode_passes_logging_mode_through(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="scrubbed q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="scrubbed q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-sc", user_id=10, user_message_id=mid, logging_mode="scrubbed")
     # In scrubbed mode the SQL literals are hashed by the writer; we pass
     # through whatever the writer stored.
@@ -696,7 +701,7 @@ def test_malformed_sql_executed_json_returns_empty_list(session_factory, caplog)
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="bad json", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="bad json", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-bad", user_id=10, user_message_id=mid)
     _add_tool_call(
         s,
@@ -720,13 +725,13 @@ def test_two_runs_same_user_message_id_both_appear_with_deterministic_order(sess
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="retried q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="retried q", when=AUDIT_NOW)
     _add_agent_run(
         s,
         run_id="run-first",
         user_id=10,
         user_message_id=mid,
-        created_at=datetime(2026, 6, 1, 12, 0, 5),
+        created_at=AUDIT_NOW + timedelta(seconds=5),
     )
     _add_tool_call(
         s,
@@ -742,7 +747,7 @@ def test_two_runs_same_user_message_id_both_appear_with_deterministic_order(sess
         run_id="run-second",
         user_id=10,
         user_message_id=mid,
-        created_at=datetime(2026, 6, 1, 12, 0, 10),
+        created_at=AUDIT_NOW + timedelta(seconds=10),
     )
     _add_tool_call(
         s,
@@ -775,7 +780,7 @@ def test_export_caps_at_max_audit_export_rows(session_factory, monkeypatch):
     _seed_user(s, id=10, username="alice")
 
     # Seed 60 legacy questions.
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(60):
         _add_question(
             s,
@@ -801,8 +806,8 @@ def test_ordering_reverse_chronological_by_question_then_call_index(session_fact
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    older = datetime(2026, 6, 1, 11, 0, 0)
-    newer = datetime(2026, 6, 1, 13, 0, 0)
+    older = AUDIT_NOW - timedelta(hours=1)
+    newer = AUDIT_NOW + timedelta(hours=1)
     _add_question(s, user_id=10, content="older legacy", when=older, assistant_sql="SELECT old")
     mid = _add_question(s, user_id=10, content="newer agentic", when=newer)
     _add_agent_run(s, run_id="run-n", user_id=10, user_message_id=mid)

--- a/tests/orm/test_question_audit.py
+++ b/tests/orm/test_question_audit.py
@@ -10,6 +10,11 @@ from orm.models import Base, Message, RoleTypeEnum, User, UserRole
 from utils.enums import MessageType, RoleType
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 @pytest.fixture
 def session_factory(monkeypatch):
     """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
@@ -135,7 +140,7 @@ def test_single_user_three_questions_reverse_chrono(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice", org="Acme")
 
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="q1 oldest", when=now - timedelta(hours=2))
     _add_question(s, user_id=10, content="q2 middle", when=now - timedelta(hours=1))
     _add_question(s, user_id=10, content="q3 newest", when=now)
@@ -152,7 +157,7 @@ def test_pagination(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(3):
         _add_question(s, user_id=10, content=f"q{i}", when=base - timedelta(hours=i))
 
@@ -170,7 +175,7 @@ def test_username_filter(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
     _seed_user(s, id=11, username="bob")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="a-only", when=now)
     _add_question(s, user_id=11, content="b-only", when=now)
 
@@ -191,7 +196,7 @@ def test_org_filter_no_org_sentinel(session_factory):
     _seed_roles(s)
     _seed_user(s, id=10, username="alice", org="Acme")
     _seed_user(s, id=11, username="bob", org=None)
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="acme-q", when=now)
     _add_question(s, user_id=11, content="noorg-q", when=now)
 
@@ -224,7 +229,7 @@ def test_search_matches_question_content(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="What about John Doe today?", when=now)
     _add_question(s, user_id=10, content="Show me yesterday's totals", when=now - timedelta(minutes=1))
 
@@ -239,7 +244,7 @@ def test_search_matches_assistant_sql_content(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(
         s,
         user_id=10,
@@ -260,7 +265,7 @@ def test_status_success_summary(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="ok", when=now, summary="here you go")
 
     result = get_question_audit_page(_filters(), page=1, page_size=50)
@@ -273,7 +278,7 @@ def test_status_error(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="fail", when=now, summary="partial", error="boom")
 
     result = get_question_audit_page(_filters(), page=1, page_size=50)
@@ -286,7 +291,7 @@ def test_status_empty(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="hanging", when=now)
 
     result = get_question_audit_page(_filters(), page=1, page_size=50)
@@ -299,7 +304,7 @@ def test_elapsed_is_sum_across_assistant_rows(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_question(s, user_id=10, content="q", when=now, elapsed=1.5, sql="select 1", summary="ok")
     last_assistant = (
         s.query(Message)
@@ -345,7 +350,7 @@ def test_export_returns_full_filtered_set_no_pagination(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(7):
         _add_question(s, user_id=10, content=f"q{i}", when=base - timedelta(hours=i))
 

--- a/tests/orm/test_question_audit_scope.py
+++ b/tests/orm/test_question_audit_scope.py
@@ -25,6 +25,11 @@ from orm.models import AgentRun, Base, Message, RoleTypeEnum, ToolCall, User, Us
 from utils.enums import MessageType, RoleType
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures + helpers (lightly adapted from tests/orm/test_question_audit.py)
 # ---------------------------------------------------------------------------
@@ -160,7 +165,7 @@ def test_scope_legacy_when_no_agent_run(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    _add_question(s, user_id=10, content="legacy q", when=datetime(2026, 6, 1, 12, 0, 0))
+    _add_question(s, user_id=10, content="legacy q", when=AUDIT_NOW)
 
     page = get_question_audit_page(_filters(), page=1, page_size=50)
     assert len(page["items"]) == 1
@@ -174,7 +179,7 @@ def test_scope_patient_when_slot_filled(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="slot-filled", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="slot-filled", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-a", user_id=10, user_message_id=mid, selected_patient_source_id="pat-123")
 
     page = get_question_audit_page(_filters(), page=1, page_size=50)
@@ -194,7 +199,7 @@ def test_scope_patient_when_patient_intent_tool_only(session_factory, tool_name)
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content=f"intent-{tool_name}", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content=f"intent-{tool_name}", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-b", user_id=10, user_message_id=mid)  # slot empty
     _add_tool_call(s, run_id="run-b", user_id=10, tool_name=tool_name)
 
@@ -209,7 +214,7 @@ def test_scope_pop_health(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="cohort q", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="cohort q", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-c", user_id=10, user_message_id=mid)  # no slot
     _add_tool_call(s, run_id="run-c", user_id=10, tool_name="search_patients_by_criteria")
 
@@ -224,7 +229,7 @@ def test_scope_other_when_agent_run_but_no_classified_tools(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="kb only", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="kb only", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-d", user_id=10, user_message_id=mid)
     _add_tool_call(s, run_id="run-d", user_id=10, tool_name="search_knowledge_base")
     _add_tool_call(s, run_id="run-d", user_id=10, tool_name="run_sql")
@@ -242,7 +247,7 @@ def test_scope_patient_wins_over_pop_when_both_tool_families_fire(session_factor
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    mid = _add_question(s, user_id=10, content="mixed", when=datetime(2026, 6, 1, 12, 0, 0))
+    mid = _add_question(s, user_id=10, content="mixed", when=AUDIT_NOW)
     _add_agent_run(s, run_id="run-e", user_id=10, user_message_id=mid)
     _add_tool_call(s, run_id="run-e", user_id=10, tool_name="find_patient")
     _add_tool_call(s, run_id="run-e", user_id=10, tool_name="search_patients_by_criteria")
@@ -265,7 +270,7 @@ def _seed_mixed_page(s) -> dict[str, int]:
     """
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     n = 0
 
     def _ts(i):

--- a/tests/orm/test_user_activity_pagination.py
+++ b/tests/orm/test_user_activity_pagination.py
@@ -21,6 +21,11 @@ from sqlalchemy.orm import sessionmaker
 from orm.models import Base, RoleTypeEnum, User, UserActivity, UserRole
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 @pytest.fixture
 def session_factory(monkeypatch):
     """In-memory SQLite with SessionLocal patched on orm.logging_functions."""
@@ -112,7 +117,7 @@ def test_returns_all_ten_fields_per_item(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_activity(
         s,
         user_id=10,
@@ -160,7 +165,7 @@ def test_returns_reverse_chronological_order(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_activity(s, user_id=10, username="alice", activity_type="login", when=now - timedelta(hours=2))
     _add_activity(s, user_id=10, username="alice", activity_type="setting", when=now - timedelta(hours=1))
     _add_activity(s, user_id=10, username="alice", activity_type="logout", when=now)
@@ -177,7 +182,7 @@ def test_pagination_page_one_returns_first_page(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(5):
         _add_activity(
             s,
@@ -198,7 +203,7 @@ def test_pagination_page_two_returns_next_page(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(5):
         _add_activity(
             s,
@@ -223,7 +228,7 @@ def test_pagination_out_of_range_returns_empty_items_with_correct_total(session_
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     for i in range(3):
         _add_activity(
             s,
@@ -245,7 +250,7 @@ def test_pagination_page_size_variants(session_factory, page_size):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    base = datetime(2026, 6, 1, 12, 0, 0)
+    base = AUDIT_NOW
     # Seed 30 rows so 25 is a partial page and 50/100/200 are not.
     for i in range(30):
         _add_activity(
@@ -270,7 +275,7 @@ def test_null_user_id_failed_login_row_is_returned(session_factory):
     s = session_factory()
     _seed_roles(s)
     # No user seeded — failed login with null user_id but a captured username.
-    now = datetime(2026, 6, 1, 12, 0, 0)
+    now = AUDIT_NOW
     _add_activity(
         s,
         user_id=None,

--- a/tests/views/test_admin_audit_queries_final_answer.py
+++ b/tests/views/test_admin_audit_queries_final_answer.py
@@ -32,6 +32,11 @@ from orm.models import (
 from utils.enums import MessageType, RoleType
 
 
+# Keep ordinary audit fixtures inside the readers' rolling windows. Tests that
+# exercise cutoff behavior create their own recent and expired timestamps.
+AUDIT_NOW = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures and seed helpers (mirrors tests/orm/test_per_query_audit.py)
 # ---------------------------------------------------------------------------
@@ -159,7 +164,7 @@ def test_agentic_rows_carry_final_answer_text_from_agent_run(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     mid = _add_user_question(s, user_id=10, content="agentic q", when=when)
     _add_agent_run(
         s, run_id="run-1", user_id=10, user_message_id=mid, final_answer_text="The patient has 3 active conditions."
@@ -190,7 +195,7 @@ def test_agentic_row_result_text_matches_tool_result_summary(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     mid = _add_user_question(s, user_id=10, content="lab q", when=when)
     _add_agent_run(s, run_id="run-1", user_id=10, user_message_id=mid, final_answer_text="3 labs in range.")
     _add_tool_call(
@@ -216,7 +221,7 @@ def test_agentic_run_error_status_with_no_final_answer_yields_none(session_facto
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     mid = _add_user_question(s, user_id=10, content="fail q", when=when)
     _add_agent_run(s, run_id="run-1", user_id=10, user_message_id=mid, final_answer_text=None, status="error")
     _add_tool_call(s, run_id="run-1", user_id=10, tool_name="run_sql", call_index=0, result_summary="error: timeout")
@@ -235,7 +240,7 @@ def test_disabled_logging_mode_still_surfaces_final_answer_text(session_factory)
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     mid = _add_user_question(s, user_id=10, content="opaque q", when=when)
     _add_agent_run(
         s,
@@ -265,7 +270,7 @@ def test_legacy_row_final_answer_text_comes_from_latest_summary_message(session_
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     _add_user_question(s, user_id=10, content="legacy q", when=when)
     _add_assistant_message(
         s,
@@ -297,7 +302,7 @@ def test_legacy_row_without_summary_message_yields_none(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     _add_user_question(s, user_id=10, content="no-summary q", when=when)
     _add_assistant_message(
         s,
@@ -320,7 +325,7 @@ def test_legacy_row_without_summary_message_yields_none(session_factory):
 
 def _make_item(**overrides) -> dict:
     base = {
-        "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+        "asked_at": AUDIT_NOW,
         "user_id": 7,
         "username": "alice",
         "organization": "Acme",
@@ -504,7 +509,7 @@ def test_question_detail_dialog_body_renders_final_answer_section():
     try:
         header = {
             "user_message_id": 1,
-            "asked_at": datetime(2026, 6, 1, 12, 0, 0),
+            "asked_at": AUDIT_NOW,
             "username": "alice",
             "organization": "Acme",
             "question": "How many patients?",
@@ -558,7 +563,7 @@ def test_csv_export_includes_final_answer_column(session_factory):
     s = session_factory()
     _seed_roles(s)
     _seed_user(s, id=10, username="alice")
-    when = datetime(2026, 6, 1, 12, 0, 0)
+    when = AUDIT_NOW
     mid = _add_user_question(s, user_id=10, content="big-q", when=when)
     long_answer = "long answer " * 50  # well beyond the truncation cap
     _add_agent_run(s, run_id="run-1", user_id=10, user_message_id=mid, final_answer_text=long_answer)


### PR DESCRIPTION
## Summary

- keep ordinary audit fixtures within the application's rolling audit windows instead of anchoring them to an expiring calendar date
- document the current HEALTHeINTELLIGENCE architecture, security boundaries, ownership, and deliberately unresolved consent/patient-resolution decisions
- add a repository-wide GitHub delivery agreement so issue, PR, merge, and Project reconciliation are part of future work

## Root cause

Six audit test modules seeded ordinary data at June 1, 2026. Once that data aged beyond readers' rolling windows, the same tests failed even though the tested behavior had not regressed. Cutoff-specific tests already create their own recent and expired timestamps, so ordinary fixtures now use a stable same-day anchor.

## Validation

- `uv run ruff check tests/views/test_admin_audit_queries_final_answer.py tests/orm/test_patient_audit_autocomplete.py tests/orm/test_user_activity_pagination.py tests/orm/test_per_query_audit.py tests/orm/test_question_audit_scope.py tests/orm/test_question_audit.py` — passed
- focused audit/logging suite — **246 passed, 2 skipped**
- full suite — **2089 passed, 6 failed, 6 skipped**
  - two pre-existing sample-db admissions failures are tracked in #281
  - three shared Milvus database isolation failures are tracked in #280
  - one stale-cookie test failed only in the full run and passed immediately in isolation; no speculative issue was opened

No production behavior changed. Existing unrelated local model/provider work is not included.

Closes #279
Closes #271
Refs #261