### PR TITLE
feat(#311/#247-253): use-case retrieval validation + ICD-10 block-prefix + prompt tuning

### DIFF
--- a/agent/db/queries/diagnoses.py
+++ b/agent/db/queries/diagnoses.py
@@ -15,6 +15,7 @@ def diagnoses_sql(
     *,
     source_id: str,
     icd10_codes: Optional[List[str]] = None,
+    condition_code_prefixes: Optional[List[str]] = None,
     condition_text: Optional[str] = None,
     most_recent_only: bool = False,
     schema_prefix: str = "",
@@ -22,17 +23,31 @@ def diagnoses_sql(
     where: list[str] = ["source_id = :source_id"]
     params: dict = {"source_id": source_id}
 
-    if icd10_codes:
+    # icd10_codes = exact codes; condition_code_prefixes = ICD-10 block prefixes
+    # (e.g. ['E08','E11'] -> code LIKE 'E08%' OR 'E11%'), the NARROW reading of a
+    # named condition. Both restrict code_type to ICD-10 variants and are OR'd.
+    if icd10_codes or condition_code_prefixes:
         ct_variants = variants_for("icd10")
         ct_placeholders = ", ".join(f":ct_{i}" for i in range(len(ct_variants)))
         where.append(f"code_type IN ({ct_placeholders})")
         for i, v in enumerate(ct_variants):
             params[f"ct_{i}"] = v
 
-        code_placeholders = ", ".join(f":dc_{i}" for i in range(len(icd10_codes)))
-        where.append(f"code IN ({code_placeholders})")
-        for i, c in enumerate(icd10_codes):
-            params[f"dc_{i}"] = c
+        code_clauses: list[str] = []
+        if icd10_codes:
+            code_placeholders = ", ".join(f":dc_{i}" for i in range(len(icd10_codes)))
+            code_clauses.append(f"code IN ({code_placeholders})")
+            for i, c in enumerate(icd10_codes):
+                params[f"dc_{i}"] = c
+        if condition_code_prefixes:
+            pref_clauses = []
+            for i, p in enumerate(condition_code_prefixes):
+                pref_clauses.append(f"code LIKE :cp_{i}")
+                params[f"cp_{i}"] = f"{p}%"
+            code_clauses.append("(" + " OR ".join(pref_clauses) + ")")
+        # Single filter keeps the bare clause shape; only wrap when OR-combining
+        # exact codes with prefix blocks.
+        where.append(code_clauses[0] if len(code_clauses) == 1 else "(" + " OR ".join(code_clauses) + ")")
 
     if condition_text:
         where.append("LOWER(diagnosis) LIKE :ct")

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -82,7 +82,7 @@ Available domains and their key filters:
       demographics — no filters
       encounters — facility_type (inpatient|outpatient|ed|ltc|any), date_range
       labs — loinc_codes, test_name_text, date_range, result_filter (positive|negative|abnormal|any), most_recent_only
-      diagnoses — icd10_codes, condition_text, most_recent_only
+      diagnoses — icd10_codes, condition_code_prefixes, condition_text, most_recent_only
       medications — date_range (returns the full med list; filter by med_name / status yourself)
       immunizations — cvx_codes, vaccine_text, date_range
       procedures — cpt_codes, procedure_text, date_range
@@ -102,15 +102,27 @@ search_codes(cvx, "mmr") — not three for measles/mumps/rubella).
     — visit history. facility_type literal: inpatient | outpatient | ed | ltc | any.
   - get_patient_clinical_data({{domain:'labs', loinc_codes, test_name_text, \
     date_range, result_filter, most_recent_only}}) — lab results from federated_results_v. \
-    Each row's source_name is the Reporting organization. service_provider is a \
-    source placeholder and MUST NOT be presented as a clinician. \
+    Each row's source_name is the Reporting organization — this is the "lab that \
+    performed/reported the test"; report it when asked which lab did the testing. \
+    service_provider is a source placeholder and MUST NOT be presented as a clinician. \
+    event_datetime is the date the specimen was drawn/resulted. \
     LOINC coverage is ~50%; the tool returns reliability_note when non-LOINC rows \
     are mixed in. Always include this caveat in your reply. \
-    When the user asks for the "most recent" or "latest" result for a lab test, \
-    set most_recent_only=True — this returns only the single most recent row. \
-    test_name_text searches both the name AND mnemonic columns.
-  - get_patient_clinical_data({{domain:'diagnoses', icd10_codes, condition_text, \
-    most_recent_only}}) — problems list. ICD-10 ~57%; SNOMED/ICD-9 the rest. \
+    For "negative <analyte> results" use result_filter='negative' (e.g. negative \
+    hepatitis screen). When the user asks for the "most recent" or "latest" \
+    result, set most_recent_only=True. Resolve LOINC codes via search_codes \
+    (e.g. HbA1c 4548-4; hepatitis and measles IgM/IgG panels have their own \
+    LOINCs) rather than free-texting. test_name_text searches name AND mnemonic.
+  - get_patient_clinical_data({{domain:'diagnoses', icd10_codes, \
+    condition_code_prefixes, condition_text, most_recent_only}}) — problems \
+    list. ICD-10 ~57%; SNOMED/ICD-9 the rest. For "does the patient have \
+    <condition>" (the NARROW reading), pass condition_code_prefixes = the \
+    condition's core ICD-10 block(s), e.g. diabetes=['E08','E09','E10','E11','E13'], \
+    hepatitis B=['B16','B17','B18','B19'], pregnancy=['O','Z33','Z34','Z3A']; \
+    use your ICD-10 knowledge for the block of any named condition. Answer \
+    "history of <condition>?" as Yes iff any row matches. Use a curated set \
+    (search_codes) only for the BROAD reading ("any history of", "including \
+    related"). condition_text matches the display column only, never `code`. \
     Surface reliability_note when present. Use normalized status when present \
     (active, inactive, or resolved); a missing status is unknown, so \
     never guess active-vs-resolved.

--- a/agent/tools/get_patient_clinical_data.py
+++ b/agent/tools/get_patient_clinical_data.py
@@ -79,6 +79,9 @@ class DiagnosesQuery(BaseModel):
 
     domain: Literal["diagnoses"] = "diagnoses"
     icd10_codes: Optional[List[str]] = None
+    # ICD-10 block prefixes for the NARROW reading of a named condition, e.g.
+    # diabetes = ["E08","E09","E10","E11","E13"]; matched as code LIKE '<p>%'.
+    condition_code_prefixes: Optional[List[str]] = None
     condition_text: Optional[str] = None
     most_recent_only: bool = False
 
@@ -546,6 +549,7 @@ def _build_diagnoses_result(
         lambda sid: diagnoses_sql(
             source_id=sid,
             icd10_codes=query.icd10_codes,
+            condition_code_prefixes=query.condition_code_prefixes,
             condition_text=query.condition_text,
             most_recent_only=query.most_recent_only,
             schema_prefix=schema_prefix,

--- a/tests/agent/use_cases/test_uc_retrieval.py
+++ b/tests/agent/use_cases/test_uc_retrieval.py
@@ -1,0 +1,88 @@
+"""Use-case retrieval validation (#247-#253).
+
+Proves the data-retrieval layer supports each go-live use-case question against
+the synthetic patient (src-john-1962), independent of the LLM. These pin the
+"capabilities already exist" finding: the remaining work on #248-#253 is
+prompt/RAG tuning + eval measurement, not new query features. Each test maps to
+a use-case acceptance criterion.
+"""
+
+from agent.db.analytics_adapter import AnalyticsDbAdapter
+from agent.db.federation import federated_source_ids
+from agent.tools.get_patient_clinical_data import (
+    DiagnosesQuery,
+    LabsQuery,
+    MedicationsQuery,
+    ProceduresQuery,
+    _build_diagnoses_result,
+    _build_labs_result,
+    _build_medications_result,
+    _build_procedures_result,
+)
+
+_PATIENT = "src-john-1962"
+
+
+def _ctx(synthetic_db):
+    adapter = AnalyticsDbAdapter(engine=synthetic_db, dialect="sqlite")
+    return adapter, federated_source_ids(adapter, _PATIENT, "")
+
+
+def test_uc248_diabetes_history_and_latest_a1c(synthetic_db):
+    """#248 UC2-1: diabetes diagnosis (binary) + most-recent A1C."""
+    adapter, sids = _ctx(synthetic_db)
+    dx = _build_diagnoses_result(adapter, sids, "", DiagnosesQuery(icd10_codes=["E11.9"]))
+    assert any(getattr(i, "code", None) == "E11.9" for i in dx.items)  # has diabetes
+
+    labs = _build_labs_result(adapter, sids, "", LabsQuery(loinc_codes=["4548-4"]))
+    a1c = [i for i in labs.items if i.code == "4548-4"]
+    assert a1c and a1c[0].clean_result == "7.2"  # most recent A1C value retrievable
+
+
+def test_uc250_hepatitis_negative_with_performing_lab(synthetic_db):
+    """#250 UC3-2 (HIGH): negative hepatitis result + date drawn + performing lab."""
+    adapter, sids = _ctx(synthetic_db)
+    labs = _build_labs_result(adapter, sids, "", LabsQuery(loinc_codes=["5195-3"], result_filter="negative"))
+    hbsag = [i for i in labs.items if i.code == "5195-3"]
+    assert hbsag, "HBsAg negative result must be retrievable"
+    row = hbsag[0]
+    assert (row.clean_result or "").lower() == "negative"
+    assert row.event_datetime  # 3A: date drawn
+    assert row.source_name  # 3B: performing lab (reporting organization)
+
+
+def test_uc251_measles_igg_ever(synthetic_db):
+    """#251 UC3-3: measles/rubeola IgM/IgG testing ever."""
+    adapter, sids = _ctx(synthetic_db)
+    labs = _build_labs_result(adapter, sids, "", LabsQuery(loinc_codes=["22501-7"]))
+    assert any(i.code == "22501-7" for i in labs.items)  # test was performed (ever)
+
+
+def test_uc249_procedures_in_range_with_date(synthetic_db):
+    """#249 UC3-1: invasive procedures/surgeries in date range + date performed."""
+    adapter, sids = _ctx(synthetic_db)
+    procs = _build_procedures_result(adapter, sids, "", ProceduresQuery())
+    assert procs.items
+    # every returned procedure carries a performed date (event_date)
+    assert all(i.event_date for i in procs.items)
+
+
+def test_uc252_gc_chlamydia_meds_carry_dosage(synthetic_db):
+    """#252 UC3-4 (HIGH): antibiotic med with dosage/duration retrievable.
+
+    The antibiotic (azithromycin) with strength + sig + days-supply is what
+    answers 5a (which meds) and 5b (dosage/duration).
+    """
+    adapter, sids = _ctx(synthetic_db)
+    meds = _build_medications_result(adapter, sids, "", MedicationsQuery())
+    azi = [i for i in meds.items if "azithromycin" in (getattr(i, "med_name", "") or "").lower()]
+    assert azi, "azithromycin must be retrievable"
+    m = azi[0]
+    assert m.med_strength and m.med_sig  # dosage + directions present
+
+
+def test_uc253_hepatitis_b_detectable(synthetic_db):
+    """#253 UC3-5: detect Hep B (diagnosis)."""
+    adapter, sids = _ctx(synthetic_db)
+    dx = _build_diagnoses_result(adapter, sids, "", DiagnosesQuery(icd10_codes=["B16.9"]))
+    assert any(getattr(i, "code", None) == "B16.9" for i in dx.items)  # Hep B present

--- a/tests/agent/use_cases/test_uc_retrieval.py
+++ b/tests/agent/use_cases/test_uc_retrieval.py
@@ -39,6 +39,29 @@ def test_uc248_diabetes_history_and_latest_a1c(synthetic_db):
     assert a1c and a1c[0].clean_result == "7.2"  # most recent A1C value retrievable
 
 
+def test_condition_code_prefix_narrow_reading_diabetes(synthetic_db):
+    """#311: narrow "has diabetes" via ICD-10 block prefixes (E08-E13) matches
+    E11.9 without needing the exact code."""
+    adapter, sids = _ctx(synthetic_db)
+    dx = _build_diagnoses_result(
+        adapter, sids, "", DiagnosesQuery(condition_code_prefixes=["E08", "E09", "E10", "E11", "E13"])
+    )
+    assert any(getattr(i, "code", None) == "E11.9" for i in dx.items)
+
+
+def test_condition_code_prefix_is_selective(synthetic_db):
+    """#311: a prefix block only matches its own codes — the diabetes block does
+    not pull in the Hep B diagnosis (B16.9), and the Hep B block does."""
+    adapter, sids = _ctx(synthetic_db)
+    diabetes = _build_diagnoses_result(adapter, sids, "", DiagnosesQuery(condition_code_prefixes=["E11"]))
+    assert all(getattr(i, "code", "") != "B16.9" for i in diabetes.items)
+
+    hepb = _build_diagnoses_result(
+        adapter, sids, "", DiagnosesQuery(condition_code_prefixes=["B16", "B17", "B18", "B19"])
+    )
+    assert any(getattr(i, "code", None) == "B16.9" for i in hepb.items)
+
+
 def test_uc250_hepatitis_negative_with_performing_lab(synthetic_db):
     """#250 UC3-2 (HIGH): negative hepatitis result + date drawn + performing lab."""
     adapter, sids = _ctx(synthetic_db)


### PR DESCRIPTION
Starts the use-case cluster (#247–#253) and implements #311. This is the retrieval-validation + query/prompt-tuning layer; live eval measurement (needs the LLM + 20-patient roster) is the remaining step, tracked below.

## Key finding
thrive's clinical tools **already support** these go-live questions — `LabsQuery` has `loinc_codes` + `result_filter='negative'` + `date_range` + `source_name` (performing lab), procedures carry `event_date`, meds carry strength/sig, diagnoses take ICD-10 codes, and `questions.yaml` already holds the eval cases. So #248–#253 are **validation + prompt-tuning**, not new query features (as the issues say: "train/tune").

## What's in this PR

**Retrieval validation** (`tests/agent/use_cases/test_uc_retrieval.py`) — proves each use-case's data path against the synthetic patient, independent of the LLM:
- #248 diabetes dx (E11.9) + A1C (4548-4 = 7.2)
- #250 (HIGH) negative HBsAg (5195-3) + date drawn + **performing lab** (`source_name`, 3B)
- #251 measles IgG (22501-7) ever
- #249 procedures with performed date
- #252 (HIGH) azithromycin with strength + sig (5a/5b)
- #253 Hep B dx (B16.9)

**#311 — ICD-10 block-prefix criterion** (from Chiron `a0c3a45`/`7294736`):
- `diagnoses_sql` + `DiagnosesQuery` gain `condition_code_prefixes` — ICD-10 block prefixes matched as `code LIKE '<p>%'`, restricted to ICD-10 code_type, OR'd with any exact codes. Single-filter SQL shape unchanged (no regression).
- Tests: narrow-reading (diabetes block E08–E13 matches E11.9) + selectivity (diabetes block doesn't pull Hep B; Hep B block does).

**Prompt/RAG tuning** (`agent/system_prompt.py`):
- diagnoses: "has \<condition\>" = NARROW reading via `condition_code_prefixes` (diabetes/hep B/pregnancy blocks); curated sets only for BROAD "any history of"; `condition_text` matches the display column, never `code`.
- labs: `source_name` IS the performing/reporting lab (report it when asked which lab tested); `event_datetime` = date drawn; `result_filter='negative'` for negative screens; `most_recent_only` for "latest"; resolve LOINCs via `search_codes`.

## Verification
`tests/agent` **872 passed**, no regressions · ruff clean.

## Remaining for the cluster (follow-up)
- **#252 5c** — pregnancy-at-time-of-positive-test (cross-domain temporal reasoning — the one genuinely hard piece)
- **#247** — 360 question tuning (Q12 care team, Q14 history)
- **Cohort-side `condition_code_prefixes`** (#311 follow-up — for "how many patients with diabetes")
- **Eval measurement** — run the harness against these (#254/#257; needs the roster with real source_ids)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
