### PR TITLE
fix(#299/#300): tighten procedure/imaging precision

### DIFF
--- a/agent/db/queries/imaging.py
+++ b/agent/db/queries/imaging.py
@@ -21,13 +21,21 @@ from __future__ import annotations
 from typing import Optional, Tuple
 
 
+# Short modality tokens include spaces that become portable word boundaries
+# when matched against _padded(). This avoids substring matches such as POCT.
 _MODALITY_KEYWORDS = {
     "xray": ("x-ray", "xray", "x ray", "radiograph"),
-    "ct": ("ct ", " ct,", " ct;", "computed tomography", " ct scan"),
+    "ct": (" ct ", " ct,", " ct;", "computed tomography", "ct scan"),
     "mri": ("mri", "magnetic resonance"),
     "us": ("ultrasound", " us ", "sonogram"),
-    "pet": ("pet ", "positron emission"),
+    "pet": (" pet ", "positron emission"),
 }
+
+
+def _padded(column: str) -> str:
+    """Return a portable, space-padded case-insensitive match target."""
+    return f"(' ' || LOWER({column}) || ' ')"
+
 
 _BODY_REGION_KEYWORDS: dict[str, tuple[str, ...]] = {
     "head": ("head", "brain", "cranial", "cranium", "skull", "intracranial"),
@@ -68,8 +76,8 @@ def imaging_sql(
             for i, kw in enumerate(keywords):
                 key = f"mod_{i}"
                 params[key] = f"%{kw}%"
-                order_terms.append(f"LOWER(name) LIKE :{key}")
-                doc_terms.append(f"LOWER(name) LIKE :{key} OR LOWER(mnemonic) LIKE :{key}")
+                order_terms.append(f"{_padded('name')} LIKE :{key}")
+                doc_terms.append(f"{_padded('name')} LIKE :{key} OR {_padded('mnemonic')} LIKE :{key}")
             modality_clause_orders = f"AND ({' OR '.join(order_terms)})"
             modality_clause_docs = f"AND ({' OR '.join(doc_terms)})"
 
@@ -121,9 +129,10 @@ def imaging_sql(
           AND (
               LOWER(name) LIKE '%imag%'
               OR LOWER(name) LIKE '%x-ray%' OR LOWER(name) LIKE '%xray%'
-              OR LOWER(name) LIKE '%ct %' OR LOWER(name) LIKE '%mri%'
+              OR {_padded("name")} LIKE '% ct %' OR {_padded("name")} LIKE '% ct,%'
+              OR LOWER(name) LIKE '%mri%'
               OR LOWER(name) LIKE '%ultrasound%' OR LOWER(name) LIKE '%sonogram%'
-              OR LOWER(name) LIKE '%radiograph%' OR LOWER(name) LIKE '%pet %'
+              OR LOWER(name) LIKE '%radiograph%' OR {_padded("name")} LIKE '% pet %'
           )
           {modality_clause_orders}
           {body_clause_orders}
@@ -146,8 +155,8 @@ def imaging_sql(
           AND (
               LOWER(name) LIKE '%radiolog%'
               OR LOWER(name) LIKE '%imag%'
-              OR LOWER(mnemonic) LIKE '%xr%'
-              OR LOWER(mnemonic) LIKE '%ct%'
+              OR {_padded("mnemonic")} LIKE '% xr%'
+              OR {_padded("mnemonic")} LIKE '% ct %'
               OR LOWER(mnemonic) LIKE '%mri%'
           )
           {modality_clause_docs}

--- a/agent/db/queries/procedures.py
+++ b/agent/db/queries/procedures.py
@@ -90,7 +90,7 @@ def procedures_sql(
             NULL AS facility_name
         FROM {schema_prefix}federated_orders_v
         WHERE source_id = :source_id
-          AND (code_type IN ({cpt_ct_placeholders}) OR code_type = '' OR code_type IS NULL)
+          AND code_type IN ({cpt_ct_placeholders})
           {cpt_filter}
           {text_filter_orders}
           {date_filter_orders}

--- a/tests/agent/db/test_imaging_queries.py
+++ b/tests/agent/db/test_imaging_queries.py
@@ -1,3 +1,5 @@
+from sqlalchemy import text
+
 from agent.db.analytics_adapter import AnalyticsDbAdapter
 from agent.db.queries.imaging import imaging_sql
 
@@ -46,3 +48,70 @@ def test_imaging_body_region_fallback_for_unknown_region(synthetic_db):
     rows = adapter.fetch_all(sql, params)
     # No imaging rows should match 'elbow' in our test data
     assert isinstance(rows, list)
+
+
+def _insert_imaging_precision_rows(synthetic_db):
+    with synthetic_db.begin() as conn:
+        order_rows = [
+            ("POCT GLUCOSE METER", "POCT-1"),
+            ("Product Notification", "PRODUCT-1"),
+            ("CT HEAD WO CONTRAST", "CT-1"),
+            ("CHEST CT", "CT-2"),
+            ("PET SCAN WHOLE BODY", "PET-1"),
+            ("CAT SCAN PETITE", "PETITE-1"),
+        ]
+        conn.execute(
+            text(
+                "INSERT INTO federated_orders_v VALUES "
+                "('src-john-1962', :code, 'CPT', :name, '2026-04-01 09:00', "
+                "'2026-04-01 08:00', '22', 'completed')"
+            ),
+            [{"name": name, "code": code} for name, code in order_rows],
+        )
+        document_rows = [
+            ("Transition of Care Visit", "AS::ECTOCIVCH"),
+            ("Doctor note", "DOCTOR_NOTES"),
+            ("CT Report", "CT HEAD"),
+        ]
+        conn.execute(
+            text(
+                "INSERT INTO federated_documents_v VALUES "
+                "('src-john-1962', '2026-04-01 09:30', :name, :mnemonic, "
+                "'final', 'enc-precision', '22', 'Buffalo Medical Group')"
+            ),
+            [{"name": name, "mnemonic": mnemonic} for name, mnemonic in document_rows],
+        )
+
+
+def _imaging_descriptions(synthetic_db, *, modality=None):
+    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
+    sql, params = imaging_sql(source_id="src-john-1962", modality=modality)
+    return {row["description"] for row in adapter.fetch_all(sql, params)}
+
+
+def test_imaging_base_predicates_require_ct_xr_pet_boundaries(synthetic_db):
+    _insert_imaging_precision_rows(synthetic_db)
+
+    descriptions = _imaging_descriptions(synthetic_db)
+
+    assert {"CT HEAD WO CONTRAST", "CHEST CT", "PET SCAN WHOLE BODY", "CT Report"} <= descriptions
+    assert {
+        "POCT GLUCOSE METER",
+        "Product Notification",
+        "CAT SCAN PETITE",
+        "Transition of Care Visit",
+        "Doctor note",
+    }.isdisjoint(descriptions)
+    assert "Radiology Report" in descriptions  # XRREPORT remains a genuine document match.
+
+
+def test_imaging_modality_predicates_preserve_true_ct_and_pet_matches(synthetic_db):
+    _insert_imaging_precision_rows(synthetic_db)
+
+    ct_descriptions = _imaging_descriptions(synthetic_db, modality="ct")
+    pet_descriptions = _imaging_descriptions(synthetic_db, modality="pet")
+
+    assert {"CT HEAD WO CONTRAST", "CHEST CT", "CT Report"} <= ct_descriptions
+    assert {"POCT GLUCOSE METER", "Transition of Care Visit", "Doctor note"}.isdisjoint(ct_descriptions)
+    assert "PET SCAN WHOLE BODY" in pet_descriptions
+    assert "CAT SCAN PETITE" not in pet_descriptions

--- a/tests/agent/db/test_procedures_queries.py
+++ b/tests/agent/db/test_procedures_queries.py
@@ -48,6 +48,48 @@ def test_procedures_orders_carry_cpt_codes(synthetic_db):
     assert "71046" in cpt_codes
 
 
+def test_procedures_excludes_blank_and_null_code_type_orders(synthetic_db):
+    with synthetic_db.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO federated_orders_v VALUES "
+                "(:source_id, :code, :code_type, :name, :procedure_date, "
+                ":created_date, :place_of_service, :status)"
+            ),
+            [
+                {
+                    "source_id": "src-john-1962",
+                    "code": "NOISE-BLANK",
+                    "code_type": "",
+                    "name": "CBC panel",
+                    "procedure_date": "2026-04-01 09:00",
+                    "created_date": "2026-04-01 08:00",
+                    "place_of_service": "22",
+                    "status": "completed",
+                },
+                {
+                    "source_id": "src-john-1962",
+                    "code": "NOISE-NULL",
+                    "code_type": None,
+                    "name": "Visit note",
+                    "procedure_date": "2026-04-02 09:00",
+                    "created_date": "2026-04-02 08:00",
+                    "place_of_service": "22",
+                    "status": "completed",
+                },
+            ],
+        )
+
+    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
+    sql, params = procedures_sql(source_id="src-john-1962")
+    rows = adapter.fetch_all(sql, params)
+    codes = {row["code"] for row in rows}
+
+    assert {"NOISE-BLANK", "NOISE-NULL", "LOC-X-1"}.isdisjoint(codes)
+    assert {"45378", "71046"} <= codes
+    assert any(row["source"] == "problems" and row["code_type"] == "ICD-10-PCS" for row in rows)
+
+
 def test_procedures_filtered_by_cpt(synthetic_db):
     adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
     sql, params = procedures_sql(


### PR DESCRIPTION
Closes #299. Closes #300.

## Summary
Tightens procedure/imaging retrieval so it excludes known false positives while preserving true positives.

- **#299 procedures** (`agent/db/queries/procedures.py`): drop the `OR code_type = '' OR code_type IS NULL` branch that swept in blank/NULL code-type noise. Procedures now match only real CPT/CT code types.
- **#300 imaging** (`agent/db/queries/imaging.py`): replace substring modality matching (`%ct%`, `%pet %`) with portable space-padded word-boundary matching via a new `_padded()` helper (`' ' || LOWER(col) || ' '`). This stops arbitrary mnemonic/POCT false positives (e.g. "POCT" no longer matches the "ct" modality) while preserving true CT/XR/MRI/US/PET matches.

## Verification
- `uv run pytest -q tests/agent/db/test_imaging_queries.py tests/agent/db/test_procedures_queries.py` — **14 passed** (new precision regressions for false-positive exclusion + true-positive preservation).
- `uv run pytest -q` (full suite) — **2068 passed, 7 skipped**; the only non-passes are the `tests/sample_db/test_schema_matches_redshift.py` cases, which require the local-only Redshift catalog JSON (gitignored) and are unrelated to this change — this branch modifies no schema.

## Notes
- Changes only query-builder string matching; no schema, model, or logging changes.
- Portability preserved (Postgres/Redshift/SQLite) — `_padded()` uses standard `||` concatenation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
