### PR TITLE
docs: refresh stale documentation

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -142,12 +142,7 @@ and `docs/superpowers/plans/2026-07-10-authenticated-evaluation-workspace.md`.
 
 ### Worker configuration
 
-Add to `.streamlit/secrets.toml` (defaults shown; the worker runs with these
-even if the section is absent):
-
-```toml
-[agent_evaluations]
-worker_enabled = true
-poll_interval_s = 5
-heartbeat_timeout_s = 120
-```
+The worker's timing is fixed in `evals/worker.py`: the poll interval
+(`POLL_INTERVAL_S = 5`) and heartbeat timeout (`HEARTBEAT_TIMEOUT_S = 120`) are
+module constants, not secrets. The worker always starts once after DB bootstrap
+(`app.py`) — there is no secrets.toml toggle to enable or disable it.


### PR DESCRIPTION
Automated documentation refresh: one stale claim found and corrected.

- **evals/README.md** ("Worker configuration") → the section instructed adding an `[agent_evaluations]` block to `.streamlit/secrets.toml` with `worker_enabled`, `poll_interval_s`, and `heartbeat_timeout_s`, implying the worker reads and honors these keys. → The code never reads any `agent_evaluations` secrets: the poll interval and heartbeat timeout are hardcoded module constants in `evals/worker.py` (`POLL_INTERVAL_S = 5.0`, `HEARTBEAT_TIMEOUT_S = 120.0`), and `app.py` starts the worker unconditionally after DB bootstrap (no `worker_enabled` toggle). Replaced the fabricated config block with an accurate description of the fixed constants.

Automated by doc-sentinel (nightly claude -p).