### PR TITLE
fix(#288): deterministic cross-process ETL RNG

### DIFF
--- a/scripts/sample_db/transformers/base.py
+++ b/scripts/sample_db/transformers/base.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import random
 from dataclasses import dataclass, field
 
@@ -22,7 +23,8 @@ class TransformContext:
     def rng(self, key: str) -> random.Random:
         """Return a deterministic per-key RNG. Independent of other keys."""
         if key not in self.rngs:
-            self.rngs[key] = random.Random(self.seed + hash(key) % 10**6)
+            key_offset = int.from_bytes(hashlib.sha256(key.encode()).digest(), "big") % 10**6
+            self.rngs[key] = random.Random(self.seed + key_offset)
         return self.rngs[key]
 
     def add_rows(self, table: str, rows: list[dict]) -> None:

--- a/tests/sample_db/test_transform_context_rng.py
+++ b/tests/sample_db/test_transform_context_rng.py
@@ -1,0 +1,51 @@
+"""Regression coverage for deterministic per-key sample ETL RNG streams."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from scripts.sample_db.transformers.base import TransformContext
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SEQUENCE_SCRIPT = """
+import json
+from scripts.sample_db.transformers.base import TransformContext
+
+rng = TransformContext(seed=42).rng("allergies")
+print(json.dumps([rng.random() for _ in range(10)]))
+"""
+
+
+def _sequence_from_subprocess(hash_seed: str) -> list[float]:
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = hash_seed
+    result = subprocess.run(
+        [sys.executable, "-c", _SEQUENCE_SCRIPT],
+        cwd=_REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_rng_sequence_is_stable_across_python_processes() -> None:
+    assert _sequence_from_subprocess("1") == _sequence_from_subprocess("2")
+
+
+def test_rng_streams_are_independent_per_key() -> None:
+    context = TransformContext(seed=42)
+    allergies = context.rng("allergies")
+    medications = context.rng("medications")
+
+    allergies_sequence = [allergies.random() for _ in range(20)]
+    medications_sequence = [medications.random() for _ in range(5)]
+    reference_rng = TransformContext(seed=42).rng("medications")
+
+    assert allergies_sequence[:5] != medications_sequence
+    assert medications_sequence == [reference_rng.random() for _ in range(5)]


### PR DESCRIPTION
Closes #288.

## Summary
Makes the sample-DB ETL's per-key RNG deterministic across Python processes. `TransformContext.rng(key)` seeded each stream with `self.seed + hash(key) % 10**6`, but Python's builtin `hash()` is salted per process (`PYTHONHASHSEED`) for `str`, so the same `(seed, key)` produced different random streams on every run — the sample dump was not reproducible. Derive the per-key offset from `sha256(key)` instead, which is stable across processes while keeping distinct keys independent.

```python
key_offset = int.from_bytes(hashlib.sha256(key.encode()).digest(), "big") % 10**6
self.rngs[key] = random.Random(self.seed + key_offset)
```

## Verification
- `uv run pytest -q tests/sample_db/test_transform_context_rng.py tests/sample_db/test_allergies_transformer.py` — **9 passed** (new regressions pin cross-process stability and per-key independence).
- `uv run pytest -q` (full suite, minus the local-catalog-dependent schema-match test) — **2067 passed, 7 skipped**.

## On the committed sample dump
This PR is intentionally scoped to the RNG fix and does **not** regenerate `data/sample/thrive_sample.sql.zst`. The fix guarantees that *future* regenerations are reproducible; the existing committed dump remains valid synthetic data. A fresh regenerate from the current Synthea 3.3.0 CSVs produces a materially different (~6.3 MB vs 5.6 MB) dump — i.e. it would fold a **Synthea data refresh** into this change rather than a pure RNG fix, and would need its own sample-DB verification pass. That belongs in a dedicated `chore(sample-db): regenerate` follow-up (workflow documented in `data/sample/README.md`), keeping this PR reviewable and single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
