### PR TITLE
Isolate app worker test modules

### DIFF
--- a/tests/test_app_evaluation_worker.py
+++ b/tests/test_app_evaluation_worker.py
@@ -62,6 +62,7 @@ class _FakeCookieManager:
 
 @pytest.fixture
 def app_env(monkeypatch):
+    modules_before = set(sys.modules)
     fake_st = _FakeSt()
     fake_cookie_mod = type(sys)("streamlit_cookies_manager_ext")
     fake_cookie_mod.EncryptedCookieManager = _FakeCookieManager
@@ -69,8 +70,18 @@ def app_env(monkeypatch):
     monkeypatch.setitem(sys.modules, "streamlit_cookies_manager_ext", fake_cookie_mod)
 
     started = {"count": 0}
-    monkeypatch.setattr(worker_mod, "start_evaluation_worker", lambda *a, **k: started.__setitem__("count", started["count"] + 1))
-    return fake_st, started, monkeypatch
+    monkeypatch.setattr(
+        worker_mod, "start_evaluation_worker", lambda *a, **k: started.__setitem__("count", started["count"] + 1)
+    )
+    yield fake_st, started, monkeypatch
+
+    # monkeypatch restores sys.modules["streamlit"], but modules imported by
+    # app.py retain the fake object in their module globals. Remove only those
+    # newly imported modules so later tests re-import them with real Streamlit.
+    for name in set(sys.modules) - modules_before:
+        module = sys.modules.get(name)
+        if isinstance(module, type(sys)) and getattr(module, "st", None) is fake_st:
+            sys.modules.pop(name, None)
 
 
 def test_worker_starts_once_after_successful_bootstrap(app_env):


### PR DESCRIPTION
## Summary
- convert the app-worker environment fixture to a yield fixture with explicit teardown
- remove only modules newly imported while the fixture's fake Streamlit module was installed
- allow later auth tests to re-import those modules against real Streamlit

## Root cause
`tests/test_app_evaluation_worker.py` temporarily replaced `sys.modules["streamlit"]` and executed `app.py`. Pytest restored the `streamlit` entry, but `utils.auth` remained cached with the fake Streamlit object in its module globals. The stale-cookie test then exercised that cached object and failed because the worker test's fake cookie manager does not implement `.get()`.

## Impact
Test-only change. Production authentication behavior is unchanged.

## Validation
- `uv run ruff check tests/test_app_evaluation_worker.py`
- `uv run ruff format --check tests/test_app_evaluation_worker.py`
- `uv run pytest -q tests/test_app_evaluation_worker.py tests/utils/test_auth_stale_cookie.py tests/utils/test_auth_dispatcher.py` — 7 passed
- `uv run pytest -q` — 2093 passed, 6 skipped; the #286 auth failure is resolved. The only two remaining failures are the sample-database SQL cast failures tracked in #281.

Closes #286
Refs #281